### PR TITLE
evaluate pass fail likelihoods

### DIFF
--- a/notebooks/access_github_ci_data.ipynb
+++ b/notebooks/access_github_ci_data.ipynb
@@ -80,7 +80,12 @@
    "outputs": [],
    "source": [
     "# mode can be \"check or \"workflow\" depending on whether you want to collect checks data or workflows data\n",
-    "MODE = \"workflow\""
+    "MODE = \"workflow\"\n",
+    "test_id = \"28698040\" # Pre-commit test\n",
+    "# test_id = \"29176617\" # Build and push image\n",
+    "# test_id = \"37149896\" # File linting\n",
+    "# test_id = \"37149895\" # Spell Check\n",
+    "# test_id = \"39411153\" #\"Compile all queries using the latest stable CodeQL CLI\""
    ]
   },
   {
@@ -229,7 +234,6 @@
     "\n",
     "elif MODE == \"workflow\":\n",
     "    # get workflows\n",
-    "    test_id = \"28698040\" # Pre-commit test\n",
     "    page_numbers = get_page_numbers(test_id)\n",
     "    workflow_df = get_workflow_runs(test_id, page_numbers)\n",
     "    test_df = workflow_df[['created_at', 'updated_at', 'id', 'status', 'conclusion']]\n",
@@ -278,6 +282,16 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>2023-03-21T16:47:52Z</td>\n",
+       "      <td>2023-03-21T16:48:28Z</td>\n",
+       "      <td>4481655529</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>36.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
        "      <td>2023-03-02T18:04:52Z</td>\n",
        "      <td>2023-03-02T18:05:21Z</td>\n",
        "      <td>4316905413</td>\n",
@@ -287,7 +301,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>2</th>\n",
        "      <td>2023-02-28T22:46:09Z</td>\n",
        "      <td>2023-02-28T22:46:39Z</td>\n",
        "      <td>4298089675</td>\n",
@@ -297,7 +311,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>3</th>\n",
        "      <td>2023-02-28T22:42:47Z</td>\n",
        "      <td>2023-02-28T22:43:10Z</td>\n",
        "      <td>4298071211</td>\n",
@@ -307,7 +321,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>4</th>\n",
        "      <td>2023-02-28T22:21:25Z</td>\n",
        "      <td>2023-02-28T22:21:46Z</td>\n",
        "      <td>4297918764</td>\n",
@@ -317,7 +331,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>5</th>\n",
        "      <td>2023-02-22T23:15:44Z</td>\n",
        "      <td>2023-02-22T23:16:07Z</td>\n",
        "      <td>4247826657</td>\n",
@@ -327,7 +341,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
+       "      <th>6</th>\n",
        "      <td>2023-02-22T18:27:33Z</td>\n",
        "      <td>2023-02-22T18:28:00Z</td>\n",
        "      <td>4245797712</td>\n",
@@ -337,7 +351,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
+       "      <th>7</th>\n",
        "      <td>2023-02-22T17:58:00Z</td>\n",
        "      <td>2023-02-22T17:58:29Z</td>\n",
        "      <td>4245558935</td>\n",
@@ -347,7 +361,7 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
+       "      <th>8</th>\n",
        "      <td>2023-02-22T14:42:04Z</td>\n",
        "      <td>2023-02-22T14:42:26Z</td>\n",
        "      <td>4243845186</td>\n",
@@ -357,20 +371,10 @@
        "      <td>28698040</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
+       "      <th>9</th>\n",
        "      <td>2023-02-21T21:03:50Z</td>\n",
        "      <td>2023-02-21T21:04:14Z</td>\n",
        "      <td>4236840889</td>\n",
-       "      <td>completed</td>\n",
-       "      <td>success</td>\n",
-       "      <td>24.0</td>\n",
-       "      <td>28698040</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>2023-02-21T20:53:45Z</td>\n",
-       "      <td>2023-02-21T20:54:09Z</td>\n",
-       "      <td>4236770912</td>\n",
        "      <td>completed</td>\n",
        "      <td>success</td>\n",
        "      <td>24.0</td>\n",
@@ -382,27 +386,27 @@
       ],
       "text/plain": [
        "             created_at            updated_at      run_id     status  \\\n",
-       "0  2023-03-02T18:04:52Z  2023-03-02T18:05:21Z  4316905413  completed   \n",
-       "1  2023-02-28T22:46:09Z  2023-02-28T22:46:39Z  4298089675  completed   \n",
-       "2  2023-02-28T22:42:47Z  2023-02-28T22:43:10Z  4298071211  completed   \n",
-       "3  2023-02-28T22:21:25Z  2023-02-28T22:21:46Z  4297918764  completed   \n",
-       "4  2023-02-22T23:15:44Z  2023-02-22T23:16:07Z  4247826657  completed   \n",
-       "5  2023-02-22T18:27:33Z  2023-02-22T18:28:00Z  4245797712  completed   \n",
-       "6  2023-02-22T17:58:00Z  2023-02-22T17:58:29Z  4245558935  completed   \n",
-       "7  2023-02-22T14:42:04Z  2023-02-22T14:42:26Z  4243845186  completed   \n",
-       "8  2023-02-21T21:03:50Z  2023-02-21T21:04:14Z  4236840889  completed   \n",
-       "9  2023-02-21T20:53:45Z  2023-02-21T20:54:09Z  4236770912  completed   \n",
+       "0  2023-03-21T16:47:52Z  2023-03-21T16:48:28Z  4481655529  completed   \n",
+       "1  2023-03-02T18:04:52Z  2023-03-02T18:05:21Z  4316905413  completed   \n",
+       "2  2023-02-28T22:46:09Z  2023-02-28T22:46:39Z  4298089675  completed   \n",
+       "3  2023-02-28T22:42:47Z  2023-02-28T22:43:10Z  4298071211  completed   \n",
+       "4  2023-02-28T22:21:25Z  2023-02-28T22:21:46Z  4297918764  completed   \n",
+       "5  2023-02-22T23:15:44Z  2023-02-22T23:16:07Z  4247826657  completed   \n",
+       "6  2023-02-22T18:27:33Z  2023-02-22T18:28:00Z  4245797712  completed   \n",
+       "7  2023-02-22T17:58:00Z  2023-02-22T17:58:29Z  4245558935  completed   \n",
+       "8  2023-02-22T14:42:04Z  2023-02-22T14:42:26Z  4243845186  completed   \n",
+       "9  2023-02-21T21:03:50Z  2023-02-21T21:04:14Z  4236840889  completed   \n",
        "\n",
        "  conclusion  run_duration   test_id  \n",
-       "0    success          29.0  28698040  \n",
-       "1    success          30.0  28698040  \n",
-       "2    failure          23.0  28698040  \n",
-       "3    success          21.0  28698040  \n",
-       "4    success          23.0  28698040  \n",
-       "5    success          27.0  28698040  \n",
-       "6    success          29.0  28698040  \n",
-       "7    success          22.0  28698040  \n",
-       "8    success          24.0  28698040  \n",
+       "0    success          36.0  28698040  \n",
+       "1    success          29.0  28698040  \n",
+       "2    success          30.0  28698040  \n",
+       "3    failure          23.0  28698040  \n",
+       "4    success          21.0  28698040  \n",
+       "5    success          23.0  28698040  \n",
+       "6    success          27.0  28698040  \n",
+       "7    success          29.0  28698040  \n",
+       "8    success          22.0  28698040  \n",
        "9    success          24.0  28698040  "
       ]
      },
@@ -457,7 +461,7 @@
     {
      "data": {
       "text/plain": [
-       "(121, 7)"
+       "(122, 7)"
       ]
      },
      "execution_count": 12,
@@ -478,7 +482,7 @@
     {
      "data": {
       "text/plain": [
-       "(149, 7)"
+       "(148, 7)"
       ]
      },
      "execution_count": 13,
@@ -521,7 +525,7 @@
     {
      "data": {
       "text/plain": [
-       "(96, 7)"
+       "(97, 7)"
       ]
      },
      "execution_count": 16,
@@ -563,7 +567,7 @@
     {
      "data": {
       "text/plain": [
-       "(119, 7)"
+       "(118, 7)"
       ]
      },
      "execution_count": 18,
@@ -603,10 +607,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "passing_train.to_csv(\"../data/processed/passing_train.csv\")\n",
-    "failing_train.to_csv(\"../data/processed/failing_train.csv\")\n",
-    "passing_test.to_csv(\"../data/processed/passing_test.csv\")\n",
-    "failing_test.to_csv(\"../data/processed/failing_test.csv\")"
+    "passing_train.to_csv(\"../data/processed/{}passing_train.csv\".format(test_id))\n",
+    "failing_train.to_csv(\"../data/processed/{}failing_train.csv\".format(test_id))\n",
+    "passing_test.to_csv(\"../data/processed/{}passing_test.csv\".format(test_id))\n",
+    "failing_test.to_csv(\"../data/processed/{}failing_test.csv\".format(test_id))"
    ]
   },
   {
@@ -622,7 +626,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -636,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/pass_fail_likelihoods.ipynb
+++ b/notebooks/pass_fail_likelihoods.ipynb
@@ -1,0 +1,2690 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dcf594ab-1dda-4f56-959c-265e069f75de",
+   "metadata": {},
+   "source": [
+    "## Pass and Fail likelihood"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bf608b52-fcb7-4fd2-9eee-95b373d2022f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Import libraries\n",
+    "import os\n",
+    "import gzip\n",
+    "import json\n",
+    "import datetime\n",
+    "import itertools\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.ticker as ticker\n",
+    "\n",
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "import seaborn as sns\n",
+    "from fitter import Fitter, get_common_distributions, get_distributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28448538-e882-408c-b89f-1e3b144c13d2",
+   "metadata": {},
+   "source": [
+    "## Import dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59c6bb0f-0a07-4064-afa2-00e134c68f05",
+   "metadata": {},
+   "source": [
+    "### Test 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f6e60ad8-60fe-4b66-972a-23aa6ac31320",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_id = \"28698040\" # Pre-commit test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "32ec543f-f1f9-48a1-ae3a-406c48a3e845",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_train = pd.read_csv(\"../data/processed/{}passing_train.csv\".format(test_id))\n",
+    "failing_train = pd.read_csv(\"../data/processed/{}failing_train.csv\".format(test_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3096433d-c3d5-4583-85be-15138d2936a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>updated_at</th>\n",
+       "      <th>run_id</th>\n",
+       "      <th>status</th>\n",
+       "      <th>conclusion</th>\n",
+       "      <th>run_duration</th>\n",
+       "      <th>test_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>12</td>\n",
+       "      <td>2022-12-14T15:53:31Z</td>\n",
+       "      <td>2022-12-14T15:54:12Z</td>\n",
+       "      <td>3696463705</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>41.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>28</td>\n",
+       "      <td>2022-06-29T20:52:20Z</td>\n",
+       "      <td>2022-06-29T20:52:49Z</td>\n",
+       "      <td>2585823572</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7</td>\n",
+       "      <td>2022-10-25T20:59:24Z</td>\n",
+       "      <td>2022-10-25T21:00:05Z</td>\n",
+       "      <td>3324245010</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>41.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6</td>\n",
+       "      <td>2022-07-12T21:11:13Z</td>\n",
+       "      <td>2022-07-12T21:11:42Z</td>\n",
+       "      <td>2659424327</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>23</td>\n",
+       "      <td>2022-07-05T15:28:26Z</td>\n",
+       "      <td>2022-07-05T15:29:06Z</td>\n",
+       "      <td>2617219129</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Unnamed: 0            created_at            updated_at      run_id  \\\n",
+       "0          12  2022-12-14T15:53:31Z  2022-12-14T15:54:12Z  3696463705   \n",
+       "1          28  2022-06-29T20:52:20Z  2022-06-29T20:52:49Z  2585823572   \n",
+       "2           7  2022-10-25T20:59:24Z  2022-10-25T21:00:05Z  3324245010   \n",
+       "3           6  2022-07-12T21:11:13Z  2022-07-12T21:11:42Z  2659424327   \n",
+       "4          23  2022-07-05T15:28:26Z  2022-07-05T15:29:06Z  2617219129   \n",
+       "\n",
+       "      status conclusion  run_duration   test_id  \n",
+       "0  completed    success          41.0  28698040  \n",
+       "1  completed    success          29.0  28698040  \n",
+       "2  completed    success          41.0  28698040  \n",
+       "3  completed    success          29.0  28698040  \n",
+       "4  completed    success          40.0  28698040  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "passing_train.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ca3a6320-c1a4-4691-8541-7368ba71caeb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>updated_at</th>\n",
+       "      <th>run_id</th>\n",
+       "      <th>status</th>\n",
+       "      <th>conclusion</th>\n",
+       "      <th>run_duration</th>\n",
+       "      <th>test_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8</td>\n",
+       "      <td>2022-10-11T15:27:59Z</td>\n",
+       "      <td>2022-10-11T21:30:30Z</td>\n",
+       "      <td>3228155174</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>21751.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>19</td>\n",
+       "      <td>2022-09-27T19:49:11Z</td>\n",
+       "      <td>2022-09-27T19:49:59Z</td>\n",
+       "      <td>3138511295</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2022-12-01T18:58:49Z</td>\n",
+       "      <td>2022-12-01T18:59:25Z</td>\n",
+       "      <td>3595655421</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>36.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16</td>\n",
+       "      <td>2022-11-16T19:04:40Z</td>\n",
+       "      <td>2022-11-16T19:05:09Z</td>\n",
+       "      <td>3482315892</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>6</td>\n",
+       "      <td>2022-12-08T16:33:31Z</td>\n",
+       "      <td>2022-12-08T16:33:57Z</td>\n",
+       "      <td>3650200301</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>26.0</td>\n",
+       "      <td>28698040</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Unnamed: 0            created_at            updated_at      run_id  \\\n",
+       "0           8  2022-10-11T15:27:59Z  2022-10-11T21:30:30Z  3228155174   \n",
+       "1          19  2022-09-27T19:49:11Z  2022-09-27T19:49:59Z  3138511295   \n",
+       "2           0  2022-12-01T18:58:49Z  2022-12-01T18:59:25Z  3595655421   \n",
+       "3          16  2022-11-16T19:04:40Z  2022-11-16T19:05:09Z  3482315892   \n",
+       "4           6  2022-12-08T16:33:31Z  2022-12-08T16:33:57Z  3650200301   \n",
+       "\n",
+       "      status conclusion  run_duration   test_id  \n",
+       "0  completed    failure       21751.0  28698040  \n",
+       "1  completed    failure          48.0  28698040  \n",
+       "2  completed    failure          36.0  28698040  \n",
+       "3  completed    failure          29.0  28698040  \n",
+       "4  completed    failure          26.0  28698040  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "failing_train.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "627fe83d-bc6f-43a7-bccd-a972a782bb0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranges = np.arange(0, max(passing_train['run_duration'])+1, 10).tolist()\n",
+    "ranges.append(np.inf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "857a87cc-9ddd-4246-b219-0651da0cf126",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# time bucket passing and failing run durations into buckets of 10 seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c202110b-e7b0-405a-8763-bcd94ed20905",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_train['run_duration_ranges'] = pd.cut(passing_train['run_duration'], bins=ranges)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d21ba177-54c3-4129-8fd5-6b2912f4e722",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "failing_train['run_duration_ranges'] = pd.cut(failing_train['run_duration'], bins=ranges)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "82be8abe-6f1d-4cc8-9f2a-3969848842b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get frequency of how many tests lie in those time buckets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a8632ebe-e34b-41a5-9789-3e964d22d714",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_vc = pd.DataFrame(passing_train['run_duration_ranges'].value_counts().sort_index())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8a0f9f33-cf4b-4e3b-a481-4544a007a808",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>38</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, 50.0]</th>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(50.0, 60.0]</th>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(60.0, 70.0]</th>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(70.0, inf]</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges\n",
+       "(0.0, 10.0]                     0\n",
+       "(10.0, 20.0]                    0\n",
+       "(20.0, 30.0]                   35\n",
+       "(30.0, 40.0]                   38\n",
+       "(40.0, 50.0]                   12\n",
+       "(50.0, 60.0]                    6\n",
+       "(60.0, 70.0]                    5\n",
+       "(70.0, inf]                     1"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a0f8026b-8106-4b7b-a8c3-444860ec2ccd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAFHCAYAAAC4ZhcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAlq0lEQVR4nO3dedgcZZ3u8e9NFnYB4RUiEIIRZVEJEhFHmWEQxogiMCMig0COaFwGFVfQ4yAueMCDih5HnKgMAZRFBUFRARFElC2BsIQAQQhCCCQIEcISWX7nj+fppNLpfrvzblXVuT/X1dfbXVXddXd1v7+uemp5FBGYmVn9rFV2ADMzGxgXcDOzmnIBNzOrKRdwM7OacgE3M6spF3Azs5pyAa8YSXMk7Vl2jjJJOlDS/ZKWStql7DxVkJfFy8rOYdXiAj6CJM2XtHfTsKmSrm48joidIuLKDq8zQVJIGj1MUct2MnBURGwQETc1j8zv/clc1BZI+oakUUMdorCcl+bbw5J+KWmfoZ5X03yvlPS+4rC8LO4ZhnnNl/R0fn8PSTpd0gZDPR8bHi7gtooK/DBsA8zpMM3OEbEB8E/AwcB7hzHPxnleOwOXARdImjqQF6rAsm1lv/z+JgG7AJ8tN451ywW8Yopr6ZJ2kzRT0uN57e8bebKr8t8lec3pDZLWkvR5SfdJWiTpDEkbFV738Dzur5L+s2k+x0v6qaSzJD0OTM3zvkbSEkkLJX1H0tjC64WkD0uaJ+kJSV+WNFHSn3Le84rTN73HllklrS1pKTAKuFnSnzstr4i4G/gjqfisskVTyPryfP90Sf8l6eKc+zpJE7v5bCLioYj4FnA8cJKktZpfvzCPr+T7e0p6QNIxkh4C/kfSJnlNfrGkx/L9rfL0JwB7AN/Jn+13WryHjfIyW5yX4ecLWaZKulrSyfm175X01m7fH3BJY1nm1ztW0p/zsrpd0oGFcf3OS9K2kq7Kz/1tXu5nFcbvnr8vSyTdrELTYX7te/Jz75V0aDfvYY0TEb6N0A2YD+zdNGwqcHWraYBrgMPy/Q2A3fP9CUAAowvPey9wN/CyPO35wJl53I7AUuBNwFhSE8Wzhfkcnx8fQPpRXxfYFdgdGJ3nNxc4ujC/AC4EXgTsBCwDLs/z3wi4HTiizXJom7Xw2i/vZzkuHw9sDywEPt5qebaY/nTgr8Bu+b39CDinzXxWWc55+Mvy8B1a5c3z+Eq+vyfwHHASsHZetpsC/wasB2wI/AT4eeH5VwLv6+c9nJGX/YY5413AkYX3/yzwftIP4YeABwF1+k4CWwG3At8qjD8IeGn+XhwMPAmM62ZepO/vyaTv3JuAx4Gz8rgt8+ewb37tffLjPmD9PO0r87TjgJ3K/v+t4q30AGvSLf+zLAWWFG5P0b6AXwV8Edis6XVWKSyk4vnhwuNX5n+u0cBxwNmFcesBf2flAn5Vh+xHAxcUHgfwxsLjWcAxhcdfB05p81ptsxZeu1MBfzwXkwDOBtbO46bSuYD/oDBuX+CONvNZZTnn4esU339zXlYt4H8H1unn/UwCHis8vpI2BZxUKP8O7FgY9wHgysL7v7vpsw5giw7fySfydJeTmozaZZ0N7N9pXsB40g/XeoXxZ7GigB9D4Uc7D7sEOIJUwJeQfuTWLev/tQ43N6GMvAMiYuPGDfhwP9MeCbwCuEPSDZLe3s+0LwXuKzy+j1S8N8/j7m+MiIinSGs7RfcXH0h6Rd60fyg3q3wV2KzpOQ8X7j/d4nG7nWH9Ze3Wa/PrHwy8nvRP362HCvefon3OdrbMfx/tcvrFEfFM44Gk9ST9d27+eJz0Q72xutsRuxkwhlWX35aFx8vfX/6sof/3eEBEbEj6sdmewuecm95m52aOJcCrWPl70G5eLwUeLQyDlb9j2wAHNV43v/abSGv3T5I+1w8CC3Nz1/b95F9juYBXWETMi4hDgJeQNsF/Kml90lpOswdJ/xQNjTWgh0lNDFs1RkhqbMavNLumx6cCdwDbRcSLgM8BGvi76Tpr1yI5j7Spflwe/CRpTRAASVsMLmpLBwKLgDvz46eK8yStga4UtenxJ0lbHa/Py/Yf83C1mb7oEdLWSvPyW9BV8n5ExO9JWw8nA0jaBvg+cBSwaV7huI3uvgcLgRdLKi6XrQv37yetgW9cuK0fESfmLJdExD6k5pM7cg5r4gJeYZLeI6kvIl4gbVICvAAszn+LxwWfDXw87zjagLTGfG5EPAf8FNhP0j/kHYvH0/mfcENSM8XSvPbzoSF6W52yDsSJwPtzsb4Z2EnSJEnrkN7rkJC0uaSjgC8An82fC6RmhX+XNErSFNKRMf3ZkLSFskTSi/PrFT3Myp/tchHxPHAecIKkDXOR/QSpeWIonALsI2ln0lZNkL5vSPpfpDXwjiLiPmAmcLyksZLeAOxXmOQs0nfyLXm5rZN3+G6Vl/P+eWVlGamJ54VV52Iu4NU2BZijdGTGt4B3R8TTebP0BOCPefNzd+A04EzS5vi9wDPARwAiYk6+fw5pzWgpaQ1yWT/z/hTw76S20e8D5w7h+2qbdSAi4tb8Wp+OiLuALwG/BeYBV/f33C4tkfQkaQffvsBBEXFaYfzHSMVpCXAo8PMOr3cKaWfmI8C1wG+axn8LeGc+suPbLZ7/EdKWxj2k9/dj0jIdtIhYTNpJelxE3E7al3EN6Ufl1aQjfrp1KPAGUnPdV0jfoWV5PvcD+5O27BaT1sg/TapJa5F+lB4kNVP9E0O7AtEzGnuLbQ2S13qXkJpH7i05jq0hJJ1L2mHcvMVhA+Q18DWEpP3yzrP1SW2ct5KOQDAbFpJep3RuwFq5aWl/Om+d2GpwAV9z7E/aJH0Q2I7UHOPNLxtOW5AOiVwKfBv4ULS4NIINnJtQzMxqymvgZmY15QJuZlZTI3pltM022ywmTJgwkrM0M6u9WbNmPRIRfc3DR7SAT5gwgZkzZ47kLM3Mak/Sfa2GuwnFzKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGpqRE/kMSuacOzFpc17/olvK23eZkPFa+BmZjXlAm5mVlMu4GZmNeUCbmZWUy7gZmY15QJuZlZTLuBmZjXlAm5mVlMu4GZmNeUCbmZWUy7gZmY15QJuZlZTHQu4pHUkXS/pZklzJH0xDz9d0r2SZufbpGFPa2Zmy3VzNcJlwF4RsVTSGOBqSb/O4z4dET8dvnhmZtZOxwIeEQEszQ/H5FsMZygzM+usqzZwSaMkzQYWAZdFxHV51AmSbpH0TUlrD1dIMzNbVVcdOkTE88AkSRsDF0h6FfBZ4CFgLDAdOAb4UvNzJU0DpgGMHz9+aFJb19xpglnvWq2jUCJiCXAFMCUiFkayDPgfYLc2z5keEZMjYnJfX9+gA5uZWdLNUSh9ec0bSesC+wB3SBqXhwk4ALht+GKamVmzbppQxgEzJI0iFfzzIuKXkn4nqQ8QMBv44PDFNDOzZt0chXILsEuL4XsNSyIzM+uKz8Q0M6spF3Azs5pyATczqykXcDOzmnIBNzOrKRdwM7OacgE3M6spF3Azs5pyATczqykXcDOzmnIBNzOrKRdwM7OacgE3M6spF3Azs5pyATczqykXcDOzmnIBNzOrKRdwM7Oa6qZT43UkXS/pZklzJH0xD99W0nWS7pZ0rqSxwx/XzMwaulkDXwbsFRE7A5OAKZJ2B04CvhkRLwceA44ctpRmZraKjgU8kqX54Zh8C2Av4Kd5+AzggOEIaGZmrXXVBi5plKTZwCLgMuDPwJKIeC5P8gCw5bAkNDOzlroq4BHxfERMArYCdgO273YGkqZJmilp5uLFiweW0szMVrFaR6FExBLgCuANwMaSRudRWwEL2jxnekRMjojJfX19g8lqZmYF3RyF0idp43x/XWAfYC6pkL8zT3YEcOEwZTQzsxZGd56EccAMSaNIBf+8iPilpNuBcyR9BbgJ+OEw5jQzsyYdC3hE3ALs0mL4PaT2cDMzK4HPxDQzqykXcDOzmnIBNzOrKRdwM7OacgE3M6spF3Azs5pyATczqykXcDOzmnIBNzOrKRdwM7OacgE3M6spF3Azs5pyATczqykXcDOzmnIBNzOrKRdwM7OacgE3M6spF3Azs5rqplPjrSVdIel2SXMkfSwPP17SAkmz823f4Y9rZmYN3XRq/BzwyYi4UdKGwCxJl+Vx34yIk4cvnpmZtdNNp8YLgYX5/hOS5gJbDncwMzPr32q1gUuaQOqh/ro86ChJt0g6TdImQx3OzMza67qAS9oA+BlwdEQ8DpwKTAQmkdbQv97medMkzZQ0c/HixYNPbGZmQJcFXNIYUvH+UUScDxARD0fE8xHxAvB9YLdWz42I6RExOSIm9/X1DVVuM7M1XjdHoQj4ITA3Ir5RGD6uMNmBwG1DH8/MzNrp5iiUNwKHAbdKmp2HfQ44RNIkIID5wAeGIZ+ZmbXRzVEoVwNqMepXQx/HzMy65TMxzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqqpte6beWdIWk2yXNkfSxPPzFki6TNC//3WT445qZWUM3a+DPAZ+MiB2B3YH/kLQjcCxweURsB1yeH5uZ2QjpWMAjYmFE3JjvPwHMBbYE9gdm5MlmAAcMU0YzM2thtdrAJU0AdgGuAzaPiIV51EPA5kMbzczM+tN1AZe0AfAz4OiIeLw4LiICiDbPmyZppqSZixcvHlRYMzNboasCLmkMqXj/KCLOz4MfljQujx8HLGr13IiYHhGTI2JyX1/fUGQ2MzO6OwpFwA+BuRHxjcKoi4Aj8v0jgAuHPp6ZmbUzuotp3ggcBtwqaXYe9jngROA8SUcC9wHvGpaEZmbWUscCHhFXA2oz+s1DG8fMzLrlMzHNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymuunU+DRJiyTdVhh2vKQFkmbn277DG9PMzJp1swZ+OjClxfBvRsSkfPvV0MYyM7NOOhbwiLgKeHQEspiZ2WoYTBv4UZJuyU0smwxZIjMz68pAC/ipwERgErAQ+Hq7CSVNkzRT0szFixcPcHZmZtZsQAU8Ih6OiOcj4gXg+8Bu/Uw7PSImR8Tkvr6+geY0M7MmAyrgksYVHh4I3NZuWjMzGx6jO00g6WxgT2AzSQ8AXwD2lDQJCGA+8IHhi2hmZq10LOARcUiLwT8chixmZrYafCammVlNuYCbmdWUC7iZWU25gJuZ1ZQLuJlZTbmAm5nVlAu4mVlNuYCbmdWUC7iZWU25gJuZ1ZQLuJlZTXW8ForZmmjCsReXNu/5J76ttHlbvXgN3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MaqpjAZd0mqRFkm4rDHuxpMskzct/NxnemGZm1qybNfDTgSlNw44FLo+I7YDL82MzMxtBHQt4RFwFPNo0eH9gRr4/AzhgaGOZmVknA20D3zwiFub7DwGbD1EeMzPr0qB3YkZEANFuvKRpkmZKmrl48eLBzs7MzLKBFvCHJY0DyH8XtZswIqZHxOSImNzX1zfA2ZmZWbOBFvCLgCPy/SOAC4cmjpmZdaubwwjPBq4BXinpAUlHAicC+0iaB+ydH5uZ2QjqeDnZiDikzag3D3EWMzNbDT4T08ysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKY69shjZtUy4diLS5v3/BPfVtq8bVWDKuCS5gNPAM8Dz0XE5KEIZWZmnQ3FGvg/R8QjQ/A6Zma2GtwGbmZWU4Mt4AFcKmmWpGlDEcjMzLoz2CaUN0XEAkkvAS6TdEdEXFWcIBf2aQDjx48f5OzMrMrK3MEKa95O1kGtgUfEgvx3EXABsFuLaaZHxOSImNzX1zeY2ZmZWcGAC7ik9SVt2LgP/Atw21AFMzOz/g2mCWVz4AJJjdf5cUT8ZkhSmZlZRwMu4BFxD7DzEGYxM7PV4MMIzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MasoF3MysplzAzcxqygXczKymXMDNzGrKBdzMrKZcwM3MamqwvdKbmdXChGMvLnX+809825C/ptfAzcxqalAFXNIUSXdKulvSsUMVyszMOhtwAZc0Cvgv4K3AjsAhknYcqmBmZta/wayB7wbcHRH3RMTfgXOA/YcmlpmZdTKYAr4lcH/h8QN5mJmZjQBFxMCeKL0TmBIR78uPDwNeHxFHNU03DZiWH74SuHPgcQdlM+CRkubdibMNjLMNjLMNTJnZtomIvuaBgzmMcAGwdeHxVnnYSiJiOjB9EPMZEpJmRsTksnO04mwD42wD42wDU8Vsg2lCuQHYTtK2ksYC7wYuGppYZmbWyYDXwCPiOUlHAZcAo4DTImLOkCUzM7N+DepMzIj4FfCrIcoy3EpvxumHsw2Msw2Msw1M5bINeCemmZmVy6fSm5nVlAu4mVlN9eTVCCW9uIvJXoiIJcOdpZmkT3Qx2ZMR8d/DHqaJpH/tYrJn8r6PESXptV1M9mxE3DrsYZpUfLlV+ftW5WyV/b4V9WQbuKRngAcB9TPZqIgYP0KRlpO0EDiV/rMdGhGvGKFIy0n6K3Ah/Wf7x4iYOEKRlpP0BOnQ1f6ybRsRE0Ym0QoVX25V/r5VOVtlv29FPbkGDsyNiF36m0DSTSMVpsmZEfGl/iaQtP5IhWny64h4b38TSDprpMI0uSEi9upvAkm/G6kwTaq83Kr8fatytip/31Zk6NE18HUi4pnBTmNmayZJb4yIP0paOyKWlZ2nnZ4s4ACSRLpiYuMCWwuA66MCb1jSW4ADWDnbhRHxm9JCZZK2J11VspjtooiYW16qRNJGwBRWznZJGfsymlV8uVX5+1bJbJJmRcSukm6MiG7aw0vRkwVc0r8A3wXmseL6LFsBLwc+HBGXlpjtFOAVwBmkKzhCynY4MC8iPlZSNCQdAxxCujRwMdu7gXMi4sQSsx0OfAG4lJU/032AL0bEGSVmq/JyO4Xqft9OobrZrgVuIf0on9s8PiI+OuKhWujVAj4XeGtEzG8avi3wq4jYoZRgKcNdrXbK5C2GuyJiuxJiNTLcBewUEc82DR8LzCk5252kq10uaRq+CXBdGTu6ChmqvNwq/X2rcLbNgL2Bk4DjmsdHxIwRD9VCr+7EHM2KX/SiBcCYEc7S7BlJr4uIG5qGvw4ou03+BeClwH1Nw8flcWUS0Gpt4wX6P1JgJFR5uVX5+1bZbBHxCHCOpLkRcXOZWfrTqwX8NOAGSeewotOJrUmbtD8sLVUyFThV0oas+JHZGvhbHlemo4HLJc1jxXIbT2p6Oqrdk0bICcCNki5l5Wz7AF8uLVVyNNVdblOp7vdtKtXN1vCgpM8BEyjUy05HHY2UnmxCAZC0A613Kt1eXqoVJG1BIVtEPFRmngZJa7Hqzt8bIuL58lIlubnkLay6E/Ox8lIlVV5uUN3vG1Q+25+APwCzgOWfZUT8rLRQBT1bwM3MBkvS7IiYVHaOdta4a6FIOr7sDO1IurHsDO1I+mXZGdqRVLnLfDZUfLlV+ftWlWy/lLRv2SHaWePWwCXtFxG/KDtH3UgaFxELy87RiqRdI2JW2TlaqfJys87yKfXrA8uAZ8k70yPiRaUGy9a4Al4VkjZn5Xa/h8vM06xxQbCIeLTsLHVS1eVW5e9blbNVXU8WcEmjgSOBA0mHd0E+wwv4YfPxuiOcbRLwPWAjVj4hZQnpJKPSNh0ljQe+Brw55xHwIuB3wLHNx9WPcLaNgM+Sztp7CemQwkWkz/TEMs/GrPhym0R1v2+TqG627SPijnZXJSwz20oiouduwNmkq5ztTvpCbJXvnwqcW3K22aQTUpqH7w7cXHK2a4CDSVdqbAwbRTr88tqSs10CHANsURi2RR52qZdbLb9vVc42Pf+9osXtd2VmK956dQ285RlencaNBEnzos0ZZpLujoiXj3Smwvz7y9Z23EiQdGdEvHJ1x42Eii+3un7fSs1WF716Is+jkg4CfhYRL8Dy43QPAso+ZvjXki4mXf+heJLR4UDZFxeaJem7wAxWznYEUNbldxvuk/QZYEbkNtLcdjqVFVnLUuXlVuXvW5Wz1UKvroFPIF3DYC9WFOyNSZs/x0bEveUkSyS9ldYnGY14jy1F+dodR9IiG2nfQWmX1cwn8Rybs70kD344ZzspStxpWOXlBtX9vkG1s9VBTxbwIkmbAkTEX8vOYmY2lHr+RJ6I+GuxeEvap8w8kkZJ+oCkL0v6h6Zxny8rV57/epI+I+nTktaRdISkiyR9TdIGZWZrRRXoEQWWX7mu+Pg9kr4taVq+sl5pJB3VyCdpoqSrJD0m6TpJry452/mSDq3id6sdSeMkrV12joaeXwNvJukvUUJfmIX5/wBYD7geOAz4fUR8Io8r9eLxks4jtUWuC7wSmEu6FvI7SEd/HFZitluaB5GuJX0nQES8ZsRDNYIUPrf8I7wH8GPg7cADEfHxErPNiYid8v2LgR9ExAWS9gROiIg3lphtAekInr2A35KOHrs4Iv5eVqZOJP0WmEjav/apsvP05E5MSRe1GwVsOpJZWtitUWwkfQf4rqTzSR0ClH1Z1FdExLvyWuNCYO+ICElXA2VfUnM+8DjwFeBp0rL6A7BfiZkaip/bvwJ7RMSTkn4MlH28cPF//CURcQFARFyZrwJYpkUR8U5JLyK1g78fmJ4vP3B2lNjxSjsRsXf+/9ix7CzQowWctAb0HmBp0/BGN2tlGtu4ExHPAdMkHUc66aMSm5K5aP8q8uZZflzqplpEvEPSgcB04OSIuEjSsxHRfA3uMqwraRdSk+SoiHgSICKelVT21Qh/Kul04EvABZKOBi4grfX+pcRckK/vHhGPA2cCZ+Z9VgeRdliXWsBzoW7XLeOc0oIV9GoBvxZ4KiJ+3zxCqWeXMs2UNCUKff5FxJckPUg60ahMMyVtEBFLo3C9Y0kTgSdKzAVA3vS/FPiypCMp/BiWbCHwjXz/0cb1T3Ixeq7EXETE/5Y0ldQ8MRFYG5gG/Bw4tLxkwKorWI2DDb6Xb6VRP90ySiq1W8aiNa4N3AZGkqJCXxZJOwNviIhS/9H7I2kUsHZEPFV2Fls9qnC3jEUu4GZmTZR6V9ohN3MWh48Fbq/KWaK92oRiZjYYVe6WcTmvgZuZtaCKd8sILuCVIWkc8GjZp123UuVsNjBV/kyrnK1qev5MzCJJMySdKulVZWdp4UzgDkknlx2khcpmkzQ338ru/X0VVc5GhT9Tqp2tUt0yrlFr4JJeB4wnnUxzTNl5mjVOEIiIShxjWlTxbJsCu0fExWVnaVbxbFX+TKucrTLdMq5RBbwqOpwgUKoqZ4Nqd79V1WxV/kyrnK0OerKAq9rdb7U9QYDUjVRpJwhUPNskqtv91iSqm63Kn2mVs1W2W8aVtOqmp+43qt391lxgQovh2wJzna1tttlUt/utKmer8mda5WyV7ZaxeOvV48AnRMRJxQER8RBwkqT3tnnOSBkNPNBi+AJgzAhnaVblbOtHxHXNAyPiWknrlxGooMrZqvyZVjnbrrFq14sPANdKuquMQK30agG/T9XtfqvKJwhUOVuVu9+qcrYqf6ZVzlblbhmX69U28Mp2vwXVPkGg4tkq2/1WxbNV+TOtZDZVvFvGhp4s4GZmQ0UV7pZxjTqRB0BSaT3edFKlEwSaVTzbtLIztFPxbMeXnaGdsrNJeody12nR1C1jlaxxBRz4UNkB+jGr7AD9qHK2snsy6k+Vs1X5My0727nAAklnSto3Xxq4ctyEYmbWRNJNpPbvd5J2qr6K1JPR2dGio5iy9GwBzyfzTGHlnSOXRIkn8UC1TxCocjYASW8hnZxV/EwvjELvRmWparYqf6YVz7ZSB+OStgDeReq7dquI2LqsbEU9WcAlHQ58gdSnXvEMr32AL0bEGSVmO5t0ht4MVhwDuxVwBPDiiDi4pGhVz3YKqRf6M1g52+HAvIj4WEnRqp6typ9plbPdFBG7tBm3TVSjL9aeLeB3ks6MW9I0fBPguhYH6I8YSXe1m39/40ZCHbPla2ncFRHblRCrkaF22TqNGwkVz7ZnRFxZ1vy71as7MUXu8brJC5S/U+lRSQflkwKAdIKApIMp/wSBKmd7Jl9NstnrgGdGOkyTKmer8mda5Wwd27nzD3SpevVMzBOAG5V6MG+c4TWe1ITy5dJSJe8mnSDwXUnNJwi8u6xQWZWzTQVOlbQhKza3twb+lseVaSrVzdb8mYp00a0qfKatsm0M/I7ys10h6Wek/Rh/aQxU6hPzTaRmniuA08uJl/P0YhMKLG8ueQur7sQs+5d9uSqfIFDVbHlnUvGSrQ+Vmaeoytmgup8pVC+bpHWA9wKHki6utQRYBxhF2rf23Yi4qbSAWU8WcEmKDm+sm2lGmqR9IuKykjO8COiLiD83DX9NRNxSUqxGhi0gXZhMUh+wB3BH2addtyLpqxHxubJzNJO0LbALqWf1O0rOMh5YFBHP5OaIqcBrgduB70dTj/BlkTQG2Ax4uuyj2Jr1agG/Eui4+RMRp5cSsA1Jf4mI8SXO/13AKaRrp48BpkbEDXncSodVlZDtA6Tr24i02T0VuI30eX4tIkq7+JGkb7cYfDjpqBQi4qMjm2gFST+PiAPy/f1Jn++VwBuBr5b5PyDpNlLvWE9JOgmYCPycdPw1EVH2lUMrr1fbwKeQNn/OzmscS4B1STttLwVOKWvzR9JF7UYBm45klhY+R7qM5kJJuwFnSvpsRFxA+Tt/jwJ2In2O9wEvz2vim5DaIsu8et2BpJ1el7JiOR1C+WcTAmxTuH8MsFdE3CtpM+Byym3DXSsinsr39wZel6/8d5akm0vMVRs9WcAj4hlSTx/freDmzx7Ae4ClTcMbXUuVaVRELASIiOsl/TPwS0lb0/qonpH0bP5nf0rSnxvtyxHxmKSys+1I2jk+BfhURDwo6QsRMaPkXLDy5za6cRW9iHhE0gslZWq4X9JeEfE7YD5px+99jfZw66wnC3hRPptrYdk5Cq4Fnmp1Om4+fr1MT0ia2Gj/zmvie5I2a3cqMRdASBqTP8+3NQbmnU2lHg4bEU8AR0vaFfiR0rXBq3KI7s6SHietIKwtaVz+XMeSdsiV6X3AGUoXrvobMFvSbNKRKJ8oL1Z99GQbuA2MpJ1JPy7zmoaPAd4VET8qJ9nyHV4PNu/YkrQlsENE/LacZCvLO+M+DLwhIt5Tdp52JG1MWm7XVCDLDqQzWRs99NzQ6ETB+ucCPsKqfISMsw2Msw1MlbPVRVU289YkV0j6SF6jXE7SWEl7SZpBOkrG2ZzN2crLVgteAx9hVT5BwNmGNFvxqKeqZavycqtEtrpwAS9RBY+QWc7ZBsbZBqbK2arMBdzMrKbcBm5mVlMu4GZmNeUCbgMi6XlJsyXdJukX+bjioXjdKyXdKekWSXdI+s5QvXZ+/T0l/UPh8QeVenAa7OtOkPR0Xia3Szojt+uaDRsXcBuopyNiUkS8CngU+I8hfO1DI+I1wGuAZaQ+Erum1NdiO3sCywt4RHwvhq6LvT9HxCTg1aSuwd41RK9r1pILuA2Fa8jXwc5r0JPz/c0kzc/3p0o6X9JvJM2T9LVOLxoRfwc+A4yXtHNey72tMV7Sp/Jp2I35niJpJvAxSftJuk7STZJ+K2lzSROADwIfz2vKe0g6XtKn8mtMknRtXvu/QOlCWY3XPknS9ZLukrRHh9zPA9cXlskqWfLw4yWdll//HknLr1oo6T/zlsjVks4uZJyYl+EsSX+QtH0eflDeGrpZ0lWdlq31BhdwGxRJo4A3A+2uslg0CTiYtIZ6sNJFsvqVi+HNwPZdvP7YiJgcEV8HrgZ2j9Qx7TnAZyJiPvA94Jt56+EPTc8/Azgmr/3fSuoYu2F0ROwGHN00fBX5+ObXA40e6VfJUph8e1LHI7sBX5A0Rql7tn8DdgbeCkwuTD8d+EhE7Ap8inTRNoDjgLdExM7AO/rLZ72j5y9mZcNmXaULD20JzAW66Yji8oj4G4Ck20mXOr2//6cA3V/K9tzC/a2AcyWNA8YC9/Y7A2kjYOPCRcZmAD8pTHJ+/jsLmNDmZSbmZbItcHGhA4z+slwcEcuAZZIWAZuTrtV9Yb6q5jOSfpEzbkBq/vmJVnTHuHb++0fgdEnnFbJaj/MauA3U07m9dxtSgW20gT/Hiu/VOk3PWVa4/zxdrEDkNfxXk34kiq/d6vWfLNz/f8B3IuLVwAdaTLu6Gtn7y91oA58I7CqpsSbcX5bVWSZrAUvy1kPjtgNARHwQ+Dzpkqyz5EuyrhFcwG1Q8jW6Pwp8Mu88nA/smke/czCvnY/i+D/A/Xlt9mHgJZI2lbQ28PZ+nr4RqR9UWPl6Gk8AG7Z4H38DHiu0bx9GFz2TtxIRj5B6D/pshyzt/BHYT9I6ea377fl1HwfulXQQpAs9KV1BEqXLAF8XEccBi0mF3HqcC7gNWr5exS2kXmhOBj4k6SbSqdED8SNJt5C6TFsf2D/P51ngS6QdhJcB/fXpeDypqWEW8Ehh+C+AAxs7MZuecwTwf/O8J+V5DdTPgfXyPNplaSl3Y3cRaZn+mtQe/7c8+lDgSKUea+aQl03OfWveyfsn0n4D63E+ld6sgiRtEBFLJa0HXAVMi4gby85l1eKdmGbVNF3SjqT28hku3taK18DNzGrKbeBmZjXlAm5mVlMu4GZmNeUCbmZWUy7gZmY15QJuZlZT/x8hGMmHsm5NfwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.bar(p_vc.index.astype(str), p_vc['run_duration_ranges'].values)\n",
+    "\n",
+    "# set the x-axis label and title\n",
+    "plt.xlabel('Run Duration Ranges')\n",
+    "plt.title('Histogram of Run Duration Ranges')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# display the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1fcf534b-4ad3-43e1-ae6c-d3ad10aa1f08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f_vc = pd.DataFrame(failing_train['run_duration_ranges'].value_counts().sort_index())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "94385efa-82a2-4975-a0d6-cdb86baa5b49",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAFHCAYAAAC4ZhcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAk3klEQVR4nO3de7gcVZ3u8e9Lwh0EhAgRCGEiykUlDBFxlBkGYUQUgRkRGQRyxImXQcEr6HEQb3PAgw56HHHiyCGAchkFQXEERBBRQBII1wBBCHIJEMQI4SaX3/yxVieVTvfuzr5VrZ338zz97O6q2l1vV/f+7epVVWspIjAzs/KsVncAMzMbHBdwM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAt4w0i6VdLudeeok6QDJN0naYmknerO0wR5W/xF3TmsWVzAR5GkBZL2bJs2XdJVrccRsUNEXNHjeSZLCknjRyhq3U4CjoyI9SLihvaZ+bU/mYvaA5K+JmnccIeobOcl+fawpJ9I2mu419W23iskva86LW+Lu0dgXQskPZ1f30OSTpO03nCvx0aGC7itoAH/GLYCbu2xzI4RsR7wN8BBwHtHMM+GeV07ApcC50uaPpgnasC27WTf/PqmAjsBn643jvXLBbxhqnvpknaRNFvS43nv72t5sSvzz8V5z+kNklaT9FlJ90p6RNLpkjaoPO9hed4fJP1L23qOl/QDSWdKehyYntd9taTFkhZK+qakNSrPF5I+JGm+pCckfVHSFEm/yXnPrS7f9ho7ZpW0pqQlwDjgRkm/67W9IuIu4Nek4rPCN5pK1lfk+6dJ+ndJF+Xc10qa0s97ExEPRcTXgeOBEyWt1v78lXV8Kd/fXdL9ko6R9BDw/yVtlPfkF0n6Y76/RV7+y8BuwDfze/vNDq9hg7zNFuVt+NlKlumSrpJ0Un7ueyS9td/XB1zc2pb5+Y6V9Lu8rW6TdEBl3oDrkrS1pCvz7/48b/czK/N3zZ+XxZJuVKXpMD/33fl375F0SD+vYZUTEb6N0g1YAOzZNm06cFWnZYCrgUPz/fWAXfP9yUAA4yu/917gLuAv8rLnAWfkedsDS4A3AWuQmiieq6zn+Px4f9I/9bWBnYFdgfF5ffOAoyvrC+AC4CXADsCzwGV5/RsAtwGHd9kOXbNWnvsVA2zHpfOBbYGFwEc7bc8Oy58G/AHYJb+27wFnd1nPCts5T/+LPH27TnnzOr6U7+8OPA+cCKyZt+3GwD8A6wDrA/8F/Kjy+1cA7xvgNZyet/36OeOdwBGV1/8c8E+kf4QfBB4E1OszCWwB3Ax8vTL/QODl+XNxEPAkMLGfdZE+vyeRPnNvAh4HzszzNs/vwz75uffKjycA6+ZlX5WXnQjsUPffbxNvtQdYlW75j2UJsLhye4ruBfxK4PPAJm3Ps0JhIRXPD1Uevyr/cY0HjgPOqsxbB/gzyxfwK3tkPxo4v/I4gDdWHs8Bjqk8/ipwcpfn6pq18ty9CvjjuZgEcBawZp43nd4F/D8r8/YBbu+ynhW2c56+VvX1t+dlxQL+Z2CtAV7PVOCPlcdX0KWAkwrln4HtK/PeD1xRef13tb3XAWzW4zP5RF7uMlKTUbesc4H9eq0LmET6x7VOZf6ZLCvgx1D5p52nXQwcTirgi0n/5Nau6++1hJubUEbf/hGxYesGfGiAZY8AXgncLuk6SW8fYNmXA/dWHt9LKt6b5nn3tWZExFOkvZ2q+6oPJL0yf7V/KDer/CuwSdvvPFy5/3SHx90Ohg2UtV9/mZ//IOD1pD/6fj1Uuf8U3XN2s3n++Vifyy+KiGdaDyStI+k/cvPH46R/1BuqvwOxmwCrs+L227zyeOnry+81DPwa94+I9Un/bLal8j7npre5uZljMfBqlv8cdFvXy4HHKtNg+c/YVsCBrefNz/0m0t79k6T39QPAwtzcte0A+VdZLuANFhHzI+Jg4GWkr+A/kLQuaS+n3YOkP4qW1h7Qw6Qmhi1aMyS1vsYvt7q2x6cAtwPbRMRLgM8AGvyr6Ttr3yI5l/RV/bg8+UnSniAAkjYbWtSODgAeAe7Ij5+qrpO0B7pc1LbHHyd963h93rZ/naery/JVj5K+rbRvvwf6Sj6AiPgl6dvDSQCStgK+AxwJbJx3OG6hv8/BQuClkqrbZcvK/ftIe+AbVm7rRsQJOcvFEbEXqfnk9pzD2riAN5ik90iaEBEvkr5SArwILMo/q+cFnwV8NB84Wo+0x3xORDwP/ADYV9Jf5QOLx9P7j3B9UjPFkrz388Fhelm9sg7GCcA/5WJ9I7CDpKmS1iK91mEhaVNJRwKfAz6d3xdIzQr/KGmcpL1JZ8YMZH3SN5TFkl6an6/qYZZ/b5eKiBeAc4EvS1o/F9mPkZonhsPJwF6SdiR9qwnS5w1J/4u0B95TRNwLzAaOl7SGpDcA+1YWOZP0mXxL3m5r5QO+W+TtvF/eWXmW1MTz4oprMRfwZtsbuFXpzIyvA++OiKfz19IvA7/OXz93BU4FziB9Hb8HeAb4MEBE3Jrvn03aM1pC2oN8doB1fwL4R1Lb6HeAc4bxdXXNOhgRcXN+rk9GxJ3AF4CfA/OBqwb63T4tlvQk6QDfPsCBEXFqZf5RpOK0GDgE+FGP5zuZdDDzUeAa4Gdt878OvDOf2fGNDr//YdI3jbtJr+/7pG06ZBGxiHSQ9LiIuI10LONq0j+V15DO+OnXIcAbSM11XyJ9hp7N67kP2I/0zW4RaY/8k6SatBrpn9KDpGaqv2F4dyDGjNbRYluF5L3exaTmkXtqjmOrCEnnkA4Yt3/jsEHyHvgqQtK++eDZuqQ2zptJZyCYjQhJr1O6NmC13LS0H72/ndhKcAFfdexH+kr6ILANqTnGX79sJG1GOiVyCfAN4IPRoWsEGzw3oZiZFcp74GZmhepZwPPpPb/NfRXcKunzefrWSv1I3CXpHHXp98LMzEZGzyYUSQLWjYglklYnnbZ0FOk0n/Mi4mxJ3wZujIhTBnquTTbZJCZPnjw8yc3MVhFz5sx5NCImtE/v2bVlPtC1JD9cPd8C2IN0njDALNIFEwMW8MmTJzN79uz+U5uZGZLu7TS9rzbwfKXUXNLFH5cCvwMWV66cu5/l+2IwM7MR1lcBj4gXImIqqT+NXUgd3vRF0gylPq1nL1q0aHApzcxsBSt1FkpELAYuJ10eu6GWjS6yBV0604mImRExLSKmTZiwQhOOmZkNUj9noUyQtGG+vzap4/V5pEL+zrzY4aQO5s3MbJT0Mz7fRGBW7qt4NeDciPiJpNuAs5WGjroB+O4I5jQzszb9nIVyE2mg0/bpd5Paw83MrAa+EtPMrFAu4GZmheqnDdwKNvnYi2pb94IT3lbbuofK281K4D1wM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoVyATczK5QLuJlZoVzAzcwK5QJuZlYoF3Azs0K5gJuZFcoF3MysUC7gZmaFcgE3MyuUC7iZWaFcwM3MCuUCbmZWqJ4FXNKWki6XdJukWyUdlacfL+kBSXPzbZ+Rj2tmZi3j+1jmeeDjEXG9pPWBOZIuzfP+LSJOGrl4ZmbWTc8CHhELgYX5/hOS5gGbj3QwMzMb2Eq1gUuaDOwEXJsnHSnpJkmnStpouMOZmVl3fRdwSesBPwSOjojHgVOAKcBU0h76V7v83gxJsyXNXrRo0dATm5kZ0GcBl7Q6qXh/LyLOA4iIhyPihYh4EfgOsEun342ImRExLSKmTZgwYbhym5mt8vo5C0XAd4F5EfG1yvSJlcUOAG4Z/nhmZtZNP2ehvBE4FLhZ0tw87TPAwZKmAgEsAN4/AvnMzKyLfs5CuQpQh1k/Hf44ZmbWL1+JaWZWKBdwM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVqh+LqU3GxGTj72otnUvOOFtta3bbLh4D9zMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoVyATczK5QLuJlZoVzAzcwK5QJuZlYoF3Azs0K5gJuZFcoF3MysUD0LuKQtJV0u6TZJt0o6Kk9/qaRLJc3PPzca+bhmZtbSzx7488DHI2J7YFfgnyVtDxwLXBYR2wCX5cdmZjZKehbwiFgYEdfn+08A84DNgf2AWXmxWcD+I5TRzMw6WKk2cEmTgZ2Aa4FNI2JhnvUQsOnwRjMzs4H0PSq9pPWAHwJHR8TjkpbOi4iQFF1+bwYwA2DSpElDS2tmTD72otrWveCEt9W2bltRX3vgklYnFe/vRcR5efLDkibm+ROBRzr9bkTMjIhpETFtwoQJw5HZzMzo7ywUAd8F5kXE1yqzLgQOz/cPBy4Y/nhmZtZNP00obwQOBW6WNDdP+wxwAnCupCOAe4F3jUhCMzPrqGcBj4irAHWZ/ebhjWNmZv3ylZhmZoVyATczK5QLuJlZoVzAzcwK5QJuZlYoF3Azs0K5gJuZFcoF3MysUC7gZmaFcgE3MyuUC7iZWaFcwM3MCuUCbmZWKBdwM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoVyATczK5QLuJlZoXoWcEmnSnpE0i2VacdLekDS3HzbZ2RjmplZu372wE8D9u4w/d8iYmq+/XR4Y5mZWS89C3hEXAk8NgpZzMxsJQylDfxISTflJpaNui0kaYak2ZJmL1q0aAirMzOzqsEW8FOAKcBUYCHw1W4LRsTMiJgWEdMmTJgwyNWZmVm7QRXwiHg4Il6IiBeB7wC7DG8sMzPrZVAFXNLEysMDgFu6LWtmZiNjfK8FJJ0F7A5sIul+4HPA7pKmAgEsAN4/chHNzKyTngU8Ig7uMPm7I5DFzMxWgq/ENDMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoVyATczK1TPKzHNzPo1+diLal3/ghPeVuv6R5v3wM3MCuUCbmZWKBdwM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoVyATczK5QLuJlZoXoWcEmnSnpE0i2VaS+VdKmk+fnnRiMb08zM2vWzB34asHfbtGOByyJiG+Cy/NjMzEZRzwIeEVcCj7VN3g+Yle/PAvYf3lhmZtbLYNvAN42Ihfn+Q8Cmw5THzMz6NOSDmBERQHSbL2mGpNmSZi9atGioqzMzs2ywBfxhSRMB8s9Hui0YETMjYlpETJswYcIgV2dmZu0GW8AvBA7P9w8HLhieOGZm1q9+TiM8C7gaeJWk+yUdAZwA7CVpPrBnfmxmZqNofK8FIuLgLrPePMxZzMxsJfhKTDOzQrmAm5kVygXczKxQLuBmZoVyATczK5QLuJlZoVzAzcwK5QJuZlYoF3Azs0K5gJuZFcoF3MysUC7gZmaFcgE3MyuUC7iZWaFcwM3MCuUCbmZWKBdwM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQ44fyy5IWAE8ALwDPR8S04QhlZma9DamAZ38bEY8Ow/OYmdlKcBOKmVmhhlrAA7hE0hxJM4YjkJmZ9WeoTShviogHJL0MuFTS7RFxZXWBXNhnAEyaNGmIqzMzs5Yh7YFHxAP55yPA+cAuHZaZGRHTImLahAkThrI6MzOrGHQBl7SupPVb94G/A24ZrmBmZjawoTShbAqcL6n1PN+PiJ8NSyozM+tp0AU8Iu4GdhzGLGZmthJ8GqGZWaFcwM3MCjUcV2KamTXe5GMvqnX9C05427A/p/fAzcwK5QJuZlYoF3Azs0K5gJuZFcoF3MysUC7gZmaFcgE3MyuUC7iZWaFcwM3MCuUCbmZWKBdwM7NCuYCbmRXKBdzMrFAu4GZmhXIBNzMrlAu4mVmhXMDNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoVyATczK5QLuJlZoYZUwCXtLekOSXdJOna4QpmZWW+DLuCSxgH/DrwV2B44WNL2wxXMzMwGNpQ98F2AuyLi7oj4M3A2sN/wxDIzs16GUsA3B+6rPL4/TzMzs1GgiBjcL0rvBPaOiPflx4cCr4+II9uWmwHMyA9fBdwx+LhDsgnwaE3r7sXZBsfZBsfZBqfObFtFxIT2ieOH8IQPAFtWHm+Rpy0nImYCM4ewnmEhaXZETKs7RyfONjjONjjONjhNzDaUJpTrgG0kbS1pDeDdwIXDE8vMzHoZ9B54RDwv6UjgYmAccGpE3DpsyczMbEBDaUIhIn4K/HSYsoy02ptxBuBsg+Nsg+Nsg9O4bIM+iGlmZvXypfRmZoVyATczK9SQ2sCbStJL+1jsxYhYPNJZ2kn6WB+LPRkR/zHiYdpI+vs+FnsmH/sYVZL+so/FnouIm0c8TJuGb7cmf96anK2xn7eqMdkGLukZ4EFAAyw2LiImjVKkpSQtBE5h4GyHRMQrRynSUpL+AFzAwNn+OiKmjFKkpSQ9QTp1daBsW0fE5NFJtEzDt1uTP29NztbYz1vVmNwDB+ZFxE4DLSDphtEK0+aMiPjCQAtIWne0wrT574h470ALSDpztMK0uS4i9hhoAUm/GK0wbZq83Zr8eWtytiZ/3pZlGKN74GtFxDNDXcbMVk2S3hgRv5a0ZkQ8W3eebsZkAQeQJFKPia0Oth4AfhsNeMGS3gLsz/LZLoiIn9UWKpO0LalXyWq2CyNiXn2pEkkbAHuzfLaL6ziW0a7h263Jn7dGZpM0JyJ2lnR9RPTTHl6LMVnAJf0d8C1gPsv6Z9kCeAXwoYi4pMZsJwOvBE4n9eAIKdthwPyIOKqmaEg6BjiY1DVwNdu7gbMj4oQasx0GfA64hOXf072Az0fE6TVma/J2O5nmft5OprnZrgFuIv1TPqd9fkR8ZNRDdTBWC/g84K0RsaBt+tbATyNiu1qCpQx3djook78x3BkR29QQq5XhTmCHiHiubfoawK01Z7uD1Nvl4rbpGwHX1nGgq5Khydut0Z+3BmfbBNgTOBE4rn1+RMwa9VAdjNWDmONZ9h+96gFg9VHO0u4ZSa+LiOvapr8OqLtN/kXg5cC9bdMn5nl1EtBpb+NFBj5TYDQ0ebs1+fPW2GwR8ShwtqR5EXFjnVkGMlYL+KnAdZLOZtmgE1uSvtJ+t7ZUyXTgFEnrs+yfzJbAn/K8Oh0NXCZpPsu22yRS09OR3X5plHwZuF7SJSyfbS/gi7WlSo6mudttOs39vE2nudlaHpT0GWAylXrZ66yj0TImm1AAJG1H54NKt9WXahlJm1HJFhEP1ZmnRdJqrHjw97qIeKG+VEluLnkLKx7E/GN9qZImbzdo7ucNGp/tN8CvgDnA0vcyIn5YW6iKMVvAzcyGStLciJhad45uVrm+UCQdX3eGbiRdX3eGbiT9pO4M3UhqXDefLQ3fbk3+vDUl208k7VN3iG5WuT1wSftGxI/rzlEaSRMjYmHdOTqRtHNEzKk7RydN3m7WW76kfl3gWeA58sH0iHhJrcGyVa6AN4WkTVm+3e/hOvO0a3UIFhGP1Z2lJE3dbk3+vDU5W9ONyQIuaTxwBHAA6fQuyFd4Ad9tP193lLNNBb4NbMDyF6QsJl1kVNtXR0mTgK8Ab855BLwE+AVwbPt59aOcbQPg06Sr9l5GOqXwEdJ7ekKdV2M2fLtNpbmft6k0N9u2EXF7t14J68y2nIgYczfgLFIvZ7uSPhBb5PunAOfUnG0u6YKU9um7AjfWnO1q4CBST42taeNIp19eU3O2i4FjgM0q0zbL0y7xdivy89bkbDPzz8s73H5RZ7bqbazugXe8wqvXvNEgaX50ucJM0l0R8YrRzlRZ/0DZus4bDZLuiIhXrey80dDw7Vbq563WbKUYqxfyPCbpQOCHEfEiLD1P90Cg7nOG/1vSRaT+H6oXGR0G1N250BxJ3wJmsXy2w4G6ut9tuVfSp4BZkdtIc9vpdJZlrUuTt1uTP29NzlaEsboHPpnUh8EeLCvYG5K+/hwbEffUkyyR9FY6X2Q06iO2VOW+O46gQzbSsYPautXMF/Ecm7O9LE9+OGc7MWo8aNjk7QbN/bxBs7OVYEwW8CpJGwNExB/qzmJmNpzG/IU8EfGHavGWtFedeSSNk/R+SV+U9Fdt8z5bV668/nUkfUrSJyWtJelwSRdK+oqk9erM1okaMCIKLO25rvr4PZK+IWlG7lmvNpKObOWTNEXSlZL+KOlaSa+pOdt5kg5p4merG0kTJa1Zd46WMb8H3k7S76OGsTAr6/9PYB3gt8ChwC8j4mN5Xq2dx0s6l9QWuTbwKmAeqS/kd5DO/ji0xmw3tU8i9SV9B0BEvHbUQ7WCVN63/E94N+D7wNuB+yPiozVmuzUidsj3LwL+MyLOl7Q78OWIeGON2R4gncGzB/Bz0tljF0XEn+vK1IuknwNTSMfXPlF3njF5EFPShd1mARuPZpYOdmkVG0nfBL4l6TzSgAB1d4v6yoh4V95rXAjsGREh6Sqg7i41FwCPA18CniZtq18B+9aYqaX6vv09sFtEPCnp+0Dd5wtX/8ZfFhHnA0TEFbkXwDo9EhHvlPQSUjv4PwEzc/cDZ0WNA690ExF75r+P7evOAmO0gJP2gN4DLGmb3hpmrU5rtO5ExPPADEnHkS76aMRXyVy0fxr561l+XOtXtYh4h6QDgJnASRFxoaTnIqK9D+46rC1pJ1KT5LiIeBIgIp6TVHdvhD+QdBrwBeB8SUcD55P2en9fYy7I/btHxOPAGcAZ+ZjVgaQD1rUW8Fyouw3LeGttwSrGagG/BngqIn7ZPkNpZJc6zZa0d1TG/IuIL0h6kHShUZ1mS1ovIpZEpb9jSVOAJ2rMBUD+6n8J8EVJR1D5Z1izhcDX8v3HWv2f5GL0fI25iIj/LWk6qXliCrAmMAP4EXBIfcmAFXewWicbfDvfaqMBhmWUVOuwjFWrXBu4DY4kRYM+LJJ2BN4QEbX+oQ9E0jhgzYh4qu4stnLU4GEZq1zAzczaKI2utF1u5qxOXwO4rSlXiY7VJhQzs6Fo8rCMS3kP3MysAzV8WEZwAW8MSROBx+q+7LqTJmezwWnye9rkbE0z5q/ErJI0S9Ipkl5dd5YOzgBul3RS3UE6aGw2SfPyre7R31fQ5Gw0+D2l2dkaNSzjKrUHLul1wCTSxTTH1J2nXesCgYhoxDmmVQ3PtjGwa0RcVHeWdg3P1uT3tMnZGjMs4ypVwJuixwUCtWpyNmj28FtNzdbk97TJ2UowJgu4mj38VtcLBEjDSNV2gUDDs02lucNvTaW52Zr8njY5W2OHZVxOp2F6Sr/R7OG35gGTO0zfGpjnbF2zzaW5w281OVuT39MmZ2vssIzV21g9D3xyRJxYnRARDwEnSnpvl98ZLeOB+ztMfwBYfZSztGtytnUj4tr2iRFxjaR16whU0eRsTX5Pm5xt51hx6MX7gWsk3VlHoE7GagG/V80dfqvJFwg0OVuTh99qcrYmv6dNztbkYRmXGqtt4I0dfguafYFAw7M1dvithmdr8nvayGxq+LCMLWOygJuZDRc1eFjGVepCHgBJtY1400uTLhBo1/BsM+rO0E3Dsx1fd4Zu6s4m6R3KQ6dF27CMTbLKFXDgg3UHGMCcugMMoMnZ6h7JaCBNztbk97TubOcAD0g6Q9I+uWvgxnETiplZG0k3kNq/30k6qPpq0khGZ0WHgWLqMmYLeL6YZ2+WPzhycdR4EQ80+wKBJmcDkPQW0sVZ1ff0gqiMblSXpmZr8nva8GzLDTAuaTPgXaSxa7eIiC3rylY1Jgu4pMOAz5HG1Kte4bUX8PmIOL3GbGeRrtCbxbJzYLcADgdeGhEH1RSt6dlOJo1CfzrLZzsMmB8RR9UUrenZmvyeNjnbDRGxU5d5W0UzxmIdswX8DtKVcYvbpm8EXNvhBP1RI+nObusfaN5oKDFb7kvjzojYpoZYrQzFZes1bzQ0PNvuEXFFXevv11g9iCnyiNdtXqT+g0qPSTowXxQApAsEJB1E/RcINDnbM7k3yXavA54Z7TBtmpytye9pk7P1bOfO/6BrNVavxPwycL3SCOatK7wmkZpQvlhbquTdpAsEviWp/QKBd9cVKmtytunAKZLWZ9nX7S2BP+V5dZpOc7O1v6cidbrVhPe0U7YNgV9Qf7bLJf2QdBzj962JSmNivonUzHM5cFo98XKesdiEAkubS97Cigcx6/7PvlSTLxBoarZ8MKnaZetDdeapanI2aO57Cs3LJmkt4L3AIaTOtRYDawHjSMfWvhURN9QWMBuTBVySoscL62eZ0SZpr4i4tOYMLwEmRMTv2qa/NiJuqilWK8NmkDomkzQB2A24ve7LrjuR9K8R8Zm6c7STtDWwE2lk9dtrzjIJeCQinsnNEdOBvwRuA74TbSPC10XS6sAmwNN1n8XWbqwW8CuAnl9/IuK0WgJ2Ien3ETGpxvW/CziZ1Hf66sD0iLguz1vutKoasr2f1L+NSF+7pwO3kN7Pr0REbZ0fSfpGh8mHkc5KISI+MrqJlpH0o4jYP9/fj/T+XgG8EfjXOv8GJN1CGh3rKUknAlOAH5HOvyYi6u45tPHGahv43qSvP2flPY7FwNqkg7aXACfX9fVH0oXdZgEbj2aWDj5D6kZzoaRdgDMkfToizqf+g79HAjuQ3sd7gVfkPfGNSG2RdfZedwDpoNclLNtOB1P/1YQAW1XuHwPsERH3SNoEuIx623BXi4in8v09gdflnv/OlHRjjbmKMSYLeEQ8Qxrp41sN/PqzG/AeYEnb9NbQUnUaFxELASLit5L+FviJpC3pfFbPaHou/7E/Jel3rfbliPijpLqzbU86OL438ImIeFDS5yJiVs25YPn3bXyrF72IeFTSizVlarlP0h4R8QtgAenA772t9nDrbUwW8Kp8NdfCunNUXAM81ely3Hz+ep2ekDSl1f6d98R3J32t3aHGXAAhafX8fr6tNTEfbKr1dNiIeAI4WtLOwPeU+gZvyim6O0p6nLSDsKakifl9XYN0QK5O7wNOV+q46k/AXElzSWeifKy+WOUYk23gNjiSdiT9c5nfNn114F0R8b16ki094PVg+4EtSZsD20XEz+tJtrx8MO5DwBsi4j115+lG0oak7XZ1A7JsR7qStTVCz3WtQRRsYC7go6zJZ8g42+A42+A0OVspmvI1b1VyuaQP5z3KpSStIWkPSbNIZ8k4m7M5W33ZiuA98FHW5AsEnG1Ys1XPempatiZvt0ZkK4ULeI0aeIbMUs42OM42OE3O1mQu4GZmhXIbuJlZoVzAzcwK5QJugyLpBUlzJd0i6cf5vOLheN4rJN0h6SZJt0v65nA9d37+3SX9VeXxB5RGcBrq806W9HTeJrdJOj2365qNGBdwG6ynI2JqRLwaeAz452F87kMi4rXAa4FnSWMk9k1prMVudgeWFvCI+HYM3xB7v4uIqcBrSEODvWuYntesIxdwGw5Xk/vBznvQ0/L9TSQtyPenSzpP0s8kzZf0lV5PGhF/Bj4FTJK0Y97LvaU1X9In8mXYrfWeLGk2cJSkfSVdK+kGST+XtKmkycAHgI/mPeXdJB0v6RP5OaZKuibv/Z+v1FFW67lPlPRbSXdK2q1H7heA31a2yQpZ8vTjJZ2an/9uSUt7LZT0L/mbyFWSzqpknJK34RxJv5K0bZ5+YP42dKOkK3ttWxsbXMBtSCSNA94MdOtlsWoqcBBpD/UgpU6yBpSL4Y3Atn08/xoRMS0ivgpcBewaaWDas4FPRcQC4NvAv+VvD79q+/3TgWPy3v/NpIGxW8ZHxC7A0W3TV5DPb3490BqRfoUslcW3JQ08sgvwOUmrKw3P9g/AjsBbgWmV5WcCH46InYFPkDptAzgOeEtE7Ai8Y6B8NnaM+c6sbMSsrdTx0ObAPKCfgSgui4g/AUi6jdTV6X0D/wrQf1e251TubwGcI2kisAZwz4ArkDYANqx0MjYL+K/KIufln3OAyV2eZkreJlsDF1UGwBgoy0UR8SzwrKRHgE1JfXVfkHvVfEbSj3PG9UjNP/+lZcMxrpl//ho4TdK5law2xnkP3Abr6dzeuxWpwLbawJ9n2edqrbbfebZy/wX62IHIe/ivIf2TqD53p+d/snL//wHfjIjXAO/vsOzKamUfKHerDXwKsLOk1p7wQFlWZpusBizO3x5at+0AIuIDwGdJXbLOkbtkXSW4gNuQ5D66PwJ8PB88XADsnGe/cyjPnc/i+D/AfXlv9mHgZZI2lrQm8PYBfn0D0jiosHx/Gk8A63d4HX8C/lhp3z6UPkYm7yQiHiWNHvTpHlm6+TWwr6S18l732/PzPg7cI+lASB09KfUgiVI3wNdGxHHAIlIhtzHOBdyGLPdXcRNpFJqTgA9KuoF0afRgfE/STaQh09YF9svreQ74AukA4aXAQGM6Hk9qapgDPFqZ/mPggNZBzLbfORz4v3ndU/O6ButHwDp5Hd2ydJSHsbuQtE3/m9Qe/6c8+xDgCKURa24lb5uc++Z8kPc3pOMGNsb5UnqzBpK0XkQskbQOcCUwIyKurzuXNYsPYpo100xJ25Pay2e5eFsn3gM3MyuU28DNzArlAm5mVigXcDOzQrmAm5kVygXczKxQLuBmZoX6H9ROdS/4TGrYAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.bar(f_vc.index.astype(str), f_vc['run_duration_ranges'].values)\n",
+    "\n",
+    "# set the x-axis label and title\n",
+    "plt.xlabel('Run Duration Ranges')\n",
+    "plt.title('Histogram of Run Duration Ranges')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# display the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "08b0866c-abd3-4c7e-b3dd-21cd40eef129",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for start of each time bucket get total number of tests which pass or fail after that point\n",
+    "# get the reverse cumulative sum for that"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "0489e215-eef2-494c-b36d-70355b63fafb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_vc['prefix_sum'] = p_vc['run_duration_ranges'][::-1].cumsum()[::-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "243d9a66-e261-4301-aa60-37ea03ea5467",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f_vc['prefix_sum'] = f_vc['run_duration_ranges'][::-1].cumsum()[::-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "0a243ebd-b115-4487-9b03-81bc1c75b3ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>35</td>\n",
+       "      <td>97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>38</td>\n",
+       "      <td>62</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, 50.0]</th>\n",
+       "      <td>12</td>\n",
+       "      <td>24</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum\n",
+       "(0.0, 10.0]                     0          97\n",
+       "(10.0, 20.0]                    0          97\n",
+       "(20.0, 30.0]                   35          97\n",
+       "(30.0, 40.0]                   38          62\n",
+       "(40.0, 50.0]                   12          24"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p_vc.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "722cf001-5d8e-4ea1-9a5c-f1103e5a4240",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>29</td>\n",
+       "      <td>118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>23</td>\n",
+       "      <td>89</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, 50.0]</th>\n",
+       "      <td>29</td>\n",
+       "      <td>66</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum\n",
+       "(0.0, 10.0]                     0         118\n",
+       "(10.0, 20.0]                    0         118\n",
+       "(20.0, 30.0]                   29         118\n",
+       "(30.0, 40.0]                   23          89\n",
+       "(40.0, 50.0]                   29          66"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f_vc.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ad8518ab-867c-4354-b184-d51284cf4ab1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>97</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>97</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>35</td>\n",
+       "      <td>97</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>38</td>\n",
+       "      <td>62</td>\n",
+       "      <td>63.917526</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, 50.0]</th>\n",
+       "      <td>12</td>\n",
+       "      <td>24</td>\n",
+       "      <td>24.742268</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(50.0, 60.0]</th>\n",
+       "      <td>6</td>\n",
+       "      <td>12</td>\n",
+       "      <td>12.371134</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(60.0, 70.0]</th>\n",
+       "      <td>5</td>\n",
+       "      <td>6</td>\n",
+       "      <td>6.185567</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(70.0, inf]</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.030928</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 10.0]                     0          97             100.000000\n",
+       "(10.0, 20.0]                    0          97             100.000000\n",
+       "(20.0, 30.0]                   35          97             100.000000\n",
+       "(30.0, 40.0]                   38          62              63.917526\n",
+       "(40.0, 50.0]                   12          24              24.742268\n",
+       "(50.0, 60.0]                    6          12              12.371134\n",
+       "(60.0, 70.0]                    5           6               6.185567\n",
+       "(70.0, inf]                     1           1               1.030928"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(p_vc['prefix_sum'])\n",
+    "p_vc['prefix_sum_percentage'] = p_vc['prefix_sum'] / max_duration * 100\n",
+    "p_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8f33844e-f573-4d5a-9510-effe355a948a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>118</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>118</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>29</td>\n",
+       "      <td>118</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>23</td>\n",
+       "      <td>89</td>\n",
+       "      <td>75.423729</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, 50.0]</th>\n",
+       "      <td>29</td>\n",
+       "      <td>66</td>\n",
+       "      <td>55.932203</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(50.0, 60.0]</th>\n",
+       "      <td>20</td>\n",
+       "      <td>37</td>\n",
+       "      <td>31.355932</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(60.0, 70.0]</th>\n",
+       "      <td>13</td>\n",
+       "      <td>17</td>\n",
+       "      <td>14.406780</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(70.0, inf]</th>\n",
+       "      <td>4</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3.389831</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 10.0]                     0         118             100.000000\n",
+       "(10.0, 20.0]                    0         118             100.000000\n",
+       "(20.0, 30.0]                   29         118             100.000000\n",
+       "(30.0, 40.0]                   23          89              75.423729\n",
+       "(40.0, 50.0]                   29          66              55.932203\n",
+       "(50.0, 60.0]                   20          37              31.355932\n",
+       "(60.0, 70.0]                   13          17              14.406780\n",
+       "(70.0, inf]                     4           4               3.389831"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(f_vc['prefix_sum'])\n",
+    "f_vc['prefix_sum_percentage'] = f_vc['prefix_sum'] / max_duration * 100\n",
+    "f_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "39c2bca8-a0b6-4d36-94af-c4726e0d9f81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# join dataframes a and b on their index\n",
+    "joined = f_vc.join(p_vc, how='outer', lsuffix='_f', rsuffix='_p')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "6ee7fc85-1ed1-4d8b-897a-4dae310efb8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total = joined[['prefix_sum_f', 'prefix_sum_p']].sum(axis=1)\n",
+    "joined['f_pct'] = joined['prefix_sum_f'] / total * 100\n",
+    "joined['p_pct'] = joined['prefix_sum_p'] / total * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "bbd4e618-5b9a-43a0-8e7d-effded7bc154",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.0, 10.0]     54.883721\n",
+       "(10.0, 20.0]    54.883721\n",
+       "(20.0, 30.0]    54.883721\n",
+       "(30.0, 40.0]    58.940397\n",
+       "(40.0, 50.0]    73.333333\n",
+       "(50.0, 60.0]    75.510204\n",
+       "(60.0, 70.0]    73.913043\n",
+       "(70.0, inf]     80.000000\n",
+       "Name: f_pct, dtype: float64"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "joined['f_pct']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "eda8fb47-edb0-4f88-9c4d-7ed35cf70c87",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.0, 10.0]     45.116279\n",
+       "(10.0, 20.0]    45.116279\n",
+       "(20.0, 30.0]    45.116279\n",
+       "(30.0, 40.0]    41.059603\n",
+       "(40.0, 50.0]    26.666667\n",
+       "(50.0, 60.0]    24.489796\n",
+       "(60.0, 70.0]    26.086957\n",
+       "(70.0, inf]     20.000000\n",
+       "Name: p_pct, dtype: float64"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "joined['p_pct']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "d7c61c3d-76eb-4765-9223-b9cebb9b53d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAFHCAYAAAC7/dtHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABOw0lEQVR4nO3dd5gUVdbH8e+PDEqQoKJIUJSkAhIUZY2LYgLXrOBizoE1rxtE3aC475p2TWvOAROmFVRAXSMgroICiiRFySyZAc77x62BnqF7pmegp7pmzud5+pnpiqeqq+t01b11r8wM55xzrrhqcQfgnHMuP3mCcM45l5YnCOecc2l5gnDOOZeWJwjnnHNpeYJwzjmXlicIl5akX0ianPJ+uqRfbsHlT5R04JZaXpbrlKSHJS2S9GmGaf4kab6kn7JY3r2S/hD9f6Ck2SnjKnz7ykOSSWobdxyQnH0GIGm0pLPLOe+bkgZt6ZhyoUbcAUiaDmwHrAOWA28CF5vZsjjjKiRpCNDWzAbGHcuWIsmAXc3s20zTmNn7QLsttL5HgNlm9vuU5XfaEssuo95AH6CFmS0vPlJSS+AKoJWZzS1tYWZ2fgnj4ti+RMvVPpN0OnC2mfUu5/xD2ILnADM7fEsspyLkyxXE0Wa2NbAX0B34fSnTFxH9MsyXbUk8SbH/cMiRVsD0dMkh0hJYkE1ycC4X8u67Z2axvoDpwC9T3t8KvBb9vw/wIbAY+AI4MGW60cCfgf8AK4G2QCdgJLAQ+Bm4Lpq2GnAt8B2wAHgOaByNaw0YMAiYCcwHfheN6wusAQqAZcAX0fAzgK+BpcA04Lxi23Q1MAf4ETg7Wn7baFxt4G/Run4G7gXqlrB/zklZ1yRgr2h4h2gfLAYmAv1S5nkE+CfwejTfJ8Au0bj3oniWR9t0EnAgMBu4BvgJeLxwWLHP6bdRDIuAh4E60bjTgQ+KxW3RZ3JutP/WROt7tfjnHu2T26P99WP0f+1oXGFsVwBzo/16Rgn7awdgeHQMfAucEw0/C1hFuFJdBtxQbL5fEo6j9dH4R6Lhz0f7ZEm07zoV289/So0z3XENDCEcc49Fn8dEoHvKtHsBn0fjngeeLVxumu3bBXiXcBzPB54EGhVb75XAf6OYny38nKLxV7Hx2DyTlGMzzbpGA38FPgX+B7xC9L3JYt8cER0rS4EfgCuj4U2B1wjH7ULgfaBarvYZ4XuS+rkvjoY3jJY9D5hB+FFaLc38mc4Bo4GbCOefpcAIoGnKfKWdu85O+e78B7gt+kzTbUNPYGz0GfwM/D3dMZdhHz4PPBHF+CWwG+F7PBeYBRxa4vk5lyf/bF7FNmin6EC4Cdgx2mFHEE7wfaL3zVJ28kxCUqgB1Ccc+FcAdaL3e0fTXgZ8DLQgnIzuA56OxrUmfEn+BdQFOgOrgQ4pO/mJYjEfSfiiCjgAWMHGE3dfwpemE1Av+nBSE8RthBNY4yjGV4G/Ztg3JxC+XD2idbUl/AquSTj5XQfUAg6ODoB2KSeuBdGBVYNwEnmm+Mk75f2BwFrglmj/1C1+8EWf01fRZ9SYcFAXnhxPJ0OCKH4izfC53xh9PtsCzQhfrJuKxXZjtN1HRPt7mwz77D3g7ugY6EI4ARycKc5i8xbZ5mjYmdHnVJjEJqSM27BdGfZX6hd1VRR7dcJJ9+NoXC3CCeqyaPuOJZyQMiWItoTvQu1oX70H3F5svZ8SEmVjwo+L81OOzZ+B3YGtgKeKHwvF1jWacPwVTv8CKd+FUvbNHOAX0f/bsPH78VfCj6Ka0esXgHK8zzb53AnJ4ZUo/tbAFOCsDPMPYdNzwGjCD87dCN+X0cDN0bhszl2pCWItcAnhu7rJj0XgI+C06P+tgX1KOF7T7cPDomU/BnwP/C7ab+cA35d4ft6ck/uWeEUbtIyQaWcQvtx1Cb9mHy827VvAoJSdfGPKuFOAzzOs42vgkJT3zQm/CGqwMUG0SBn/KXBypoMjzfJfBi6L/n+IlBM+4Qtd+GtahF/uu6SM75XpQ4q297I0w39BSELVUoY9DQyJ/n8EeCBl3BHANynv0yWINRT9pVnk4Is+p/OLLfO7Er6AZUkQ3wFHpIw7jHArqDCOlUCNlPFzib4kxZa5E+GXYv2UYX9l49XAJnEWm7/INqcZ3yjarobFtyvD/kr9or6dMq4jsDL6f3/CSVgp4z8ovr9KiOkYUo77aL0DU94PBe5NOTZvThm3W/FjodiyRxebvmN0nFTPYt/MBM4DGhSb7kbCiXmTdeZqnxX/3AkJZw3QMWXYecDoDPMPIX2C+H3K+wuBf0f/Z3PuSk0QM0v5jN8DbiDlCiXT8ZpmH45MGXc04VxbPXpfP/rMGmVad77ctz/GzBqZWSszu9DMVhJ+KZ8gaXHhi1DI2Dxlvlkp/+9EONGk0wp4KWU5XxNOJNulTJNaa2UFIVOnJelwSR9LWhgt7wjCpTOEX26pcaX+34xwVTEuJZZ/R8PTybRNOwCzzGx9yrAZhF8uZd6eyDwzW1XKNKnbMiOKY0vYIVpepmUvMLO1Ke8zbc8OwEIzW1psWTummbZUkqpLulnSd5L+R/jywcbPuiyKfx51ovvNOwA/WPSNjcwiA0nbSXpG0g9RTE+kiSfTZ1/82Ezd55kUn74m0DSLfXMc4XsxQ9IYSb2i4bcSrn5HSJom6doS1r1F9lkaTaPtKH7MlfU4ybSfszl3pSot9rMIyfwbSZ9JOqoMMf6c8v9KYL6ZrUt5DyWcG/IlQaQzi5CFG6W8tjKzm1OmKX6A7FzCsg4vtqw6ZvZDFnGkrgNJtQmX2n8DtjOzRsAbhKsDCJfWLVJm2Snl//mED6VTShwNLRTQZ4p7lzTDfwR2KlYw35Lwq6q8rPRJimxLyygOCFdF9QpHSNq+jMv+kfClSrfssvgRaCypfrFllXe/nAr0J5RPNCRcbcLGz3pLmAPsKCl1mTtlmhj4C2F/7mFmDYCBZYhnDpt+hqUpPn0B4Tgucd+Y2Wdm1p9w2/BlQnkCZrbUzK4ws52BfsDlkg7JMv7U7SjLPit+/M2PtqP4MZfpOMnmu5Eqm3NX1ss3s6lmdgphX94CDJO0FZt+76qT+cdmueRzgngCOFrSYdGvlTpRXfMWGaZ/DWguabCk2pLqS9o7Gncv8GdJrQAkNZPUP8s4fgZap5yMaxHuuc4D1ko6HDg0ZfrngDMkdZBUD/hD4YjoF/+/gNskbRvFsqOkwzKs+wHgSkndoppabaNt+ITwi+VqSTWjuuNHA8+UYZsyJdOSXCSphaTGhPuYz0bDvwA6SeoiqQ7h0rYs63sa+H30uTQF/kj4/MvEzGYRyi/+Gh0vexJ+fZV5WZH6hPKoBYQv4l/KuZySfES4mr1YUo3ouOxZSkzLgCWSdiQUOmfrOeB0SR2jY/P6LOYZmDL9jcCw6Bdoxn0jqZakAZIamlkBoXB1fTTuqOg4FqFwe13huDIo6z77GWghqRZAFP9zhHNC/eg7dTmZj5Pi54DSlPXcVSJJAyU1i84fi6PB6wnlJnUkHSmpJqGgvXZ51pFJ3iaI6Mven1AQO4+Qla8iQ8zRbYU+hBPlT8BU4KBo9B2EguERkpYSCkT3TrecNJ6P/i6QND5az6WEA2wR4ZfU8JQ43gTuBEYRLqU/jkatjv5eUzg8ujR/mwzPG5jZ84SaWk8RCqFfJtQiWRNt5+GEX0N3A782s2+y3KYhwKPR5e+JWc5DFMcIQs2t74A/RXFOIZw83ibs9w+Kzfcg0DFa38tplvsnQi2N/xJqWowvXHY5nEL4Nfsj8BJwvZm9Xc5lPUa49fADoUbOxyVPXnbRZ3ksIZEtJlwRvMbG46W4Gwg1eJYQaqm9WIZ1vUkoTH6XcAy+m8VsjxPKWn4iFPxfGg0vbd+cBkyPjvHzgQHR8F0Jx8kywon+bjMble02RNtR1n32LqHyy0+S5kfDLiH8Ap9GOF6fIpTRpFPkHJBFfGU6d2WhLzBR0jLCuexkM1tpZksIZR8PED6H5YQaf1tMYe0BlyOSOhBq/9Qudh/dubQkfUIoWH445jhGEwpnH4gzjmzkyz6rbPL2CiLJJP0qus21DeGe4aueHFwmkg6QtH10u2QQsCeh8oLLwPdZxfAEkRvnEapifke4V3pBvOG4PNeOUI6zmPAcz/FmNifWiPKf77MK4LeYnHPOpeVXEM4559LyBOGccy6t/Go5MIOmTZta69at4w7DOecSZdy4cfPNrNwPzyUiQbRu3ZqxY8fGHYZzziWKpGyaU8nIbzE555xLyxOEc865tDxBOOecSysRZRDpFBQUMHv2bFatKq2FalfZ1KlThxYtWlCzZs24Q3GuUstpgpD0GzZ2ufkloavO5oRWR5sA4wg9Ja0p67Jnz55N/fr1ad26NUVb/XWVmZmxYMECZs+eTZs2beIOx7lKLWe3mKKmiC8l9CO7O6EXp5MJbRPdZmZtCa2hnlWe5a9atYomTZp4cqhiJNGkSRO/cnSuAuS6DKIGUDfqBaoeoaOPg4Fh0fhHCV0mlosnh6rJP3fnKkbOEkTUW9vfCH3TziG0Xz8OWJzSsulsytkdpNvo9ttvZ8WKFWWa5/3336dTp0506dKFlStXFhl355130qFDBwYMGJBhbhg7diyXXhq6BnjkkUe4+OKLyx64cy69FSvg7ruha1dYvDi2MHJ5i2kbQqcZbQh9yG5F6Pgi2/nPlTRW0th58+blKMr4rF275Vr/Lk+CePLJJ/ntb3/LhAkTqFu3bpFxd999NyNHjuTJJ5/MOH/37t258847yxXvltx25yqVBQvgxhuhVSu46CKoUwd+/rn0+XIkl7eYfgl8b2bzom4HXwT2AxpFt5wg9N2cth9YM7vfzLqbWfdmzbZoN6tbxPTp02nfvj0DBgygQ4cOHH/88RtO0uPGjeOAAw6gW7duHHbYYcyZE1ohPvDAAxk8eDDdu3fnjjvu4LPPPmPfffelc+fO9OzZk6VLl7Ju3TquuuoqevTowZ577sl9990HwOjRoznwwAM5/vjjN6zXzLjzzjv58ccfOeiggzjooIM2ifOdd96ha9eu7LHHHpx55pmsXr2aBx54gOeee44//OEPm1wlnH/++UybNo3DDz+c2267jU8//ZRevXrRtWtX9t13XyZPnrwhnqOO2rTv9NNPP51hw4ZteL/11ltvmP4Xv/gF/fr1o2PHjhm307kqafp0uPRSaNkSrr8eevWC99+HDz+Edmk7nKwYZpaTF6FLz4mEsgcRyhsuIXTfd3I0zb3AhaUtq1u3blbcpEmTNhlWkb7//nsD7IMPPjAzszPOOMNuvfVWW7NmjfXq1cvmzp1rZmbPPPOMnXHGGWZmdsABB9gFF1xgZmarV6+2Nm3a2KeffmpmZkuWLLGCggK777777KabbjIzs1WrVlm3bt1s2rRpNmrUKGvQoIHNmjXL1q1bZ/vss4+9//77ZmbWqlUrmzdv3iYxrly50lq0aGGTJ082M7PTTjvNbrvtNjMzGzRokD3//PNpty11eYVxmZmNHDnSjj32WDMzGzVqlB155JFmZvbwww/bRRddlHa5W2211Ybp69WrZ9OmTTMzy7id2Yr783duixg/3uyUU8yqVzerWdPsjDPMJk7cYosHxtpmnMdzVs3VzD6RNIzQv/Ba4HPgfkI/us9I+lM07MHNXtngwTBhwmYvpoguXeD220ucZKeddmK//fYDYODAgdx555307duXr776ij59+gCwbt06mjdvvmGek046CYDJkyfTvHlzevToAUCDBg0AGDFiBP/97383/ApfsmQJU6dOpVatWvTs2ZMWLVpE4XVh+vTp9O7dO2N8kydPpk2bNuy2224ADBo0iH/+858MHjw4692wZMkSBg0axNSpU5FEQUFB1vMW17Nnzw1VUzNtp1dddZWeGbzzDgwdCiNHQv36cPnlcNllsGN+Fcnm9DkIM7seuL7Y4GlAz1yut6IUr00jCTOjU6dOfPTRR2nn2WqrrUpcpplx1113cdhhhxUZPnr0aGrXrr3hffXq1SvkXv4f/vAHDjroIF566SWmT5/OgQceWOL0NWrUYP369QCsX7+eNWs2PuKSuu2ZttO5SmvtWhg2LCSGzz+H7beHm2+G88+Hhg3jji6txD5JXUQpv/RzZebMmXz00Uf06tWLp556it69e9OuXTvmzZu3YXhBQQFTpkyhU6dOReZt164dc+bM4bPPPqNHjx4sXbqUunXrcthhh3HPPfdw8MEHU7NmTaZMmcKOpfyqqF+/PkuXLqVp06abrGP69Ol8++23tG3blscff5wDDjigTNu4ZMmSDet/5JFHSp2+devWjBs3jhNPPJHhw4dnvOLItJ2lJVDnEmfFCnjoIfi//wtlDe3awQMPwMCBkPKjLx95W0yboV27dvzzn/+kQ4cOLFq0iAsuuIBatWoxbNgwrrnmGjp37kyXLl348MMPN5m3Vq1aPPvss1xyySV07tyZPn36sGrVKs4++2w6duzIXnvtxe677855551X6pXCueeeS9++fTcppK5Tpw4PP/wwJ5xwAnvssQfVqlXj/PPPL9M2Xn311fz2t7+la9euWV2xnHPOOYwZM4bOnTvz0UcfZTzhl2c7nUuU+fPhhhtCwfMll0Dz5vDyyzBpEpx1Vt4nB0hIn9Tdu3e34v1BfP3113To0CGmiEItpqOOOoqvvvoqthiqsrg/f+cy+v57+Pvf4cEHYeVK6NcPrr4aovLKiiRpnJl1L+/8leMWk3POxW38eLj1VnjuOaheHU47Da68EhL8Q8YTRDm1bt3arx6cq+rM4O23Q8Hz229DgwYhKVx2GeywQ9zRbTZPEM45V1Zr18Lzz4fEMGFCKF8YOhTOPTdvaySVhycI55zL1vLloUbS3/8eaiS1bx/en3pqIgqdy8oThHPOlWbePPjHP8Jr4cJQ4HznnXDkkVCt8lYG9QThnHOZTJsWnl946CFYtQr694erroqlRlIcPEFUArfffjvnnnsu9erVy3qe999/n/PPP5+aNWvy0UcfbdKiay78+OOPXHrppUUa83MJUlAA334b6vFPmgQTJ4a/M2fCdtuFFkjTvXbcEWok7FQzblyokfT88yH2whpJ7dvHHVmF8ucgYrJ27VpqbKEvTevWrRk7duwmT1KX5Pzzz6d3794MHDhwi8RQ0ZL++ee1NWtgypSNiaAwGUyZEgpnASRo0wY6dgxJ4OefYcaM8Jo7t+jyqlcPSSJTAmnZEirgB0qpzELbSEOHhraSGjSACy4IrawmtEaSPwcRk+nTp9O3b1+6devG+PHj6dSpE4899hj16tVj3LhxXH755SxbtoymTZvyyCOP0Lx5cw488EC6dOnCBx98wCmnnML+++/PZZddxvLly6lduzbvvPMO9erV49prr2X06NGsXr2aiy66iPPOO4/Ro0czZMgQmjZtyldffUW3bt144oknuOuuuzY09920aVNGjRpVJM533nmHK6+8krVr19KjRw/uueceHn/8cZ577jneeust3nzzzSL9PpS0XTfeeCOvvvoqK1euZN999+W+++5DEnfeeSf33nsvNWrUoGPHjjzzzDOMGTOGyy67DAhtVL333nssWLBgw8OFjzzyCMOHD2fFihV89913/OpXv2Lo0KEAPPjgg9xyyy00atSIzp07U7t2bf7xj39U3IdbVaxaFU76hVcCha+pU2HdujCNBLvsEhJB//7hb8eO4Zd0pivWlSvDVUVhwkh9vfcezJ4NUXtdG2y7beYE0qoVNGqUu/2wdm14dmHoUPjii5AMbr011EiKGtGssjanKdiKenlz3xXX3Hem7TIzW7BgwYbpBg4caMOHDzczs+bNm9uqVavMzGzRokVmZnbUUUdtWMbSpUutoKDAvv/+e+vUqZOZhSbC27RpY4sXL7aVK1day5YtbebMmfbDDz9Yq1atbMGCBbZmzRrr3bv3hqbEU8X9+SfK8uWhWeknnjC77jqz/v3Ndt3VrFo1s/C7OTQ33a6d2a9+Zfa735k9+aTZhAlmK1Zs+XgKCsymTzcbM8bsscfMbrrJ7Oyzzfr0MdttN7M6dTbGVfhq0MBsjz3MjjrK7KKLzIYONXv2WbOPPzabM8ds/fqyx7Fsmdkdd5i1ahXW0aGD2cMPm61evaW3ODbka3PfFWnwvwcz4acJW3SZXbbvwu19by9xmsra3He67bryyisZNWoUQ4cOZcWKFSxcuJBOnTpx9NFHs+eeezJgwACOOeYYjjnmGAD2228/Lr/8cgYMGMCxxx67Ie5UhxxyCA2jOuMdO3ZkxowZzJ8/nwMOOIDGjRsDcMIJJzBlypQS43WR5cvh66+LXg1MmhQKWgtvJdeoAbvuCp07wymnbLwi2G23iqumWaPGxiuDdMzCbap0VyAzZoSOdJYsKTpP7drhVlVJ5SA1a4Zp584NtZH++c9QI6l3b7jrrkpfI6k8KkWCiEtlbe473XatWrWKCy+8kLFjx7LTTjsxZMgQVq1aBcDrr7/Oe++9x6uvvsqf//xnvvzyS6699lqOPPJI3njjDfbbbz/eeust6tSpU2S5cTRfXiksXboxEaTeHpo+feM0NWuGVkO7dYNf/3pjImjbFmrVii30rEih0Hu77aBnhp4BlizJnEBee23TbjqrVQtJokWL0NT26tUbayTtu2/utymhKkWCKO2Xfq5U1ua+021XYTJo2rQpy5YtY9iwYRx//PGsX7+eWbNmcdBBB9G7d2+eeeYZli1bxoIFC9hjjz3YY489+Oyzz/jmm2/o0qVLqevu0aMHgwcPZtGiRdSvX58XXniBPfbYo9T5KqUlSzYtKJ40CWbN2jhN7dqhPKBXr9BCaMeO0KlTKDdIWs2hsmjYEPbcM7zSWbUqfTnIzJmhRtLll1e5GknlUeoRJKlxmsFLLfQzXaUVNvd95pln0rFjxyLNfV966aUsWbKEtWvXMnjw4E0SRGpz3ytXrqRu3bq8/fbbnH322UyfPp299toLM6NZs2a8/PLLJcZR2Nz3DjvsUKSQOrW578JC6mya+063XfXq1eOcc85h9913Z/vtt99wa2zdunUMHDiQJUuWYGZceumlNGrUiD/84Q+MGjWKatWq0alTJw4//PANfXOXZMcdd+S6666jZ8+eNG7cmPbt22+4DVUlrF8fWv585hn4IaW79jp1QqNv++8fEkDhFUGbNpU7EZRXnTrhtll0e9WVU2mFFMB0YB0wH1gQ/f8DoSvRbptTAJLtK18LqQsLXCuTfNiupUuXmplZQUGBHXXUUfbiiy9uMk3cn39OrF9v9pvfhALT/v3Nbr7ZbPhws+++M1u7Nu7oXAJRAYXUI4FhZvYWgKRDgeOAh4G7gb23cM5yVdyQIUN4++23WbVqFYceeuiGgu9K75Zb4LbbQucyd9wR7sU7F6NSH5ST9KWZ7VFs2H/NbE9JE8ysSy4DhMr5oJzbPJXu83/gATjnnNDo2+OPe20at0VUxINycyRdAzwTvT8J+FlSdWB95tmcc1l58UU47zzo2xceftiTg8sb2RyJpwItgJejV8toWHXgxFwFlo3Srn5c5VSpPvdRo8LzCD17wrBh+V8F1VUppV5BmNl84JIMo7/dsuFkr06dOixYsIAmTZpsUm/fVV5mxoIFCzZ5piKRxo8PdfHbtoXXX4dSnpFxrqJlU811N+BKoHXq9GZ2cO7CKl2LFi2YPXs28+bNizMMF4M6deqkfTI7UaZODbeUttkG3noLGqerTe5cvLIpg3geuBd4gFDFNSuS2gHPpgzaGfgj8Fg0vDWhCu2JZrYo2+UWqlmzJm3atCnrbM7F78cf4dBDQ5MSI0aEp3udy0PZJIi1ZnZPWRdsZpOBLgBRgfYPwEvAtcA7ZnazpGuj99eUdfnOJdKiRXDYYTB/fih/aNcu7oicyyibQupXJV0oqbmkxoWvMq7nEOA7M5sB9AcejYY/ChxTxmU5l0wrVsDRR4cmtl9+GbqXu/ahcxUimyuIQdHfq1KGGeGWUbZOBp6O/t/OzArbXPgJ2K4My3EumQoK4IQT4MMPQ98DhxwSd0TOlSqbWkybdaNfUi2gH/DbNMs2SWnrLEo6FzgXoGXLlpsTgnPxWr8ezjwT3ngD7r0Xjj8+7oicy0rGBCHpYDN7V9Kx6cab2YtZruNwYLyZFba/+7Ok5mY2R1JzYG66mczsfuB+CE9SZ7ku5/KLGVxxBTzxBNx0U3ggzrmEKOkK4gDgXeDoNOMMyDZBnMLG20sAwwm3rW6O/r6S5XKcS56bb4bbbw/9Gv/ud3FH41yZlNoW02YtXNoKmAnsbGZLomFNgOcIT2TPIFRzXVjSctK1xeRc3vvXv0K/xgMGwGOPeRMarsLlrC0mSZeXNKOZ/b20hZvZcqBJsWELCLWanKu8XnwRzj8fDj/c21dyiVXSLab6FRaFc5VJYftKe+8Nzz+/sS9k5xImY4IwsxsqMhDnKoXC9pV23TX0jeztK7kEK+kW09VmNlTSXYRC6SLM7NKcRuZc0kyZEtpXatzY21dylUJJt5i+jv566bBzpfnhh6LtK+24Y9wRObfZSrrF9Gr099FM0zjngIULQ/tKCxbA6NGw225xR+TcFpFNc9/NCI3pdQQ2NMIfd3PfzuWFwvaVpk6FN9+Ebt3ijsi5LSabundPEm43tQFuIDTR/VkOY3IuGQoKQrMZH30ETz0FB/tvJle5ZJMgmpjZg0CBmY0xszMB/ya4qm39ejjjjHDVcO+9cNxxcUfk3BaXTWuuBdHfOZKOBH4EvHqGq7rM4PLL4ckn4U9/Ck9LO1cJZZMg/iSpIXAFcBfQAPhNTqNyLp/99a9wxx1w2WVw3XVxR+NczpT0HMQtZnYNUDdqR2kJcFCFReZcPrr//tDo3oAB8Pe/gxR3RM7lTEllEEdIEmn6cXCuSnrhBbjgAm9fyVUZJd1i+jewCNha0v9ShovQ10+DnEbmXD5591049VRvX8lVKRl/ApnZVWbWCHjdzBqkvOp7cnBVyrhx3r6Sq5JKvUY2s/4VEYhzeWnKlHBLqUkTb1/JVTl+E9W5TArbVwJvX8lVSdlUc3Wu6ilsX2nhwtC/g7ev5KqgEq8gJFWX9GRFBeNcXli+HI46KrSv9Mor3r6Sq7JKTBBmtg5oJalWBcXjXLwKCuCEE+CTT+Dpp+Egf/THVV3Z3GKaBvxH0nBgeeHAbPqkdi5RUttXuv9+OPbYuCNyLlbZJIjvolc1vJ9qV1mltq/05z/DOefEHZFzsSs1QRT2TS1p6+j9slwH5VyF+8tfQvtKgwfDb73xAOcgi2quknaX9DkwEZgoaZykTrkPzbkKct998Pvfw8CB8H//5+0rORfJ5jmI+4HLzayVmbUitOr6r9yG5VwFGTYstK90xBHw0EPevpJzKbL5NmxlZqMK35jZaCCrtgYkNZI0TNI3kr6W1EtSY0kjJU2N/m5Tztid2zzvvhtaZe3Vy9tXci6NbBLENEl/kNQ6ev2eULMpG3cA/zaz9kBnQtel1wLvmNmuwDvRe+cq1tixoX2l3XYL7SvVqxd3RM7lnWwSxJlAM+BF4AWgaTSsRFEnQ/sDDwKY2RozWwz0Bx6NJnsUOKasQTu3WSZPLtq+0jZ+EetcOtnUYloEXFqOZbcB5gEPS+oMjAMuA7YzsznRND8B25Vj2c6VT2H7ShKMHAk77BB3RM7lrVyWyNUA9gLuMbOuhIfsitxOMjMDLN3Mks6VNFbS2Hnz5uUwTFdlLFwYksOiRfDvf4fmu51zGeUyQcwGZpvZJ9H7YYSE8bOk5gDR37npZjaz+82su5l1b9asWQ7DdFXC8uVw5JHw7behfaW99oo7IufyXs4ShJn9BMyS1C4adAgwCRgODIqGDQJeyVUMzgEwaxYcfzx8+qm3r+RcGZRaBiHpzjSDlwBjzay0k/slwJNRY3/TgDMISek5SWcBM4ATyxayc6Uwgy++CFcKr7wCn38ehnv7Ss6VSTZtMdUB2gPPR++PA74HOks6yMwGZ5rRzCYA3dOMOqRsYTpXioICGDMmJIThw2HmzFAQ3asX3HwzHHMMtGtX6mKccxtlkyD2BPaLmv5G0j3A+0Bv4MscxuZcyZYsCS2vDh8Ob7wR3tepEwqi//jH0KfDdl5JzrnyyiZBbANsTbitBOEp6sZmtk7S6pxF5lw6M2eGhDB8OIweHa4cmjWD446Dfv2gTx9/6M25LSSbBDEUmCBpNCDCw29/kbQV8HYOY3MulCdMmLDx1lFheUK7dvCb34SksM8+UL16rGE6Vxll86Dcg5LeAHpGg64zsx+j/6/KWWSu6lqzpmh5wqxZoTxh331h6NCQFLw8wbmcy+YKAkLNo3nR9G0ltTWz93IXlqtyFi8uWp7wv/9B3bqhPOGGG8IzDNtuG3eUzlUp2VRzvQU4idAfxPposAGeINzmmTGjaHnC2rUhCZxwQmhI75BDvDzBuRhlcwVxDNDOzLxA2m0es1CGUHjraMKEMLx9e7jiipAUevb08gTn8kQ2CWIaUBPwBOHKbs2acHVQmBRmzw6d8uy7L9x6ayhP2G23uKN0zqWRTYJYQajF9A4pScLMytPCq6sKFi8O5QivvBLKFZYuDbeKDj0UbroplCd4+1rO5b1sEsTw6OVcZjNmbLxKGDMmlCdstx2cdNLG8oS6deOO0jlXBtlUc320tGny1vr1pU/jyqf48wlffBGGd+wIV165sTzB+3h2LrEyJghJz5nZiZK+pGifDSJ05bBnzqPbXEcfHW51uNypVg1694a//S2UJ3gfC85VGiVdQVwW/T2qIgLJiQEDYO+9446i8mrdGo44Apo2jTsS51wOZEwQKd2CzgdWmtl6SbsRWnZ9syKC22ynnhp3BM45l1jZ3CB+D6gjaUdgBHAa8Egug3LOORe/bBKEzGwFcCxwt5mdAHTKbVjOOefillWCkNQLGAC8Hg3zR12dc66SyyZBDAZ+C7xkZhMl7QyMymlUzjnnYpfNcxBjgDEAkqoB8/0pauecq/xKvYKQ9JSkBlEHQV8BkyR5PxDOOVfJZXOLqaOZ/Y/QquubQBtCTSbnnHOVWDYJoqakmoQEMdzMCij6ZLVzzrlKKJsEcR8wHdgKeE9SK+B/uQzKOedc/LIppL4TuDNl0AxJB+UuJOecc/kgqz6pJR1JeDiuTsrgG7OYbzqwFFgHrDWz7pIaA88CrQlXJiea2aIyRe2ccy7nsqnFdC+hT+pLCC25ngC0KsM6DjKzLmbWPXp/LfCOme0KvBO9d845l2eyKYPY18x+DSwysxuAXsDm9BHZHyjsY+JRQuG3c865PJNNglgZ/V0haQegAGie5fINGCFpnKRzo2HbpbQU+xOwXdbROuecqzDZlEG8JqkRcCswnnDS/1eWy+9tZj9I2hYYKemb1JFmZpLSVpmNEsq5AC1btsxydc4557YUmWX/SIOk2kAdM1tS5hVJQ4BlwDnAgWY2R1JzYLSZtStp3u7du9vYsWPLukrnnKvSJI1LKf8ts2wKqetIulzSi8BTwJmS6mQx31aS6hf+DxxKaKpjODAommwQ8Ep5g3fOOZc72dxieoxQVfWu6P2pwOOE2kwl2Q54SVLhep4ys39L+gx4TtJZwAzgxPIE7pxzLreySRC7m1nHlPejJE0qbSYzmwZ0TjN8AXBI9iE655yLQza1mMZL2qfwjaS9AS8QcM65Si6bK4huwIeSZkbvWwKTJX1JqIi0Z86ic845F5tsEkTfnEfhnHMu72TTWN+MigjEOedcfsmmDMI551wVlDFBRA/FOeecq6JKuoL4CEDS4xUUi3POuTxSUhlELUmnAvtKOrb4SDN7MXdhOeeci1tJCeJ8YADQCDi62DgDPEE451wlljFBmNkHwAeSxprZgxUYk3POuTyQzXMQj0u6FNg/ej8GuNfMCnIX1pZxwWsX8N7M9+IOo9Jq1bAV/dr1o1+7fuxQf4e4w3HObWHZJIi7gZrRX4DTgHuAs3MV1JbSsmFLOjbrWPqErszMjC9+/oILXr+AC16/gO47dKd/u/70b9ef3bfdnaiRRudcgpXaH4SkL8ysc2nDcsn7g8hPZsbX879m+OThvDL5FT6Z/QmG0aZRG/q160f/dv3p3bI3NavXjDtU56qkze0PIpsEMR44wcy+i97vDAwzs73Ku9Ky8gSRDD8t+4nXprzGK5Nf4e1pb7Nq7Sq2qbMNR+x6BP3b9eewtofRoHaDuMN0rsqoiARxCPAwMA0Q0Ao4w8xGlXelZeUJInmWr1nOiO9GMHzKcF6b8hrzV8ynVvVaHNT6IPq368/R7Y6mRYMWcYfpXKWW8wQRraQ2UNgt6GQzW13eFZaHJ4hkW7d+HR/O+nDDraipC6cC0K15N/q360+/dv3Yc7s9vdzCuS2sQhJE3DxBVB5mxjfzv9mQLD6e/TGG0bpRa/rtFmpE7d9qfy+3cG4L8AThEu3nZT9vKLcYOW0kq9auolGdRhyx6xH0260fh+96uJdbOFdOniBcpbF8zXLenvY2r0x+hVenvMr8FfOpWa0mB7Y+cMOtqJ0a7hR3mM4lRkUUUovQ5MbOZnajpJbA9mb2aXlXWlaeIKqedevX8dHsjzbcipqyYAoAXbfvGp63aN+fztt19nIL50pQEQniHmA9cLCZdZC0DTDCzHqUd6Vl5QnCpZZbfDTrIwyjZcOW9NutH/3b9+eAVgd4uYVzxVTIcxBmtpekz82sazTMH5Rzsfl52c+8PvX1UG7x3UhWrl1Jw9oNOXzXw+nfrj+Htz2chnUaxh2mc7Hb3ASRTVMbBZKqE1pwRVIzwhWFc7HYbuvtOLPrmZzZ9UxWFKxg5HcjGT55OK9OeZVnvnqGGtVqFCm3aNmwZdwhO5dI2VxBDABOAvYCHgWOB35vZs/nPrzAryBcNtatX8fHsz/ecCtq8oLJAHTZvgvHdTiOK3pdQd2adWOO0rmKU1EPyrUHDiE8Sf2OmX1dhgCrA2OBH8zsKEltgGeAJsA44DQzW1PSMjxBuPKYPH/yhmTxn1n/oV+7frxw4gvUqJbNhbNzybe5CaKkLkcLV9AYmAs8DTwF/CypLKWBlwGpCeUW4DYzawssAs4qw7Kcy1q7pu24ar+r+ODMD7jr8LsYPnk45756Lkmo2u1cPig1QQDjgXnAFGBq9P90SeMldStpRkktgCOBB6L3Ag4GhkWTPAocU67InSuDi3tezB/3/yMPT3iYa9++Nu5wnEuEbK61RxJab30LQNKhwHGEBvzuBvYuYd7bgauB+tH7JsBiM1sbvZ8N7Fj2sJ0ruyEHDmHeinkM/XAozbZqxpX7Xhl3SM7ltWyuIPYpTA4AZjYC6GVmHwO1M80k6ShgrpmNK09gks6VNFbS2Hnz5pVnEc4VIYm7Dr+LEzudyFUjr+KRCY/EHZJzeS2bK4g5kq4hFCxDqNH0c1T4XFJ11/2AfpKOAOoADYA7gEaSakRXES2AH9LNbGb3A/dDKKTOZmOcK031atV57JjHWLhyIWcPP5smdZtwdLuj4w7LubyUzRXEqYQT+cvRq2U0rDpwYqaZzOy3ZtbCzFoDJwPvmtkAYBShqizAIOCVcsbuXLnUrlGbl056ib2a78WJw07kvRneb7lz6ZSaIMxsvpldYmZdo9fFZjbPzNaY2bflWOc1wOWSviWUSTxYjmU4t1m2rrU1bwx4g1YNW3H000fzxU9fxB2Sc3knmwflmhEKmjsRbhUBYGYH5za0jfw5CJcrM5fMZL+H9qNgXQEfnvUhO2+zc9whObfF5Pw5COBJ4BugDXADMB34rLwrdC6ftGzYkhEDR1CwvoA+j/fhp2U/xR2Sc3kjmwTRxMweBArMbIyZnUl4lsG5SqFDsw68ceob/LzsZ/o+0ZfFqxbHHZJzeSGbBFEQ/Z0j6UhJXYHGOYzJuQq3d4u9efGkF5k0bxL9nu7HyoKVcYfkXOyySRB/ktQQuAK4kvBU9OBcBuVcHA7d5VAe+9VjfDDzA05+4WTWrl9b+kzOVWLZJIhFZrbEzL4ys4PMrBuwMNeBOReHk3c/2dttci6SzYNydxGa+i5tmHOVwkU9L2LeinncMOYGmtZrytA+Q+MOyblYZEwQknoB+wLNJF2eMqoB4SE55yqt6w+4nnnL53Hrh7fSrF4zrtrvqrhDcq7ClXQFUQvYOpqmfsrw/7HxSWjnKiVJ3Hn4nSxYuYCr376apvWackbXM+IOy7kKlTFBmNkYYIykR8xsRgXG5FxeqF6tOo/9KrTbdM6r59CkXhP6tesXd1jOVZhsCqlrS7pf0ghJ7xa+ch6Zc3mgVvVavHjSi3TboRsnPu/tNrmqJZsE8TzwOfB74KqUl3NVwta1tub1U1+nzTZtOPrpo5nw04S4Q3KuQmSTINaa2T1m9qmZjSt85Twy5/JI03pNeWvgWzSo3YC+T/Tlu4XfxR2SczmXTYJ4VdKFkppLalz4ynlkzuWZwnab1q5fy6FPHMqcpXPiDsm5nMomQQwi3FL6EBgXvbxpVVcldWjWgTcGRO02PentNrnKLZv+INqkeXmbyK7K6rljT1466SW+nve1t9vkKrVSE4SkepJ+L+n+6P2uUX/TzlVZfXbpw+O/epwPZn7AScNO8nabXKWUzS2mh4E1hKeqIfQh/aecReRcQpy0+0n844h/8OqUVznn1XO83SZX6WTTFtMuZnaSpFMAzGyFJOU4LucS4cIeFzJv+TyGjBlC07pNufXQW+MOybktJpsEsUZSXcAAJO0CrM5pVM4lyB8P+CPzVszjbx/9jWZbNePq/a6OOyTntohsEsT1wL+BnSQ9CewHnJ7LoJxLksJ2m+avmM81b19D03pNObPrmXGH5dxmKzVBmNlISeOBfQABl5nZ/JxH5lyCVFM1HvvVYyxatSi021S3Cf3b9487LOc2Sza1mH5FeJr6dTN7DVgr6ZicR+ZcwtSqXosXTnyB7jt056RhJzFm+pi4Q3Jus2RTi+l6M1tS+MbMFhNuOznnikltt6nfM/283SaXaNkkiHTTZFN24VyV1LReU0YMHEHD2g293SaXaNkkiLGS/i5pl+j1d0JzGyWSVEfSp5K+kDRR0g3R8DaSPpH0raRnJdXa3I1wLt/s1HAnRpwW2m3q83gfb7fJJVI2CeISwoNyzwLPAKuAi7KYbzVwsJl1BroAfSXtA9wC3GZmbYFFwFnliNu5vNe+aXveGPAGc5fP9XabXCKVmCAkVQdeM7Nrzay7mfUws+vMbHlpC7ZgWfS2ZvQy4GBgWDT8UeCYckfvXJ5Lbbfp6KeP9nabXKKUmCDMbB2wXlLD8ixcUnVJE4C5wEjgO2CxmRU2XDMb2LE8y3YuKfrs0ocnjn2C/8z8j7fb5BIlm8LmZcCXkkYCG64czOzS0maMEkwXSY2Al4D22QYm6VzgXICWLVtmO5tzeenETieyYMUCLnzjQs4efjYP9X+IasrmDq9z8ckmQbwYvcrNzBZLGgX0AhpJqhFdRbQgNP6Xbp77gfsBunfv7q2gucS7oMcFzFsxj+tHX0/Tek25tc+teLNmLp9l8yT1o1FbTC3NbHK2C5bUDCiIkkNdoA+hgHoUcDyhwHsQ8Eq5Incugf6w/x+Yt3we//fR/7HtVtt6u00ur2XzJPXRwARCe0xI6iJpeBbLbg6MkvRf4DNgZPQk9jXA5ZK+BZoAD5YzducSRxJ3HH4HJ+9+Mte8fQ0Pff5Q3CE5l1E2t5iGAD2B0QBmNkFSqT3Kmdl/ga5phk+LludclVRN1Xj0mEdZtDK029S4bmOOaX9M3GE5t4lsSskKUpvaiKzPRTDOVRWF7Tb12KEHJw87mdHTR8cdknObyCZBTJR0KlA96m70LuDDHMflXKW3Va2teP3U19l5m53p93Q/Pp/zedwhOVdEtk9SdyI8Gf0UsAQYnMOYnKsymtRrwlsD36JRnUb0fbIv3y78Nu6QnNsgY4KI2lIaDAwFZgK9oiepf29mqyoqQOcqu8J2m9atX8ehjx/q7Ta5vFHSFcSjQHfgS+Bw4G8VEpFzVVD7pu15c8CbzF0+l8OeOIxFKxfFHZJzJdZi6mhmewBIehD4tGJCcq5q6rFjD14++WWOePIIdvj7DrRv2p6OzTrSqVknOjbrSMdmHdl5m52pUc1b23cVo6QjraDwHzNb6098Opd7v9z5l7w76F1e/uZlJs6byAczP+CpL5/aML529dq0a9ouJIymIWl02rYTu2yzCzWr14wx8vy33tYzd/lctqmzDbVr1I47nESQWfpWLCStY2PbSwLqAiui/83MGlRIhISmNsaOHVtRq3MuryxdvZRv5n/DxHkTmTRv0obX94u/3zBNzWo12a3JbptccezaZFdqVa8aXa4UrCtg9v9mM2PJDGYsnlH075IZzFoyi9XrVtO0XlMu6XkJF/W4iCb1msQddk5JGmdm3cs9f6YEkU88QTi3qeVrlvPN/G82Jo354e93C7/DCN/r6qrOrk12LZI0OjbrSLsm7RL3K3pFwYq0J/7C/39c+iPrregjWttvvT2tGraiVaNWtGrYihYNWjDiuxG8PvV16tWsx9ldz+Y3vX5D60at49moHPME4ZwrYmXBSiYvmLwhcRReeXy78NsNJ9Bqqkbbxm033KrqtG2nDYmjbs26FR6zmbFo1aISE8D8FfOLzFOjWg1aNGhRJAGk/r9Tw52oU6NO2vV9Nfcr/vbh33jyyycxM07a/SSu2vcqumzfpQK2tuJ4gnDOZWX12tVMWTBlk1tVUxdO3dBHhRA7b7NzSBhNN15xtG/anq1qbVXuda+39fy07KcSE8CyNcuKzFO3Rt20J/7CvzvU34Hq1apv1j6ZtWQWd3xyB/eNu49la5Zx6C6HcvW+V3Nwm4MrRUu7niCcc5tlzbo1TF0wtcitqolzJzJlwRQK1oe6KkK0btS6yG2qTs060aFZB7autTVr1q0J9/8zJIBZ/5vFmnVriqy3cd3GtGzYMmMCaFqvaYWdpBevWsy9Y+/l9o9v5+flP7NX8724et+rOa7jcYmuNeYJwjmXEwXrCvhu0Xeb3Kr6Zv43RU72Teo2YeHKhRvKPSAklOb1m2e8/dOyYUvq164fx2aVaNXaVTzx3ye49cNbmbJgCm0ateGKXldwRtczqFezXtzhlZknCOdchVq7fi3fL/p+Q8KYuWRm2sLgpBWCp1pv6xk+eTi3/OcWPp79cWJrPnmCcM65HDEz/jPrP9zyn1t4bcpr1KtZj7O6nsXlvS5PRM2nzU0Q3imuc85lIIneLXvz6imv8tUFX3FipxO5d+y9tL2zLae+cGqlb4HXE4RzzmWh07adeLj/w0y7bBq/2ec3vDblNfa6fy8OffxQ3p72Nkm4G1NWniCcc64MWjRowa2H3srM38zk5kNu5su5X9Ln8T50u78bz3z1zIYqw5WBJwjnnCuHRnUacU3va5h+2XQeOPoBVhSs4JQXTmHXu3blH5/+gxUFK+IOcbN5gnDOuc1Qu0ZtztrrLCZdNImXT3qZ5ls355I3L6HlbS25YfQNmzwBniSeIJxzbguopmr0b9+fD8/6kPfPeJ99d9qXIWOG0PK2llzyxiV8v+j70heSZzxBOOfcFta7ZW+GnzKciRdO5OTdT+a+cffR9q62nPLCKYyfMz7u8LLmCcI553KkY7OOPNT/Ib6/7Huu6HUFr095nW73d6PP430Y+d3IvK/55AnCOedybMcGOzK0z1Bm/WYWt/zyFibOncihTxzKXvfvxdNfPp23NZ9yliAk7SRplKRJkiZKuiwa3ljSSElTo7/b5CoG55zLJw3rNOTq/a7m+8u+58F+D7Jq7SpOffHUDTWflq9ZXvpCKlAuryDWAleYWUdgH+AiSR2Ba4F3zGxX4J3ovXPOVRm1a9TmzK5nMvHCibxy8ivsWH9HLnnzElrd3ooho4cwb/m8uEMEcpggzGyOmY2P/l8KfA3sCPQHHo0mexQ4JlcxOOdcPqumavRr148PzvyAD874gN4te3PDmBtodXsrLn7jYqYtmhZvfBWxEkmtga7AJ8B2ZjYnGvUTsF1FxOCcc/lsv5b78fLJLzPpwkmcusep3D/ufna9a1c+++Gz2GLKeYKQtDXwAjDYzP6XOs5CEX7aYnxJ50oaK2nsvHn5cbnlnHO51qFZBx7o9wDTB0/nzwf/mW47dIstlpw29y2pJvAa8JaZ/T0aNhk40MzmSGoOjDazdiUtx5v7ds65ssvb5r4V+gp8EPi6MDlEhgODov8HAa/kKgbnnHPll8vOVvcDTgO+lDQhGnYdcDPwnKSzgBnAiTmMwTnnXDnlLEGY2QdAph7HD8nVep1zzm0Z/iS1c865tDxBOOecS8sThHPOubQ8QTjnnEvLE4Rzzrm0cvqg3JYiaR6hSmx5NAWS1OdfkuL1WHMnSfEmKVZIVrybG2srM2tW3pkTkSA2h6Sxm/MkYUVLUrwea+4kKd4kxQrJijfuWP0Wk3POubQ8QTjnnEurKiSI++MOoIySFK/HmjtJijdJsUKy4o011kpfBuGcc658qsIVhHPOuXLwBOGccy6tXDb3XeEkNc5isvVmtjjXsZRG0uVZTLbczO7LeTBZkHRsFpOtMrM3ch5MKSTtlcVkBWb2Zc6DyULC9m3SjtvExJuPx22lKoOQtAr4kczNjANUN7OWFRRSRpLmAPdQcqwDzGy3CgqpRJIWEDp3Kine/c1slwoKKSNJS4HPKDnWNmbWumIiKlnC9m3SjtvExJuPx22luoIg9F7XtaQJJH1eUcGU4nEzu7GkCSRtVVHBZOFNMzuzpAkkPVFRwZTiMzM7uKQJJL1bUcFkIUn7NmnHbZLizbvjtrJdQdQxs1WbO41zzlU0SfuZ2X8k1Taz1XHHA5UsQcCGvrB7AjtGg34APrU83FBJhwHHUDTWV8zs37EFVQJJ7YH+FI13uJl9HV9U6UlqCPSlaKxv5UP5UzoJ27dJO24TEa+kcWbWTdJ4M8umPCLnKlWCkHQocDcwlXAQALQA2gIXmtmIuGIrTtLtwG7AY8DsaHAL4NfAVDO7LKbQ0pJ0DXAK8AxF4z0ZeMbMbo4rtuIk/Rq4HhhB0eOgD3CDmT0WV2zpJGzf3k6yjtvbSUi8kj4G/kv4ofBs8fFmdmmFx1TJEsTXwOFmNr3Y8DbAG2bWIZbA0pA0JV3BWHQFNMXMdo0hrIwkTQE6mVlBseG1gIn5FK+kycDexa8WJG0DfJIPBZKpErZvE3fcJiVeSU2BXwK3AH8sPt7MHq3omCpbIXUNNv5KSPUDULOCYynNKkk9zOyzYsN7APlYRrIe2IFNm11vHo3LJwLS/fJZT8k1ROKSpH2btOM2MfGa2XzgGUlfm9kXcccDlS9BPAR8JukZYFY0bCfCpfqDsUWV3unAPZLqszGp7QQsicblm8HAO5KmsnHftiTcvrs4rqAy+DMwXtIIisbaB7gptqgyG0xy9u3pJOu4PZ1kxQvwo6TrgNaknKNLq+mWC5XqFhOApA6kL+ybFF9UmUnanpRYzeynOOMpiaRqbFoB4DMzWxdfVOlFt5MOY9NC6kXxRZVZkvYtJOu4hWTFK+lD4H1gHLDh8zezFyo8lsqWIJxzLskkTTCzLnHHAVWoLSZJQ+KOIVuSxscdQ1lIei3uGLIlKUlNPSdt3ybtuM3XeF+TdETcQUAVuoKQdLSZvRp3HJWRpOZmNifuOLIhqZuZjYs7jmwlad+6LSNqcmMrYDVQQFTpwswaVHgsVSVB5CtJ21H03ujPccaTjcJGEc1sYdyxVDZJ2bdJO26TFm++qFQJQlIN4CzgV4RqgxA9NQk8WLyeeZwkdQHuBRpS9GGuxYSH+vLq8ldSS2AocAghRgENgHeBa4s/exKn6Cnq3xKent2WUOV1LuE4uDnfnqZO2L7tQrKO2y4kJF5J7c3sm0ytusYRa2VLEE8TPvhHKfrU5CCgsZmdFFNom5A0ATjPzD4pNnwf4D4z6xxLYBlI+gi4HRhWWLNGUnXgBGCwme0TY3hFSHqLcHJ9tLC2SlSLZRBwiJkdGmd8xSVs304gWcftBBISr6T7zexcSaPSjLbSGvLLSUyVLEGkfWqytHFxkDQ101Ockr41s7YVHVNJSok347g4SJpsZu3KOi4uCdu3lem4zbt4801le1BuoaQTgBfMbD1sqF9+ApBv9d/flPQ6oY2Y1If6fg3kVSNikXGS7iZcnaXGOwjIlybUC82QdDXhCuJn2HAP+nQ2xp5PkrRvk3bcJi3evFLZriBaE9oxOZiNCaERMIpwL/f7eCJLT9LhpH+oL/aew4qL2gU6izTxEsp38qJ5YtjwkNy1hFi3jQb/TIj1lnwrAE7SvoVkHbeQvHjzSaVKEKkkNQEwswVxx+Kcc0lUaR+UM7MFqclBUp844ylOUnVJ50m6SdK+xcb9Pq64MpFUT9LVkq6SVEfSIEnDJQ2VtHXc8ZVG+dWDXBFRK56p7wdKulPSuVGro3lD0sWF8UraRdJ7khZJ+kTSHnHHV5ykFyUNSMIxmomk5pJqx7LuynoFUZykmZYHfVEXkvQAUA/4FDgNGGNml0fj8qbDkEKSniPcw60LtAO+JrRZ3w/Y3sxOizG8IiT9t/ggQp8AkwHMbM8KD6oEqZ939OPgF8BTwFHAbDP7TZzxpZI00cw6Rf+/DjxgZi9JOhD4s5ntF2d8xUn6AfiIcNv5beBp4HUzWxNrYGUg6W1gF0LZ6pUVue5KVUgtaXimUUCTiowlCz0LT1SS/gHcLelFQscxefWrMbKbmZ0Y/aKdA/zSzEzSB0BeNE2cYjrwP+BPwErC/nwfODrGmEqS+nkfC/zCzJZLegrIm3r6kdRzxrZm9hKAmY1WaDE138w1s+MlNSCUQ5wD3B81YfK05VEnYpmY2S+j713Hil53pUoQhF9eA4FlxYYXdkOaT2oV/mNma4FzJf2RUH8/by+Ho6TwhkWXntH7vLoMNbN+kn4F3A/8zcyGSyows+L9LeSLupK6Em75Vjez5QBmViAp31pzHSbpEeBG4CVJg4GXCL/QZ8YYVyaFx+n/gMeBx6PyyRMIFRnyKkFEiSBTl8kTKzqeypYgPgZWmNmY4iMUehnLJ2Ml9bWUfnHN7EZJPwL3xBhXJmMlbW1my1LbpZe0C7A0xrjSim57jABuknQWKQk5D80B/h79v1BR+0vRiWxtjHFtwsx+J+l0wq2aXYDawLnAy8CA+CLLqPiPxcKKK/dGr7yhErpMlhRLl8lVpgzC5Y4kWR4fSJI6A73MLK9OCKWJnqaubWYr4o7F5Z7ysMtkTxDOOZcHFHoU7BDdck4dXguYFMdT35XtFpNzziVV3nWZ7FcQzjmXJ5RnXSZ7gsgzkpoDC/OteYVMkhavy42kHQdJizculfZJ6lSSHpV0j6Td444lC48D30j6W9yBZCkx8Ur6OnpdHHcs2UhYvIk5DiKJilcxdZlcJa4gJPUAWhIeTrsm7nhKU/hQjJlVeL3n8khSvFHV0X3M7PW4Y8lGkuJN0nEAyYpXMXWZXCUSRL4q5aGYvJPAeBPVzWRS4k3gcZCoePNJpUoQSlBXkyU9FEPoCjHfnvBMTLxKUDeTkKx4k3QcQLLiVT52mWxmleYFvAVcQ2g8rnDY9tGwEXHHVyzWr4HWaYa3Ab6OO74kxwtMAPZOM3wf4Iu440tyvEk6DpIWL+Hp9Huiz71F9NonGvZsHDFVtucgWpvZLakDLPRJfIukMzPME5cabOw3O9UPQM0KjiUbSYp3KyvWBzGAmX0saas4AipFkuJN0nEAyYq3m23aLfJs4GNJU+IIqLIliBlKTleTefdQTCmSFG/SuplMUrxJOg4gWfHmXZfJla0MImldTebVQzGlSVK8Slg3k0mKN0nHASQnXuVhl8mVKkE451xloDzpMrlKPCgHICmvemgrSVwPxZRXkuKVdG7cMZRFkuJN0nEA+RevpH6Kuha1Yl0mx6XKJAjggrgDKINxcQdQRkmKNx976ytJkuJN0nEA+Rfvs8APkh6XdETU3Hus/BaTc87lAUmfE8ofjicUou9O6K3vaUvTCVqFxFTZEkT0sFxfihZIvWV59JAc5OlDMSVIYLyHER6YTD0OXrGUHvzySVLiTeBxkJh4JY03s71S3m8PnEjop76Fme1U4TFVpgQh6dfA9YR+ZlOfmuwD3GBmj8UVW3GSniY8KfsoG+tptwAGAY3N7KSYQksrSfFKuh3YjVBtNDXWXwNTzeyymEJLK0nxJuk4gGTFK+lzM+uaYVwri6FP9cqWICYTnkhdXGz4NsAnaR5CiY2kKZniKWlcXJIUb6Z4ojZ5ppjZrjGElVGS4k3ScQDJilfSgWY2Ou44UlW2QmoR2l8qbj35V9i3UNIJ0YMwQHgoRtJJxPRQTCmSFO+qqAXf4noAqyo6mCwkKd4kHQeQrHhLLWeIfjRUmMr2JPWfgfGSRrDxqcmWhFtMN8UWVXonEx6KuVtS8YdiTo4rqBIkKd7TgXsk1WfjbYWdgCXRuHxzOsmJt/hxIEIjg/l4HED6eBsB75J/8Y6S9AKh7Glm4UCFPql7E26LjQIeqaiAKtUtJthwO+kwNi2kzrdfCxvky0Mx2UpKvFEhX2rz2T/FGU9pEhhvIo6DQvker6Q6wJnAAEJjgouBOkB1Qrnq3Wb2eYXGVJkShCRZKRuUzTRxk9THzEbGHUdxkhoAzczsu2LD9zSz/8YUVlrRyRYz+0lSM+AXwDf51rxCJpL+YmbXxR1HaSS1AboCk8zsm7jjKU5SS2Cuma2Kbs+cDuwFTAL+ZWZr44wvE0k1gabAyjhrYFa2BDEaKPUSzcweiSXALEmaaWYt444jlaQTgdsJ/WvUBE43s8+icUWq58VN0nmENrlEuL1wOvAV4RgYamZ51UibpDvTDP41oVYTZnZpxUaUmaSXzeyY6P/+hGNiNLAf8Jd8+25J+orQk+QKSbcAuwAvE543wMzyrZXnvFLZyiD6Ei7Rno5+2SwG6hIK40cAt1f0JVomkoZnGgU0qchYsnQdoTniOZJ6Ao9L+q2ZvUT+VQC4GOhE+OxnAG2jK4ltCPdw8ypBEOrojyEco4X78hTy70lfgFYp/18DHGxm30tqCrxDBd4fz1I1M1sR/f9LoEfUUuoTkr6IMa5EqFQJwsxWEXqPujtfLtFK8AtgILCs2PDC7hHzTXUzmwNgZp9KOgh4TdJOpK85FqeC6KSwQtJ3hffyzWyRpHyLFaAjoRJFX+BKM/tR0vVm9mjMcaWTuv9qFLYwambzJa2PKaaSzJJ0sJm9C0wnFP7PKCyPcCWrVAkiVfSE5Jy44yjBx8CKdI/QR89z5JulknYpLH+IriQOJFyud4oxrnRMUs3oGDiycGBUCJh3VbvNbCkwWFI34EmFviHyLs5IZ0n/I/yQqS2peXQs1CIUpuabs4HHFBrmWwJMkDSBUJPp8vjCSoZKVQbhckdSZ0JCm1pseE3gRDN7Mp7INhUVTP5YvABS0o5ABzN7O57IShcVpF4I9DKzgXHHky1JjQj79qO4Y0lHoU+I3djYw9xnhZ3yuMw8QcQkaTWukhRvkmKFZMWbpFghefHmm3y9jK0KRkm6JPq1u4GkWpIOlvQoodZVvkhSvEmKFZIVb5JiheTFm1f8CiIm+fhQTEmSFG+SYoWM8abWvsubeCvJvs3bePONJ4g8kIAaV0UkKd4kxQrJijdJsULy4s0HniCcc86l5WUQzjnn0vIE4ZxzLi1PEK5CSVonaYKkryS9GtWf39LrOFDSa1tweYMl1Ut5/8aWiFvSI5KO3wLLGSLpyjJMn/eNALr84AnCVbSVZtbFzHYHFgIXxR2QgpK+C4OBDQnCzI5IeCGnJwiXFU8QLk4fEfV/IGm0pO7R/00lTY/+P13Si5L+LWmqpKHpFiSpr6RvJI0Hjk0ZXuTXdXTl0jp6TZb0GKGl150k3SNprKSJkm6Ipr+U0Nn9KEmjomHTFRqnQ9Ll0TK/kjQ4GtZa0teS/hUta4Skuhn2wS+jdU6RdFTKNv8jJebXFJo1KdzO8ZK+kPROmv1wjqQ3JdWVNFDSp9EV232Sqku6GagbDXtS0laSXo+W95VCT2vOAZW4LSaX3yRVBw4hu5ZVuxD6HFgNTJZ0l5kV9hhYWNf9X4QmnL8Fns0yjF2BQWb2cbSc35nZwii2dxT6ubhT0uXAQWY2v9g2dAPOAPYmtE30iaQxhK4sdwVOMbNzJD0HHAc8kSaG1oTGGXchJKG2mYJV6NfiX8D+UQuqjYuNv5jQe+IxwM7AScB+ZlYg6W5ggJldK+liM+sSzXMcoVmSI6P3DbPbda4q8CsIV9HqKjSW9hOwHZBNx0jvmNmSqLXeSRRtchqgPfC9mU2NmkxIdyJOZ0ZhcoicGF2BfE5ogLBjKfP3Bl4ys+Vmtgx4kdBKL1E8E6L/xxESQTrPmdn6qI2radG2ZLIP8F5KC6oLU8b9GjgcON7MVhOSbzfgs2h/H0JIGsV9CfSRdIukX5jZkpI22FUtniBcRVsZ/XptRfjVXVgGsZaNx2OdYvOsTvl/HWW78k1dbvFlLy/8R6H/kCuBQ8xsT+D1NHGURbYxF38QySg55ky+JCShFtF7AY9G5T1dzKydmQ3ZZOVmUwg9rH0J/EnSH7NYl6siPEG4WET9NVwKXCGpBqGt/m7R6LLW7PkGaC1pl+j9KSnjphNOgEjai9DcQjoNCAljiaTtCL/GCy0F6qeZ533gGEn1JG1F6Pjn/TLGfoKkalHsOwOTo5i7RMN3YmP/IB8D+0fJjGK3mD4HzgOGS9qB0HnP8ZK2LZxWUuGVV4HCU8VE064wsyeAW4n2lXPgZRAuRmb2uaT/Ek7ofwOek3Qu4dd7WZazqnA+SSsIJ+nCE/oLwK8lTQQ+AaZkWMYXkj4nJJtZwH9SRt8P/FvSj2Z2UMo84yU9AnwaDXog2qbWZQh/ZjR/A+D8aFv+A3xPuJ32NTA+Wt+8aDtfjGpdzSWUORTG80FUIP96NPz3wIho2gLC1dqMaHv+G91Oewy4VaGznwLggjLE7io5b2rDOedcWn6LyTnnXFqeIJxzzqXlCcI551xaniCcc86l5QnCOedcWp4gnHPOpeUJwjnnXFqeIJxzzqX1/w2yugfWAyZHAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot the two series on the same graph\n",
+    "plt.plot(joined.index.astype(str), joined['f_pct'], color='red', label='percent of failure')\n",
+    "plt.plot(joined.index.astype(str), joined['p_pct'], color='green', label='percent of passing')\n",
+    "\n",
+    "# set x and y axis labels\n",
+    "plt.xlabel('Run duration buckets')\n",
+    "plt.ylabel('Percentage of passing or failing')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# set title and legend\n",
+    "plt.title('Percentage contribution of failing and passing to their sum')\n",
+    "plt.legend()\n",
+    "\n",
+    "# show the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f947cbbc-f53d-48aa-8255-d6517a62fe49",
+   "metadata": {},
+   "source": [
+    "### Test 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "94eddad4-39df-46ac-bcc6-de832542f84e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# test_id = \"29176617\" # Build and push image\n",
+    "test_id = \"37149896\" # File linting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "1f2b86db-2968-4105-a2ab-7084bb555228",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_train = pd.read_csv(\"../data/processed/{}passing_train.csv\".format(test_id))\n",
+    "failing_train = pd.read_csv(\"../data/processed/{}failing_train.csv\".format(test_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "7f281ee2-c6f7-4b7d-8072-060473929be2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranges = np.arange(0, max(passing_train['run_duration'])+1, 10).tolist()\n",
+    "ranges.append(np.inf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "e0b4aec3-3b89-4967-a4b5-b70286bb6a04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_train['run_duration_ranges'] = pd.cut(passing_train['run_duration'], bins=ranges)\n",
+    "failing_train['run_duration_ranges'] = pd.cut(failing_train['run_duration'], bins=ranges)\n",
+    "p_vc = pd.DataFrame(passing_train['run_duration_ranges'].value_counts().sort_index())\n",
+    "f_vc = pd.DataFrame(failing_train['run_duration_ranges'].value_counts().sort_index())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "002a066c-d0f5-41e6-b41c-400e828a615f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAFHCAYAAAC4ZhcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAkJklEQVR4nO3deZgdVbnv8e+PhMgoYWhjJGAQEHAiSkSczvEAUVAxcI8MihKOOUZRVByJ5/EoTveCFxW9CJojHIJ6GEQQBBUwgogikDAThjAEGTK0QIQwyfDeP2o1qezs7t497F1Zu36f5+mndw276l3Vu9+9alWtWooIzMwsP+tUHYCZmQ2PE7iZWaacwM3MMuUEbmaWKSdwM7NMOYGbmWXKCXwtIulmSW+rOo4qSdpP0r2SVkp6bdXxrA3SsXhZ1XHY2scJvEMkLZa0Z8O8QyVd3jcdEa+MiEsH2c5kSSFpbJtCrdqxwOERsVFEXNu4MJX9sZTU7pf0HUljRjuI0nFemX6WSTpf0rTR3lfDfi+V9O/leelY3NWGfS2W9EQq31JJp0jaaLT3Y+3jBG6rWQu+GF4K3DzIOjtHxEbAPwMHAh9qYzzj0752Bi4GzpF06HA2tBYc22b2SeWbArwW+GK14dhQOIGvRcq1dEm7Spov6ZFU+/tOWu2y9HtFqjm9UdI6kr4k6R5JyyWdKmmT0nYPScselPSfDfs5StJZkn4q6RHg0LTvKyStkLRE0vGSxpW2F5I+JmmRpEclfV3StpL+nOI9s7x+QxmbxirpBZJWAmOA6yXdOdjxiog7gD9RJJ81zmhKsW6XXp8i6QeSLkhxXylp21b+NhGxNCK+BxwFHCNpncbtl/bxjfT6bZLuk3SkpKXAf0vaNNXkeyU9nF5PSut/E3grcHz62x7fpAybpGPWm47hl0qxHCrpcknHpm3fLWnvVssHXNh3LNP2Zku6Mx2rhZL2Ky0bcF+StpF0WXrv79Jx/2lp+W7p87JC0vUqNR2mbd+V3nu3pINbKUMtRYR/OvADLAb2bJh3KHB5s3WAK4APptcbAbul15OBAMaW3vch4A7gZWnds4GfpGWvAFYCbwHGUTRRPF3az1Fpel+KL/T1gV2A3YCxaX+3AEeU9hfAucALgVcCTwHz0v43ARYCM/o5Dv3GWtr2dgMcx+eXAzsCS4BPNzueTdY/BXgQ2DWV7WfA6f3sZ43jnOa/LM3fqVm8aR/fSK/fBjwDHAO8IB3bzYF/BTYANgZ+Dvyy9P5LgX8foAynpmO/cYrxdmBmqfxPAx+m+CI8DHgA0GCfSWAScCPwvdLy/YGXpM/FgcBjwMRW9kXx+T2W4jP3FuAR4Kdp2Zbp7/DOtO1paboH2DCtu0NadyLwyqr/f9fWn8oDqMtP+mdZCawo/TxO/wn8MuCrwBYN21kjsVAkz4+VpndI/1xjgS8Dp5WWbQD8g9UT+GWDxH4EcE5pOoA3l6YXAEeWpr8NHNfPtvqNtbTtwRL4IymZBHAa8IK07FAGT+A/Li17J3BrP/tZ4zin+euVy98YL2sm8H8A6w1QninAw6XpS+kngVMkyn8Arygt+whwaan8dzT8rQN48SCfyUfTevMomoz6i/U6YPpg+wK2pvji2qC0/KesSuBHUvrSTvMuBGZQJPAVFF9y61f1/5rLj5tQOmvfiBjf9wN8bIB1ZwIvB26VdLWkdw+w7kuAe0rT91Ak7wlp2b19CyLicYraTtm95QlJL0+n9ktTs8r/BrZoeM+y0usnmkz3dzFsoFhb9bq0/QOBN1D807dqaen14/QfZ3+2TL8fanH93oh4sm9C0gaSfpSaPx6h+KIer9YuxG4BrMuax2/L0vTz5Ut/axi4jPtGxMYUXzY7Uvo7p6a361IzxwrgVaz+OehvXy8BHirNg9U/Yy8F9u/bbtr2Wyhq949R/F0/CixJzV07DhB/rTmBr6UiYlFEvA94EcUp+FmSNqSo5TR6gOKfok9fDWgZRRPDpL4FkvpO41fbXcP0icCtwPYR8ULgPwANvzQtx9qyKJxJcar+5TT7MYqaIACSXjyyUJvaD1gO3JamHy/vk6IGulqoDdOfpTjreEM6tv+U5quf9cv+RnG20nj87m8p8gFExB8ozh6OBZD0UuC/gMOBzVOF4yZa+xwsATaTVD4uW5Ve30tRAx9f+tkwIo5OsVwYEdMomk9uTXFYE07gaylJH5DUExHPUZxSAjwH9Kbf5fuCTwM+nS4cbURRYz4jIp4BzgL2kfSmdGHxKAb/J9yYopliZar9HDZKxRos1uE4GvhwStbXA6+UNEXSehRlHRWSJkg6HPgK8MX0d4GiWeH9ksZI2ovizpiBbExxhrJC0mZpe2XLWP1v+7yIeBY4E/impI1Tkv0MRfPEaDgOmCZpZ4qzmqD4vCHp3yhq4IOKiHuA+cBRksZJeiOwT2mVn1J8Jt+Rjtt66YLvpHScp6fKylMUTTzPrbkXAyfwtdlewM0q7sz4HnBQRDyRTku/CfwpnX7uBpwM/ITidPxu4EngEwARcXN6fTpFzWglRQ3yqQH2/Tng/RRto/8FnDGK5eo31uGIiBvTtj4fEbcDXwN+BywCLh/ovS1aIekxigt87wT2j4iTS8s/RZGcVgAHA78cZHvHUVzM/BvwF+C3Dcu/B7w33dnx/Sbv/wTFmcZdFOX7H4pjOmIR0UtxkfTLEbGQ4lrGFRRfKq+muOOnVQcDb6RorvsGxWfoqbSfe4HpFGd2vRQ18s9T5KN1KL6UHqBopvpnRrcC0VX6rhhbTaRa7wqK5pG7Kw7HakLSGRQXjBvPOGwEXAOvAUn7pItnG1K0cd5IcQeCWVtIer2KvgHrpKal6Qx+dmJD5AReD9MpTkkfALanaI7xqZe104spbolcCXwfOCyaPBrBRsZNKGZmmXIN3MwsU07gZmaZ6ujT0bbYYouYPHlyJ3dpZpa9BQsW/C0iehrndzSBT548mfnz53dyl2Zm2ZN0T7P5bkIxM8uUE7iZWaacwM3MMuUEbmaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmepoRx4bnsmzL6g6hFGz+Oh3VR2CWddwDdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLVUgKX9GlJN0u6SdJpktaTtI2kKyXdIekMSePaHayZma0yaAKXtCXwSWBqRLwKGAMcBBwDfDcitgMeBma2M1AzM1tdq00oY4H1JY0FNgCWALsDZ6Xlc4F9Rz06MzPr16AJPCLuB44F/kqRuP8OLABWRMQzabX7gC3bFaSZma2plSaUTYHpwDbAS4ANgb1a3YGkWZLmS5rf29s77EDNzGx1rTSh7AncHRG9EfE0cDbwZmB8alIBmATc3+zNETEnIqZGxNSenjXG5DQzs2FqJYH/FdhN0gaSBOwBLAQuAd6b1pkBnNueEM3MrJlW2sCvpLhYeQ1wY3rPHOBI4DOS7gA2B05qY5xmZtagpacRRsRXgK80zL4L2HXUIzIzs5a4J6aZWaacwM3MMuUEbmaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLlBG5mlikncDOzTDmBm5llygnczCxTTuBmZplyAjczy1QrgxrvIOm60s8jko6QtJmkiyUtSr837UTAZmZWaGVItdsiYkpETAF2AR4HzgFmA/MiYntgXpo2M7MOGWoTyh7AnRFxDzAdmJvmzwX2HcW4zMxsEENN4AcBp6XXEyJiSXq9FJgwalGZmdmgWk7gksYB7wF+3rgsIgKIft43S9J8SfN7e3uHHaiZma1uKDXwvYFrImJZml4maSJA+r282ZsiYk5ETI2IqT09PSOL1szMnjeUBP4+VjWfAJwHzEivZwDnjlZQZmY2uJYSuKQNgWnA2aXZRwPTJC0C9kzTZmbWIWNbWSkiHgM2b5j3IMVdKWZmVgH3xDQzy5QTuJlZppzAzcwy5QRuZpYpJ3Azs0w5gZuZZcoJ3MwsU07gZmaZcgI3M8uUE7iZWaacwM3MMuUEbmaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmWp1RJ7xks6SdKukWyS9UdJmki6WtCj93rTdwZqZ2Sqt1sC/B/w2InYEdgZuAWYD8yJie2BemjYzsw4ZNIFL2gT4J+AkgIj4R0SsAKYDc9Nqc4F92xOimZk100oNfBugF/hvSddK+nEa5HhCRCxJ6ywFJrQrSDMzW1MrCXws8DrgxIh4LfAYDc0lERFANHuzpFmS5kua39vbO9J4zcwsaSWB3wfcFxFXpumzKBL6MkkTAdLv5c3eHBFzImJqREzt6ekZjZjNzIwWEnhELAXulbRDmrUHsBA4D5iR5s0Azm1LhGZm1tTYFtf7BPAzSeOAu4B/o0j+Z0qaCdwDHNCeEM3MrJmWEnhEXAdMbbJoj1GNxszMWuaemGZmmXICNzPLlBO4mVmmnMDNzDLlBG5mlikncDOzTDmBm5llygnczCxTTuBmZplyAjczy5QTuJlZppzAzcwy5QRuZpYpJ3Azs0w5gZuZZaql54FLWgw8CjwLPBMRUyVtBpwBTAYWAwdExMPtCdPMzBoNpQb+LxExJSL6BnaYDcyLiO2BeTQMdGxmZu01kiaU6cDc9HousO+IozEzs5a1msADuEjSAkmz0rwJEbEkvV4KTBj16MzMrF+tDmr8loi4X9KLgIsl3VpeGBEhKZq9MSX8WQBbb731iII1M7NVWqqBR8T96fdy4BxgV2CZpIkA6ffyft47JyKmRsTUnp6e0YnazMwGT+CSNpS0cd9r4O3ATcB5wIy02gzg3HYFaWZma2qlCWUCcI6kvvX/JyJ+K+lq4ExJM4F7gAPaF6aZmTUaNIFHxF3Azk3mPwjs0Y6gzMxscO6JaWaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLlBG5mlikncDOzTDmBm5llygnczCxTTuBmZplyAjczy5QTuJlZppzAzcwy1XIClzRG0rWSzk/T20i6UtIdks6QNK59YZqZWaOh1MA/BdxSmj4G+G5EbAc8DMwczcDMzGxgLSVwSZOAdwE/TtMCdgfOSqvMBfZtQ3xmZtaPVmvgxwFfAJ5L05sDKyLimTR9H7Dl6IZmZmYDGTSBS3o3sDwiFgxnB5JmSZovaX5vb+9wNmFmZk20UgN/M/AeSYuB0ymaTr4HjJfUN6r9JOD+Zm+OiDkRMTUipvb09IxCyGZmBi0k8Ij4YkRMiojJwEHA7yPiYOAS4L1ptRnAuW2L0szM1jCS+8CPBD4j6Q6KNvGTRickMzNrxdjBV1klIi4FLk2v7wJ2Hf2QzMysFe6JaWaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLlBG5mlikncDOzTDmBm5llygnczCxTTuBmZplyAjczy5QTuJlZppzAzcwy1cqgxutJukrS9ZJulvTVNH8bSVdKukPSGZLGtT9cMzPr00oN/Clg94jYGZgC7CVpN+AY4LsRsR3wMDCzbVGamdkaWhnUOCJiZZpcN/0Exej0Z6X5c4F92xGgmZk111IbuKQxkq4DlgMXA3cCKyLimbTKfcCWbYnQzMyaaimBR8SzETEFmEQxkPGOre5A0ixJ8yXN7+3tHV6UZma2hiHdhRIRK4BLgDcC4yX1jWo/Cbi/n/fMiYipETG1p6dnJLGamVlJK3eh9Egan16vD0wDbqFI5O9Nq80Azm1TjGZm1sTYwVdhIjBX0hiKhH9mRJwvaSFwuqRvANcCJ7UxTjMzazBoAo+IG4DXNpl/F0V7uJmZVcA9Mc3MMuUEbmaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLVSld6s0pNnn1B1SGMmsVHv6vqEKyLuAZuZpYpJ3Azs0w5gZuZZcoJ3MwsU07gZmaZamVEnq0kXSJpoaSbJX0qzd9M0sWSFqXfm7Y/XDMz69NKDfwZ4LMR8QpgN+Djkl4BzAbmRcT2wLw0bWZmHTJoAo+IJRFxTXr9KMV4mFsC04G5abW5wL5titHMzJoYUhu4pMkUw6tdCUyIiCVp0VJgwuiGZmZmA2k5gUvaCPgFcEREPFJeFhEBRD/vmyVpvqT5vb29IwrWzMxWaSmBS1qXInn/LCLOTrOXSZqYlk8Eljd7b0TMiYipETG1p6dnNGI2MzNauwtFwEnALRHxndKi84AZ6fUM4NzRD8/MzPrTysOs3gx8ELhR0nVp3n8ARwNnSpoJ3AMc0JYIzcysqUETeERcDqifxXuMbjhmZtYq98Q0M8uUE7iZWaacwM3MMuUEbmaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLlBG5mlikncDOzTDmBm5llygnczCxTTuBmZplqZUi1kyUtl3RTad5mki6WtCj93rS9YZqZWaNWauCnAHs1zJsNzIuI7YF5adrMzDpo0AQeEZcBDzXMng7MTa/nAvuOblhmZjaY4baBT4iIJen1UmDCKMVjZmYtGvFFzIgIIPpbLmmWpPmS5vf29o50d2Zmlgw3gS+TNBEg/V7e34oRMScipkbE1J6enmHuzszMGg03gZ8HzEivZwDnjk44ZmbWqlZuIzwNuALYQdJ9kmYCRwPTJC0C9kzTZmbWQWMHWyEi3tfPoj1GORYzMxsC98Q0M8uUE7iZWaacwM3MMuUEbmaWKSdwM7NMOYGbmWXKCdzMLFNO4GZmmXICNzPLlBO4mVmmnMDNzDLlBG5mlikncDOzTDmBm5llygnczCxTTuBmZpkaUQKXtJek2yTdIWn2aAVlZmaDG3REnv5IGgP8AJgG3AdcLem8iFg4WsGZWb1Nnn1B1SGMisVHv6st2x1JDXxX4I6IuCsi/gGcDkwfnbDMzGwwI0ngWwL3lqbvS/PMzKwDht2E0ipJs4BZaXKlpNvavc8R2AL4W9VBVKjt5dcx7dz6iHTkb1/38q+lcvjcv7TZzJEk8PuBrUrTk9K81UTEHGDOCPbTMZLmR8TUquOoSp3LX+eyQ73Ln3PZR9KEcjWwvaRtJI0DDgLOG52wzMxsMMOugUfEM5IOBy4ExgAnR8TNoxaZmZkNaERt4BHxa+DXoxTL2iCLpp42qnP561x2qHf5sy27IqLqGMzMbBjcld7MLFNO4GZmmWr7feBrK0mbtbDacxGxot2xVEHSZ1pY7bGI+FHbg+kwSf+rhdWeTNd4uo6k17Ww2tMRcWPbg+mwbvu/r20buKQngQcADbDamIjYukMhdZSkJcCJDFz+gyPi5R0KqWMkPQicy8Bl/6eI2LZDIXWUpEcpbgMeqPzbRMTkzkTUOd32f1/bGjhwS0S8dqAVJF3bqWAq8JOI+NpAK0jasFPBdNhvIuJDA60g6aedCqYCV0fE7gOtIOn3nQqmw7rq/77ONfD1IuLJka5jZvmQtFNE3DLIOtn839c2gQNIEsVTFfsewnU/cFXU5KBIegewL6uX/9yI+G1lQXWIpB0pnp5ZLvt5g/1zdwtJmwB7sXr5L8yl7Xe4JC2IiF0kzYuIPaqOZ6Rqm8AlvR04AVjEqme4TAK2Az4WERdVFVsnSDoOeDlwKsWTJKEo/yHAooj4VEWhtZ2kI4H3UTwCuVz2g4DTI+LoqmLrBEmHAF8BLmL1z/404KsRcWpVsbVbah75OXAY8N3G5RHxnY4HNQJ1TuC3AHtHxOKG+dsAv46InSoJrEMk3d7sAmU6K7k9IravIKyOkHQ78MqIeLph/jjg5m4uO0B6IugbGmvbkjYFruzGC9d9JO1AcdZ5BPDDxuUR8dUOhzQidb6IOZZVta+y+4F1OxxLFZ6U9PqIuLph/uuBLNr/RuA54CXAPQ3zJ6Zl3U5As5rbcwx8d0b2IuI24BhJN0TEb6qOZ6TqnMBPphgG7nRWDUyxFcVp9EmVRdU5hwInStqYVV9kWwF/T8u62RHAPEmLWPW335qi+ezwqoLqoG8C10i6iNXLPw34emVRddbvJb0fmEwpDw52Z9baprZNKFBckab5hazajOsp6cWUyh8RS6uMp1MkrcOaF7Cvjohnq4uqc1JzyTtY8yLmw9VF1TmSfktRWVkAPP83j4hvVxbUMNQ6gZtZPUm6KSJeVXUcI+VnoTQh6aiqY6iSpGuqjqEqks6vOoYqScr20apD9GdJr646iJFyDbwJSftExK+qjsM6T9LEiFhSdRxVkbRLRCyoOo52k7SQ4prH3cBTpAu7EfGaSgMbIifwmpM0gdXbwJdVGU+n9T3cKCIeqjoW6xxJTQcJjojGO5PWarW9C0XSWGAmsB/FLWWQeiICJzXeI9xtJE2huA92E0qdOSStoOjI1LXNKJK2Br4F7AGsKGbphcDvgdmNfQO6TeqF+UWK+6FfRHFL4XKKz/7R3dwbU9ILI+IR4NGqYxkNta2BSzqN4p93Lqv3xpsBbBYRB1YUWkdIug74SERc2TB/N+BHEbFzJYF1gKQrgOOAs/ruOpE0BtgfOCIidqswvLaTdCHFl9XcvruO0t1IM4A9IuLtVcbXTpLOj4h3S7qb4ourfN97RMTLKgptWOqcwJv2RBxsWbeQtKi/HoeS7oiI7TodU6cMUvZ+l3ULSbdFxA5DXWZrn9o2oQAPSdof+EVEPAfP3xu8P1CHe2F/I+kCimehlDsyHQJ0+8OsFkg6geLsq1z2GUA2jxIdgXskfYGiBr4Mnr8WciirjodloM418MnAMcDurErY44FLKNpB764mss6RtDfNOzJ15Ug0fdIzT2bSpOwU1z+eqiq2TkideGZTlP9FafYyivIf4wu6+ahtAi+TtDlARDxYdSxmZq1yRx6KxF1O3pKmVRlPJ0gaI+kjkr4u6U0Ny75UVVydIGkDSV+Q9HlJ60maIek8Sd+StFHV8VWhi0fg6WqugTch6a+5jIk3XJJ+DGwAXAV8EPhDRHwmLbsmIloZ+DZLks6kaOtdH9gBuAU4A3gP8OKI+GCF4bWdpBsaZ1E8G/42gNw6s4yG9HhpgB9ExPGVBjMEtb2IKem8/hYBm3cylors2vePKul44ARJZ1MMdNDVjxQFXh4RB6Rnny8B9oyIkHQ5cH3FsXXCYuAR4BvAExR/7z8C+1QYU6UiYqfUlJrVLaS1TeDAW4EPACsb5vcNs9btxvW9iIhngFmSvkxxf3AtmhFS0v513xB6abrrT0kj4j2S9gPmAMdGxHmSns6tF+JINOuBnJpRL6gwrCGrcwL/C/B4RPyhcUEasaTbzZe0V3n8y4j4mqQHgBMrjKsT5kvaKCJWlkenl7QtXdJDbzARcU56HvjXJc2k9IXezbqtB7LbwM1KJKkug1r3kbQz8MaIWGOIsW7TbT2QncDNrDa6rQdynZtQzKx+uqoHsmvgZlYr3dQD2QncViNpIvBQt3cnb6bOZbc8uSdmA0lzJZ0oKfvx8obpJ8Ctko6tOpAK1LnsSLol/RxedSxVkDSr6hiGym3gazoe2Jqid+KRFcfScRGxZ+rg8oqqY+m0Opcd8u3MMoqy68DmJpQaS8lqV1ZvC7yqDrfR1bnsfeo+nF43qG0Cr/OwUgCS3g6cACyi1KGBYqDXj0XERVXF1m51Ljv035mFYoSq7DqzDJWkd1D835e/vM8td2rLRZ0TeG2HlYLnH96zd+P4j5K2AX4dETtVElgH1Lns0H2dWYZC0nEUD+46ldWHUjwEWBQRn6ootGGpcwKv9bBSkhYBO6XnoJTnjwMW5tahYSjqXHbovs4sQ9HfcImpSe323IbTq/NFzLoPK3UycLWk01m9Q8NBwEmVRdUZdS47dFlnliF6UtLrI+LqhvmvB56sIqCRqHMNvPbDSknaieYdGhZWF1Vn1Lns0F2dWYZC0usoHta2MauaULYC/g58PCIWVBXbcNQ2gZtZfaXrXeU7cJZWGc9wuSNPE+lburYkHVV1DFWpc9khz84swxERSyNiQapxf7LqeIarzm3gAzkM+HDVQVQoq9PIUVbnskOGnVmGQtL3m8w+pG8s1IjIKpm7CcXMakPSvcAfgItY9WV1LPA5gIiYW1Fow1LrBJ468+zF6hdyLuz2TjwAksYCM4H9gJek2fdTdGQ6KSKeriq2dqtz2ft0U2eWoZC0MfB1ihsXPhcRD0i6KyJeVnFow1LbBC7pEOArFN/E5d5o04CvRsSpVcXWCZJOo+h5N5fVOzTMADaLiAMrCq3t6lx26L7OLMMhaReKmvcFwOERMbnaiIanzgn8NuANjbXtdHvhlc1u9u8m/XVoGGxZN6hz2aH7OrMMVyrvxyiGk/tA1fEMR53vQhHF808aPUeXX8hJHpK0v6TnPwOS1pF0IPBwhXF1Qp3LDqkzS5P5WXZmGYqUtAGIwg8ak3d5nbVdne9C+SZwTRqZu6832tYUTShfryyqzjkIOAY4QVJf0hoPXJKWdbM6lx2K3sYnpvbgxs4sh1YUU6dcIukXFO39f+2bmR6j8BaKZrRLgFOqCW9oatuEAs83l7yDNS9i1qEW9rz0DGgi4sGqY+m0mpe9KzqzDIWk9YAPAQcD21BcC1mfojXiIuCEiLi2sgCHqLYJXJIGe/ZzK+t0I0nTIuLiquNoJ0kvBHoi4s6G+a+JiBsqCqtjUvImIpZK6gHeCtxal0cJAEhaF9gCeCLXO8/q3AZ+iaRPSNq6PFPSOEm7S5pLcTpVR139QCdJBwC3Ar+QdHNDe/Ap1UTVOZI+AlwB/EXSYcD5wLuAcyTNrDS4DoqIpyNiSa7JG+pdA++qU6mhknRef4uA3SNiw07G00npedh7R8QSSbtS3E73xYg4R9K1EfHaaiNsL0k3Am+g+LzfA2yXauKbApdExJQq47PW1fYiZkQ8STEqywndcCo1DG8FPgCsbJjfN9RYNxsTEUsAIuIqSf8CnC9pK5rfmdRtno6Ix4HHJd3Z1/YdEQ9LqkP5u0ZtE3hZ6nm3pOo4OuwvwOMR8YfGBeke+W72qKRt+9q/U038bcAvgVdWGFenhKR10+f+XX0z01lpnZtVs1PbJhSrL0k7U3x5LWqYvy5wQET8rJrIOiNd93mgyYhEW1KMVPS7aiKzoXICr6k634VT57KDy99NfLpUX3W+C6fOZQeXv2u4Bl5T/dyFsx4whi6/C6fOZQeXv5s4gVtXdGgYrjqXHVz+3DmBm5llym3gZmaZcgI3M8uUE7gNi6RnJV0n6SZJv5I0fpS2e6mk2yTdIOlWSceP1rbT9t8m6U2l6Y+qGJ1ppNudLOmJdEwWSjo1tS+btY0TuA3XExExJSJeBTwEfHwUt31wRLwGeA3wFMVYlS1TMeZlf94GPJ/AI+KHozh83p3pOSKvphii7IBR2q5ZU07gNhquID1XOtWgp6bXW0hanF4fKulsSb+VtEjStwbbaET8A/gCsLWknVMt96a+5ZI+J+mo0n6PkzQf+JSkfSRdKelaSb+TNEHSZOCjwKdTTfmtko6S9Lm0jSmS/pJq/+ekhzv1bfsYSVdJul3SWweJ+1ngqtIxWSOWNP8oSSen7d8l6ZOlsv1nOhO5XNJppRi3TcdwgaQ/Stoxzd8/nQ1dL+mywY6tdQcncBsRSWOAPYD+nm5YNgU4kKKGeqCKh0cNKCXD64EdW9j+uIiYGhHfBi4HdktPFjwd+EJELAZ+CHw3nT38seH9pwJHptr/jRSDXvcZGxG7Akc0zF9Dus/6DUDfCO9rxFJafUeKQUV2Bb4iaV0Vj7f9V2BnYG9gamn9OcAnImIX4HMUD2QD+DLwjojYGXjPQPFZ9/DDrGy41lfxWNYtgVuAVgaAmBcRfweQtBB4KauGsxtIq2MUnlF6PQk4Q9JEYBxw94A7kDYBxpce7jUX+HlplbPT7wXA5H42s206JtsAF5QGhhgolgsi4ingKUnLgQnAmymG/HqSYvzKX6UYN6Jo/vm5Vg3b+IL0+0/AKZLOLMVqXc41cBuuJ1J770spEmxfG/gzrPpcrdfwnqdKr5+lhQpEquG/muJLorztZtt/rPT6/wHHR8SrgY80WXeo+mIfKO6+NvBtgV0k9dWEB4plKMdkHWBFOnvo+9kJICI+CnyJYmzLBUpDxVl3cwK3EUnPlf4k8Nl08XAxsEta/N6RbDvdxfF/gHtTbXYZ8CJJm0t6AfDuAd6+CcUYp7D6cz0eBTZuUo6/Aw+X2rc/CKzxqN1WRMTfgNnAFweJpT9/AvaRtF6qdb87bfcR4G5J+0PxwCkVT1ZExeNxr4yILwO9FIncupwTuI1Yem7GDcD7gGOBwyRdS9FFezh+JukG4CZgQ2B62s/TwNcoLhBeTDEsWn+OomhqWAD8rTT/V8B+fRcxG94zA/i/ad9T0r6G65fABmkf/cXSVERcTXFN4QbgNxTt8X9Piw8GZkq6HriZdGxS3Demi7x/prhuYF3OXenN1kKSNoqIlZI2AC4DZkXENVXHZWsXX8Q0WzvNkfQKivbyuU7e1oxr4GZmmXIbuJlZppzAzcwy5QRuZpYpJ3Azs0w5gZuZZcoJ3MwsU/8fXOjfF/bB3yAAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.bar(p_vc.index.astype(str), p_vc['run_duration_ranges'].values)\n",
+    "\n",
+    "# set the x-axis label and title\n",
+    "plt.xlabel('Run Duration Ranges')\n",
+    "plt.title('Histogram of Run Duration Ranges')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# display the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "e5edee16-bc54-446a-b070-a2539948b50e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAFHCAYAAACI6gYLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAf4klEQVR4nO3debwcZZ3v8c+XBAxLBJWICIQgKpsKSFhcmGFQBERE7gyCopArYxREQUWB+3Iwit4LXnTQi6AZ5QLisLigCCq4gIiyJeyEJQhhEAKEJUKARJbf/FFPJ5VOn3P6nJzuek7V9/16nVe6qyrVv6dPn28/9dSmiMDMzPK1StUFmJnZ4BzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1BXQNJtknapuo4qSdpX0v2SFknatup6cpDei9dUXYflx0E9yiTNk/TOtmnTJF3Zeh4RW0XE5UOsZ4qkkDS+R6VW7STg8IhYKyJuaJ+Z2v50Cq8HJH1D0rjRLqL0Pi9KPw9LukjSbqP9Wm2ve7mkfy1PS+/FPT14rXmSnk3te0jSGZLWGu3Xsd5xUDdUBl8AGwO3DbHM1hGxFvCPwP7AR3pYzzrptbYGfgNcIGnaSFaUwXvbyd6pfdsA2wLHVluODYeDugLlXrekHSTNkvRk6s19Iy12Rfp3YeoJvUXSKpK+IOk+SY9IOkvS2qX1HpTmPSbp39peZ4akH0s6W9KTwLT02ldJWihpvqRTJK1WWl9IOkzSXElPSTpe0qaS/pzqPb+8fFsbO9Yq6SWSFgHjgJsk/WWo9ysi7gb+RBEyK2yhlGp9bXp8hqRvS7o41X2NpE27+d1ExEMR8U1gBnCipFXa1196ja+kx7tI+qukoyU9BPx/SS9LPfMFkp5IjzdMy38V2Bk4Jf1uT+nQhrXTe7YgvYdfKNUyTdKVkk5K675X0p7dtg+4pPVepvUdI+kv6b2aI2nf0rxBX0vSJpKuSP/3t+l9P7s0f6f0eVko6SaVhvzSuu9J//deSQd204ZGigj/jOIPMA94Z9u0acCVnZYBrgI+nB6vBeyUHk8BAhhf+n8fAe4GXpOW/SnwgzRvS2AR8HZgNYqhhedKrzMjPX8fxRf06sB2wE7A+PR6twNHll4vgJ8DLwW2ApYAv0uvvzYwBzh4gPdhwFpL637tIO/j0vnA5sB84NOd3s8Oy58BPAbskNr2Q+DcAV5nhfc5TX9Nmr5Fp3rTa3wlPd4FeB44EXhJem9fAfwzsAYwEfgR8LPS/78c+NdB2nBWeu8nphrvAg4ptf854KMUX3iHAg8CGuozCWwI3AJ8szR/P+DV6XOxP/A0sH43r0Xx+T2J4jP3duBJ4Ow0b4P0e3h3Wvdu6fkkYM207GZp2fWBrar++831p/IC6vaT/igWAQtLP88wcFBfAXwJWLdtPSsECEVIHlZ6vln6IxoPHAecU5q3BvB3lg/qK4ao/UjggtLzAN5Wej4bOLr0/OvAyQOsa8BaS+seKqifTKERwDnAS9K8aQwd1N8rzXs3cMcAr7PC+5ymTyi3v71eVgzqvwMTBmnPNsATpeeXM0BQUwTi34EtS/M+Blxeav/dbb/rAF41xGfyqbTc7yiGegaq9UZgn6FeC5hM8QW1Rmn+2SwL6qMpfTmnaZcAB1ME9UKKL7PVq/p7HSs/HvrojfdFxDqtH+CwQZY9BHg9cIek6yS9Z5BlXw3cV3p+H0VIr5fm3d+aERHPUPReyu4vP5H0+rRJ/lAaDvnfwLpt/+fh0uNnOzwfaKfUYLV2681p/fsDO1L8cXfrodLjZxi4zoFskP59vMvlF0TE4tYTSWtI+m4atniS4gt5HXW3Q3RdYFVWfP82KD1f2r70u4bB2/i+iJhI8aWyOaXfcxoyuzENTywE3sDyn4OBXuvVwOOlabD8Z2xjYL/WetO6307RW3+a4vf6cWB+GqbafJD6G81BXbGImBsRHwBeSbHp/GNJa1L0Wto9SPHhb2n1aB6mGBrYsDVDUmvze7mXa3t+GnAH8LqIeCnwvwCNvDVd19q1KJxPsYl9XJr8NEXPDgBJr1q5UjvaF3gEuDM9f6b8mhQ9yuVKbXv+WYqtiB3Te/sPaboGWL7sUYqtj/b374GuKh9ERPyBYmvgJABJGwP/ARwOvCJ1LG6lu8/BfODlksrvy0alx/dT9KjXKf2sGREnpFouiYjdKIY97kh1WAcO6opJ+pCkSRHxIsWmIMCLwIL0b/m42nOAT6cdOGtR9IDPi4jngR8De0t6a9rBN4Oh/9gmUgwvLEq9mUNHqVlD1ToSJwAfTaF8E7CVpG0kTaBo66iQtJ6kw4EvAsem3wsUwwEflDRO0h4UR6IMZiLFFsdCSS9P6yt7mOV/t0tFxAvA+cBXJU1MYfoZimGF0XAysJukrSm2UoLi84ak/0nRox5SRNwHzAJmSFpN0luAvUuLnE3xmdw9vW8T0o7XDdP7vE/qlCyhGJp5ccVXMXBQ52AP4DYVR0J8EzggIp5Nm5NfBf6UNht3Ak4HfkCxGX0vsBj4JEBE3JYen0vR01lE0SNcMshrHwV8kGLs8j+A80axXQPWOhIRcUta1+ci4i7gy8BvgbnAlYP93y4tlPQ0xY62dwP7RcTppflHUITQQuBA4GdDrO9kip2KjwJXA79um/9N4F/SkRTf6vD/P0mx5XAPRfv+k+I9XWkRsYBiZ+VxETGHYl/DVRRfHm+kOMKmWwcCb6EYZvsKxWdoSXqd+4F9KLbUFlD0sD9HkTurUHz5PEgxvPSPjG5HoVZae26tZlIvdiHFsMa9FZdjDSHpPIodt+1bELYS3KOuEUl7p51Ya1KMQd5CscffrCckba/i2PpV0pDQPgy9tWHD5KCul30oNiUfBF5HMYziTSbrpVdRHGq4CPgWcGh0uCSArRwPfZiZZc49ajOzzDmozcwy15OrfK277roxZcqUXqzazKyWZs+e/WhETOo0rydBPWXKFGbNmtWLVZuZ1ZKk+waa56EPM7PMOajNzDLnoDYzy5yD2swscw5qM7PMdXXUh6R5FFdYewF4PiKm9rIoMzNbZjiH5/1TRDzas0rMzKwjD32YmWWu2x51AJdKCuC7ETGzfQFJ04HpAJMnTx69ChtkyjEXV13CqJl3wl5Vl2BWG932qN8eEW8G9gQ+Iekf2heIiJkRMTUipk6a1PEsSDMzG4GugjoiHkj/PgJcAOzQy6LMzGyZIYNa0pqSJrYeA++iuEuxmZn1QTdj1OsBF0hqLf+fEdF+o04zM+uRIYM6Iu4Btu5DLWZm1oEPzzMzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLnoDYzy5yD2swscw5qM7PMOajNzDLXdVBLGifpBkkX9bIgMzNb3nB61EcAt/eqEDMz66yroJa0IbAX8L3elmNmZu267VGfDHweeLF3pZiZWSfjh1pA0nuARyJitqRdBlluOjAdYPLkyaNVnzXIlGMurrqEUTHvhL2qLsFqppse9duA90qaB5wL7Crp7PaFImJmREyNiKmTJk0a5TLNzJpryKCOiGMjYsOImAIcAPw+Ij7U88rMzAzwcdRmZtkbcoy6LCIuBy7vSSVmZtaRe9RmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmHNRmZplzUJuZZc5BbWaWOQe1mVnmhgxqSRMkXSvpJkm3SfpSPwozM7PC+C6WWQLsGhGLJK0KXCnpVxFxdY9rMzMzugjqiAhgUXq6avqJXhZlZmbLdDVGLWmcpBuBR4DfRMQ1Pa3KzMyW6iqoI+KFiNgG2BDYQdIb2peRNF3SLEmzFixYMMplmpk117CO+oiIhcBlwB4d5s2MiKkRMXXSpEmjVJ6ZmXVz1MckSeukx6sDuwF39LguMzNLujnqY33gTEnjKIL9/Ii4qLdlmZlZSzdHfdwMbNuHWszMrAOfmWhmljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mlrkhg1rSRpIukzRH0m2SjuhHYWZmVhjfxTLPA5+NiOslTQRmS/pNRMzpcW1mZkYXPeqImB8R16fHTwG3Axv0ujAzMysMa4xa0hRgW+CanlRjZmYr6DqoJa0F/AQ4MiKe7DB/uqRZkmYtWLBgNGs0M2u0roJa0qoUIf3DiPhpp2UiYmZETI2IqZMmTRrNGs3MGq2boz4EfB+4PSK+0fuSzMysrJse9duADwO7Srox/by7x3WZmVky5OF5EXEloD7UYmZmHfjMRDOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHMOajOzzDmozcwy56A2M8ucg9rMLHNDBrWk0yU9IunWfhRkZmbL66ZHfQawR4/rMDOzAQwZ1BFxBfB4H2oxM7MOPEZtZpa58aO1IknTgekAkydPHq3VmjXClGMurrqEUTPvhL2qLqF2Rq1HHREzI2JqREydNGnSaK3WzKzxPPRhZpa5bg7POwe4CthM0l8lHdL7sszMrGXIMeqI+EA/CjEzs8489GFmljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mljkHtZlZ5hzUZmaZc1CbmWXOQW1mlrmuglrSHpLulHS3pGN6XZSZmS0zZFBLGgd8G9gT2BL4gKQte12YmZkVuulR7wDcHRH3RMTfgXOBfXpblpmZtXQT1BsA95ee/zVNMzOzPhg/WiuSNB2Ynp4uknTnaK27B9YFHq26iAr1vP06sZdrXylue481vf0rYeOBZnQT1A8AG5Web5imLSciZgIzh11aBSTNioipVddRlSa3321vZtthbLe/m6GP64DXSdpE0mrAAcCFvS3LzMxahuxRR8Tzkg4HLgHGAadHxG09r8zMzIAux6gj4pfAL3tcSz+NiSGaHmpy+9325hqz7VdEVF2DmZkNwqeQm5llzkFtZpa5UTuOOleSXt7FYi9GxMJe19Jvkj7TxWJPR8R3e15MBST9jy4WW5z2wdSKpDd3sdhzEXFLz4upQN3+7ms/Ri1pMfAgoEEWGxcRk/tUUt9Img+cxuBtPzAiXt+nkvpK0mPAzxm8/f8QEZv2qaS+kfQUxaG1g7V9k4iY0p+K+qtuf/e171EDt0fEtoMtIOmGfhXTZz+IiC8PtoCkNftVTAV+FREfGWwBSWf3q5g+uy4idh1sAUm/71cxFajV330TetQTImLxyi5jZmOHpC0i4vYhlhkzf/e1D2oASaK4CmDrYlIPANdGAxovaXfgfSzf9p9HxK8rK6qPJG1OcbXHcvsvHOqPuA4krQ3swfJtv2SsjMuuDEmzI2I7Sb+LiHdUXc/Kqn1QS3oXcCowl2XXKNkQeC1wWERcWlVtvSbpZOD1wFkUVz2Eou0HAXMj4oiKSusLSUcDH6C4NG+5/QcA50bECVXV1muSDgK+CFzK8p/73YAvRcRZVdXWD2lY40fAocC/t8+PiG/0vaiV0ISgvh3YMyLmtU3fBPhlRGxRSWF9IOmuTjsK0xbGXRHxugrK6htJdwFbRcRzbdNXA26rc/vT1St3bO89S3oZcE1ddyC3SNqMYkvySOA77fMj4kt9LmmlNGFn4niW9abKHgBW7XMt/bZY0vYRcV3b9O2BMTE2t5JeBF4N3Nc2ff00r84EdOqFvcjgR0LUQkTcCZwo6eaI+FXV9aysJgT16cB1ks5l2Q0QNqLY/P1+ZVX1xzTgNEkTWfZltRHwtzSv7o4EfidpLst+95Mphr0Or6qoPvkqcL2kS1m+7bsBx1dWVf/9XtIHgSmU8m6oo6FyU/uhDyj2ANN5h9Kc6qrqH0mvotT2iHioynr6SdIqrLgj+bqIeKG6qvojDXPszoo7E5+orqr+kvRrio7JbGDp7zwivl5ZUSPQiKA2s2aSdGtEvKHqOlZWo6/1IWlG1TVURdL1VddQJUkXVV1DVSSN2ct9jsCfJb2x6iJWVqN71JL2johfVF2H9Z+k9SNiftV1VEHSdhExu+o6+kHSHIp9EvcCS0g7WSPiTZUWNkyNDuqmkLQey49RP1xlPVVoXaQnIh6vuhbrH0kdbxgbEe1HAmWt9kd9SBoPHALsS3GoFqSz84Dvtx9jWyeStqE4hnRtSic9SFpIcbJPrYc/JE0Gvga8A1hYTNJLgd8Dx7QfW18n6azEYymOJX4lxaF6j1B87k+o+9mJkl4aEU8CT1Vdy2iofY9a0jkUf6RnsvzZaQcDL4+I/Ssqreck3Qh8LCKuaZu+E/DdiNi6ksL6RNJVwMnAj1tHeUgaB+wHHBkRO1VYXk9JuoTiC+nM1lE+6eifg4F3RMS7qqyv1yRdFBHvkXQvxZdU+djxiIjXVFTaiDQhqDuenTfUvDqQNHegs+8k3R0Rr+13Tf00RPsHnFcHku6MiM2GO8/yVPuhD+BxSfsBP4mIF2HpsbX7AXU/nvRXki6muNZH+WSfg4AmXJRptqRTKbamyu0/GBgzl7gcofskfZ6iR/0wLN1XMY1l74WNEU3oUU8BTgR2ZVkwrwNcRjFOeW81lfWHpD3pfLJP7e5q0i5d0+MQOrSfYv/Ekqpq67V0sssxFG1/ZZr8MEXbT/RO1bGl9kFdJukVABHxWNW1mJl1q1EnvETEY+WQlrRblfX0mqRxkj4m6XhJb22b94Wq6uoXSWtI+rykz0maIOlgSRdK+pqktaqur99qfkeXWmtUj7qdpP8aK/dMGwlJ3wPWAK4FPgz8ISI+k+ZdHxHd3AB1zJJ0PsV47OrAZsDtwHnAe4FXRcSHKyyvpyTd3D6J4trkdwKMtRM+Rku67DHAtyPilEqLGYba70yUdOFAs4BX9LOWCuzQ+oOUdApwqqSfUlxMv/aXugReHxHvT9ffng+8MyJC0pXATRXX1mvzgCeBrwDPUvy+/wjsXWFNlYuILdIQ6Jg6NLP2QQ3sDHwIWNQ2vXV7rjpbrfUgIp4Hpks6juL42sZs+qdw/mXr1mvpea03JSPivZL2BWYCJ0XEhZKeG2tn5K2sTmflpuHPiyssa9iaENRXA89ExB/aZ6S7YNTZLEl7lO+PGBFflvQgcFqFdfXLLElrRcSi8t3IJW1KTc5YG0xEXJCuR328pEMofXHXXd3Oym30GLU1lyQ14ebGLZK2Bt4SESvclqqO6nZWroPazGqnbmflNmHow8yap1Zn5bpHbWa1VKezch3UDSRpfeDxOp9CPZimt9/GnkadmVgm6UxJp0ka8/dTG4EfAHdIOqnqQirS2PZLuj391P0u7AOSNL3qGoaryWPUpwCTKc7YO7riWvoqIt6ZTgLZsupaqtDk9o/VEz5G2Zg72ctDHzWXAmkHlh+nu7Yph6a5/b4NWx3UPqibfEsiSe8CTgXmUjron+Jmn4dFxKVV1dYPTW7/QCd8UNztaMyd8DESknan+Lsvf0n/vHwC2FjRhKBu7C2J0gVo9my/N6CkTYBfRsQWlRTWJ01uf91O+BguSSdTXITqLJa/Bd9BwNyIOKKi0kakCUHd2FsSSZoLbJGu81GevhowZ6wd9D9cTW5/3U74GK6BbrOXhsLuGmu3YWvCzsQm35LodOA6Seey/EH/BwDfr6yq/mly+2t1wscILJa0fURc1zZ9e2BxFQWtjCb0qBt9SyJJW9D5oP851VXVP01uf51O+BguSW+muPDYRJYNfWwE/A34RETMrqq2kah9UJtZc6X9UeWjXh6qsp6RauwJL7D0W7eRJM2ouoYqNbn9Y/GEj5GKiIciYnbqQX+q6npGqglj1IM5FPho1UVUZExt+vVAk9s/5k74GC5J3+ow+aDWvTIjYkyFtoc+zKx2JN0P/AG4lGVfTCcBRwFExJkVlTYijQjqdNLLHiy/U+WSOp/sAiBpPHAIsC/w6jT5AYqTfb4fEc9VVVs/uP31OeFjuCRNBI6nOIDgqIh4UNI9EfGaiksbkdoHtaSDgC9SfLOWz9DaDfhSRJxVVW29JukcijPRzmT5g/4PBl4eEftXVFpfNLn9dTvhY6QkbUfRk74YODwiplRb0cg0IajvBHZs7z2nw/au6XRQfF0MdND/UPPqosntr9sJHysjtfkwiluRfajqekaiCUd9iOL6Hu1epP47VR6XtJ+kpb9nSatI2h94osK6+qXJ7V8safsO08fkCR/DlcIZKO46HxHfbg/p8jK5a8JRH18Frk93Y26doTWZYujj+Mqq6o8DgBOBUyW1gmkd4LI0r+6a3P5pwGlprLb9hI9pFdXUT5dJ+gnFmPx/tSamywe8nWL46zLgjGrKG57aD33A0mGO3VlxZ2Lde1VLpWsQExGPVV1LFZra/rqc8DFckiYAHwEOBDah2FexOsUowqXAqRFxQ2UFDlPtg1qShrr2cDfL1I2k3SLiN1XX0WuSXgpMioi/tE1/U0TcXFFZfZFCmoh4SNIkYGfgjiacPl8maVVgXeDZsXqkVxPGqC+T9ElJk8sTJa0maVdJZ1JsBjVN3S9KhKT3A3cAP5F0W9uY7RnVVNUfkj4GXAVcLelQ4CJgL+ACSYdUWlyfRcRzETF/rIY0NKNHXatNoOGQdOFAs4BdI2LNftbTb+mazHtGxHxJO1AcqnZsRFwg6YaI2LbaCntH0i3AjhSf9fuA16ae9cuAyyJimyrrs+Gp/c7EiFhMcZePU+uwCTRMOwMfAha1TW/dnqruxkXEfICIuFbSPwEXSdqIzkcC1clzEfEM8Iykv7TGpiPiCUl1b3vt1D6oy9KZaPOrrqOPrgaeiYg/tM9Ix5fX3VOSNm2NT6ee9S7Az4CtKqyrH0LSqukzv1drYtrCbMKQZ63UfujDmkvS1hRfVHPbpq8KvD8iflhNZb2X9sk82OHuNhtQ3PXmt9VUZiPhoK6xph/x0uT2N7ntdeRNoHpr+hEvTW5/k9teO+5R19gAR7xMAMZR8yNeoNntb3Lb68hB3RANPOJlOU1uf5PbXhcOajOzzHmM2swscw5qM7PMOahtUJJekHSjpFsl/ULSOqO03ssl3SnpZkl3SDpltNad1r+LpLeWnn9cxd1+Vna9UyQ9m96TOZLOSmPAZj3joLahPBsR20TEG4DHgU+M4roPjIg3AW8CllDcy7BrKu6JOJBdgKVBHRHfGcXbrv0lXSvjjRS3t3r/KK3XrCMHtQ3HVaRrG6ce8dT0eF1J89LjaZJ+KunXkuZK+tpQK42IvwOfByZL2jr1Wm9tzZd0lKQZpdc9WdIs4AhJe0u6RtINkn4raT1JU4CPA59OPd+dJc2QdFRaxzaSrk69+QvShYpa6z5R0rWS7pK08xB1vwBcW3pPVqglTZ8h6fS0/nskfarUtn9LWxZXSjqnVOOm6T2cLemPkjZP0/dLWzc3SbpiqPfW6sFBbV2RNA54BzDQFfnKtgH2p+hx7q/iIkiDSqF3E7B5F+tfLSKmRsTXgSuBndKV8M4FPh8R84DvAP+etgb+2Pb/zwKOTr35WyhuftwyPiJ2AI5sm76CdKzyjkDrrt4r1FJafHOKm1fsAHxR0qoqLrv6z8DWwJ7A1NLyM4FPRsR2wFEUFxYDOA7YPSK2Bt47WH1WH426KJONyOoqLhe6AXA70M3NBn4XEX8DkDQH2Jhlt0EbTLf3sDuv9HhD4DxJ6wOrAfcO+gLS2sA6pQtVnQn8qLTIT9O/s4EpA6xm0/SebAJcXLoBwWC1XBwRS4Alkh4B1gPeRnGrqMUU9zj8RapxLYphmx9p2W39XpL+/RNwhqTzS7VazblHbUN5No3HbkwRpK0x6udZ9vmZ0PZ/lpQev0AXHYLUY38jxZdBed2d1v906fH/A06JiDcCH+uw7HC1ah+s7tYY9abAdpJaPdvBahnOe7IKsDBtDbR+tgCIiI8DX6C4/+FspVuMWb05qK0r6drGnwI+m3bizQO2S7P/ZWXWnY6a+D/A/al3+jDwSkmvkPQS4D2D/Pe1Ke6BCctfu+IpYGKHdvwNeKI0/vxhYIXLwHYjIh4FjgGOHaKWgfwJ2FvShNSLfk9a75PAvZL2g+LiSSquBIiKy7ZeExHHAQsoAttqzkFtXUvXhrgZ+ABwEnCopBsoTk8eiR9Kuhm4FVgT2Ce9znPAlyl21P2G4nZaA5lBMUQwG3i0NP0XwL6tnYlt/+dg4P+m194mvdZI/QxYI73GQLV0FBHXUYz53wz8imK8/G9p9oHAIZJuAm4jvTep7lvSztY/U4zrW835FHKzCklaKyIWSVoDuAKYHhHXV12X5cU7E82qNVPSlhTj2Wc6pK0T96jNzDLnMWozs8w5qM3MMuegNjPLnIPazCxzDmozs8w5qM3MMvffP+E5RpHyH3kAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.bar(f_vc.index.astype(str), f_vc['run_duration_ranges'].values)\n",
+    "\n",
+    "# set the x-axis label and title\n",
+    "plt.xlabel('Run Duration Ranges')\n",
+    "plt.title('Histogram of Run Duration Ranges')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# display the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "5d0e8b2e-9a18-4b4c-a77d-59c11eddcdc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_vc['prefix_sum'] = p_vc['run_duration_ranges'][::-1].cumsum()[::-1]\n",
+    "f_vc['prefix_sum'] = f_vc['run_duration_ranges'][::-1].cumsum()[::-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "5c013949-13c2-4666-9658-b195cfa731ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>109</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>84</td>\n",
+       "      <td>109</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>24</td>\n",
+       "      <td>25</td>\n",
+       "      <td>22.935780</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.917431</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, inf]</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.917431</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 10.0]                     0         109             100.000000\n",
+       "(10.0, 20.0]                   84         109             100.000000\n",
+       "(20.0, 30.0]                   24          25              22.935780\n",
+       "(30.0, 40.0]                    0           1               0.917431\n",
+       "(40.0, inf]                     1           1               0.917431"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(p_vc['prefix_sum'])\n",
+    "p_vc['prefix_sum_percentage'] = p_vc['prefix_sum'] / max_duration * 100\n",
+    "p_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "cef23e5d-fc91-4a5a-bde5-ee4c8408bece",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>5</td>\n",
+       "      <td>10</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>50.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 40.0]</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(40.0, inf]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 10.0]                     0          10                  100.0\n",
+       "(10.0, 20.0]                    5          10                  100.0\n",
+       "(20.0, 30.0]                    4           5                   50.0\n",
+       "(30.0, 40.0]                    1           1                   10.0\n",
+       "(40.0, inf]                     0           0                    0.0"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(f_vc['prefix_sum'])\n",
+    "f_vc['prefix_sum_percentage'] = f_vc['prefix_sum'] / max_duration * 100\n",
+    "f_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "41697171-5f0b-4a65-9fb2-1e3cce34198a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# join dataframes a and b on their index\n",
+    "joined = f_vc.join(p_vc, how='outer', lsuffix='_f', rsuffix='_p')\n",
+    "\n",
+    "total = joined[['prefix_sum_f', 'prefix_sum_p']].sum(axis=1)\n",
+    "joined['f_pct'] = joined['prefix_sum_f'] / total * 100\n",
+    "joined['p_pct'] = joined['prefix_sum_p'] / total * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "5405a153-c355-4cac-831b-0f4b62275fb4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAFHCAYAAABZIcA+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABTn0lEQVR4nO3dd5gTZdfA4d+hF+mg0hcBkd6WZgUbKNioCihVxc6nYtcX22t9FVGxgYoKIk2pKogggrQFUVQEFOkoCEiRtsD5/nhmIbtsSXY3O8nm3NeVazczyczJJJmTeaqoKsYYY0wo8vgdgDHGmOhjycMYY0zILHkYY4wJmSUPY4wxIbPkYYwxJmSWPIwxxoTMkocJiYicJyKrAu6vE5GLs3H7P4tI6+zaXpD7FBF5T0R2icjiNB7zlIj8LSJ/BrG9N0XkUe//1iKyKWBdjr++zBARFZEafscB0XPMAERkjoj0z+RzPxeRXtkdU7jk8zuAtIjIOuA04CjwL/A5cLuq7vMzriQiMhiooao9/Y4lu4iIAjVV9be0HqOq3wK1sml/7wObVPWRgO3XzY5th+hc4BKgkqr+m3KliFQB7gGqquq2jDamqgPSWefH64tq4TpmItIb6K+q52by+YPJxnOAql6WHdvJKZF+5XGFqp4CNAHigUcyeHwy3i/KSH+NUUNEIvbHRhZVBdalljg8VYAdwSQOY8IhIr97qhqRN2AdcHHA/ReAqd7/LYHvgH+AH4DWAY+bAzwNzAcOADWAusBMYCfwF/CQ99g8wAPA78AOYCxQ2lsXByjQC9gA/A087K1rBxwGEoF9wA/e8j7ASmAvsBa4OcVrug/YCmwB+nvbr+GtKwi86O3rL+BNoHA6x+fGgH39AjTxltf2jsE/wM/AlQHPeR94HZjmPW8RUN1bN9eL51/vNXUDWgObgPuBP4EPk5aleJ8e9GLYBbwHFPLW9QbmpYhbvffkJu/4Hfb2NyXl++4dkyHe8dri/V/QW5cU2z3ANu+49knneFUAJnufgd+AG73l/YCDuCvcfcDjKZ53Me5zdMxb/763fJx3THZ7x65uiuP8VGCcqX2ugcG4z9wH3vvxMxAf8NgmwPfeunHAJ0nbTeX1VQe+xn2O/wZGASVT7Pde4Ecv5k+S3idv/SBOfDb7EvDZTGVfc4BngMXAHmAS3vcmiGNzufdZ2QtsBu71lpcFpuI+tzuBb4E84TpmuO9J4Pv+j7e8hLft7cB63A/WPKk8P61zwBzgSdz5Zy8wAygb8LyMzl39A74784GXvfc0tdfQHEjw3oO/gJdS+8ylcQzHAR95Ma4AzsR9j7cBG4FLMzxHh+vkn9Vbihdb2fuQPAlU9A7m5biT/yXe/XIBb8AGXMLIBxTDfSnuAQp591t4j70LWAhUwp2o3gI+9tbF4b5A7wCFgYbAIaB2wBvwUYqY2+O+xAJcAOznxEm9He4LVRco4r1xgcnjZdzJrbQX4xTgmTSOTRfcF6+Zt68auF/P+XEnxoeAAsCF3oejVsBJbYf3ocuHO8GMCdhushOG9yE8AjznHZ/CKT+Y3vv0k/celcZ94JNOnL1JI3mkPMmm8b4/4b0/pwLlcF+6J1PE9oT3ui/3jnepNI7ZXGCY9xlohDs5XJhWnCmem+w1e8v6eu9TUoJbHrDu+OtK43gFfokPerHnxZ2QF3rrCuBOXnd5r68j7mSVVvKogfsuFPSO1VxgSIr9LsYl0dK4Hx4DAj6bfwH1gKLA6JSfhRT7moP7/CU9fgIB34UMjs1W4Dzv/1Kc+H48g/vBlN+7nQdImI/ZSe87LnFM8uKPA1YD/dJ4/mBOPgfMwf0YPRP3fZkDPOutC+bcFZg8jgB34L6rJ/2QBBYA13v/nwK0TOfzmtoxbOtt+wPgD+Bh77jdCPyR4Tk6syf3cN+8F7sPl6HX4774hXG/gj9M8dgvgV4Bb8ATAeuuA75PYx8rgYsC7pfH/ZLIx4nkUSlg/WLg2rQ+OKls/zPgLu//dwlIBrgve9KvcMH94q8esL5VWm+g93rvSmX5ebgElSdg2cfAYO//94HhAesuB34NuJ9a8jhM8l+oyT6Y3vs0IMU2fw/4AmQlefwOXB6wri2ueCkpjgNAvoD12/C+QCm2WRn3C7NYwLJnOHEVcVKcKZ6f7DWnsr6k97pKpHxdaRyvwC/xVwHr6gAHvP/Px52gJWD9vJTHK52Yribgc+/tt2fA/eeBNwM+m88GrDsz5WchxbbnpHh8He9zkjeIY7MBuBkonuJxT+BO2iftM1zHLOX7jktGh4E6ActuBuak8fzBpJ48Hgm4fyvwhfd/MOeuwOSxIYP3eC7wOAFXNml9XlM5hjMD1l2BO9fm9e4X896zkuntP9LrA65W1ZKqWlVVb1XVA7hf2F1E5J+kG67Cs3zA8zYG/F8ZdxJKTVXg04DtrMSdZE4LeExg65r9uAyfKhG5TEQWishOb3uX4y7Hwf3iC4wr8P9yuKuRpQGxfOEtT01ar6kCsFFVjwUsW4/7xRPy6/FsV9WDGTwm8LWs9+LIDhW87aW17R2qeiTgflqvpwKwU1X3pthWxVQemyERySsiz4rI7yKyB/fFhBPvdShSvh+FvPLtCsBm9b7Nno2kQUROE5ExIrLZi+mjVOJJ671P+dkMPOZpSfn4/EDZII5NJ9z3Yr2IfCMirbzlL+CummeIyFoReSCdfWfLMUtFWe91pPzMhfo5Ses4B3PuCpRR7P1wif5XEVkiIh1CiPGvgP8PAH+r6tGA+5DBuSHSk0dqNuKyd8mAW1FVfTbgMSk/PGeks63LUmyrkKpuDiKOwH0gIgVxl+8vAqepaklgOu6qAtzleqWAp1QO+P9v3BtWNyCOEuoaC6QVd/VUlm8BKqdoJFAF92ssszTjhyR7LVW8OMBdTRVJWiEip4e47S24L1xq2w7FFqC0iBRLsa3MHpfuwFW4+pASuKtUOPFeZ4etQEURCdxm5bQeDPwXdzzrq2pxoGcI8Wzl5PcwIykfn4j7HKd7bFR1iapehSuK/AxXf4Gq7lXVe1T1DOBK4G4RuSjI+ANfRyjHLOXn72/vdaT8zKX1OQnmuxEomHNX0NtX1TWqeh3uWD4HjBeRopz8vctL2j9EMy0ak8dHwBUi0tb7lVPIa0tfKY3HTwXKi8hAESkoIsVEpIW37k3gaRGpCiAi5UTkqiDj+AuICzhRF8CV8W4HjojIZcClAY8fC/QRkdoiUgR4NGmFd6XwDvCyiJzqxVJRRNqmse/hwL0i0tRrUVbDew2LcL907hOR/F7b+CuAMSG8prQSbXpuE5FKIlIaV276ibf8B6CuiDQSkUK4y+VQ9vcx8Ij3vpQFHsO9/yFR1Y24+pJnvM9LA9yvtpC35SmGq//agfuS/jeT20nPAtxV8O0iks/7XDbPIKZ9wG4RqYirAA/WWKC3iNTxPpv/CeI5PQMe/wQw3vvlmuaxEZECItJDREqoaiKuoveYt66D9zkWXEX70aR1IQj1mP0FVBKRAgBe/GNx54Ri3nfqbtL+nKQ8B2Qk1HNXukSkp4iU884f/3iLj+HqaQqJSHsRyY+r9C+YmX2kJ+qSh3ciuApXKbwdl80HkcZr8YoqLsGdRP8E1gBtvNWv4CqpZ4jIXlzlbIvUtpOKcd7fHSKyzNvPnbgP3y7cL7DJAXF8DgwFZuMuzxd6qw55f+9PWu5d7n9FGv0pVHUcrkXZaFyF+Ge41i6Hvdd5Ge5X1DDgBlX9NcjXNBgY6V1Sdw3yOXhxzMC1MPsdeMqLczXuxPIV7rjPS/G8EUAdb3+fpbLdp3CtSX7EtQhZlrTtTLgO9yt4C/Ap8B9V/SqT2/oAV5yxGddyaGH6Dw+d9152xCW5f3BXElM58XlJ6XFcS6PduNZ0E0PY1+e4iu2vcZ/Br4N42oe4up0/cY0Q7vSWZ3RsrgfWeZ/xAUAPb3lN3OdkHy4JDFPV2cG+Bu91hHrMvsY1xPlTRP72lt2B++W+Fvd5HY2rE0pNsnNAEPGFdO4KQjvgZxHZhzuXXauqB1R1N66uZTjuffgX1zIxWyW1ZjA5TERq41opFUxRbm9MqkRkEa6S+z2f45iDqyge7mccwYiUY5YbRd2VRzQTkWu8orNSuDLKKZY4TFpE5AIROd0rgukFNMA1pDBpsGOWcyx55Kybcc1Jf8eVzd7ibzgmwtXC1Rv9g+un1FlVt/oaUeSzY5ZDrNjKGGNMyOzKwxhjTMgseRhjjAlZ5I3UGIKyZctqXFyc32EYY0xUWbp06d+qmqWOg1GdPOLi4khISPA7DGOMiSoiEswQNOmyYitjjDEhs+RhjDEmZJY8jDHGhMyShzHGmJCFLXmIyLsisk1EfgpYVlpEZorIGu9vKW+5iMhQEflNRH4UkSbhissYY0zWhfPK433cqI+BHgBmqWpNYJZ3H9wosDW9203AG2GMyxhjTBaFLXmo6lzcRPaBrgJGev+PxE2VmbT8A3UWAiVFJK3ZtYwxJqZFwrBSOV3ncVrAIGV/cmK614okn3JxE5mcItQYY3Kz3Qd303x4c6avme5rHL5VmHvzDIecPkXkJhFJEJGE7du3hyEyY4yJTKpK70m9Wf7nckoULOFrLDmdPP5KKo7y/m7zlm8m+VzDlUhj3mBVfVtV41U1vly5bJ+W1xhjItb/FvyPz379jOcvfp5zqpzjayw5nTwmA728/3sBkwKW3+C1umoJ7LYx+I0x5oS56+fywFcP0LlOZwa2HOh3OOEb20pEPgZaA2VFZBPwH+BZYKyI9MPNc5w0T/Z04HLc/Mn7gT7hissYY6LNn/v+pNv4blQvXZ0RV45ARPwOKXzJQ1WvS2PVRak8VoHbwhWLMcZEqyPHjnDt+GvZfXA3M3rOoHjB4n6HBET5qLrGGJPbPTzrYb5Z/w0fXP0B9U+r73c4x9nwJMYYE6Em/TqJ5797ngFNB3B9w+v9DicZSx7GGBOBft/5O70+60V8hXiGtBvidzgnseRhjDER5kDiATqN7UQeycO4LuMomK+g3yGdxOo8jDEmwtw+/XZ++OsHpnWfRlzJOL/DSZVdeRhjTAR59/t3eXf5uzxy3iNcXvNyv8NJkyUPY4yJEMv/XM5t02/j4jMuZnDrwX6Hky5LHsYYEwH+OfgPncZ2okzhMozuOJq8efL6HVK6rM7DGGN8pqr0/qw3G3ZvYG7vuZQrGvnj9lnyMMYYn73w3QtMWjWJIW2H0KpyK7/DCUpMJo9dB3bx9/6//Q4jqhTMV5DKxStHxJg6xuQm36z7hgdnPUjXul25s8WdfocTtJhMHsOXDee+r+7zO4yoU6ZwGZpXbE6Lii1oUakFzSs2p3Th0n6HZUzU2rp3K93Gd6Nm6ZoMv2J4VP04i8nk0f7M9lQoVsHvMKLKnkN7SNiSwKLNi/jity9Qbx6vGqVruGTiJZRGpzeiQN4CPkdrTORLPJpIt/Hd2Ht4L7NumEWxgsX8DikkMZk86pSrQ51ydfwOI2odTySbFrF4y2K+/uNrRq0YBUCBvAVofHrj48mkRcUWnFHqjKj6RWVMTnho1kN8u+FbPrrmI+qeWtfvcEImkTCRembFx8drQkKC32HEPFVl055NLNq8iEWbFrFo8yIStiRw4MgBAMoWKXuiuKuiK+4qVbiUz1Eb459PV35Kx7EduTX+Vl5v/3qO719ElqpqfJa2YcnDhMORY0f4adtPx5PJos2LWLl95fHirjPLnJmsuKvBaQ2suMvEhDU71hD/TjxnlT2Lub3n+jJuVY4kDxFJrUZ0r6omZmXH2cGSR3TZfXD38XqTpKuUv/79C4CCeQvSpHyTZMVdcSXjrLjL5Cr7E/fTakQrNu3ZxLKbllG1ZFVf4sip5LEOqAzsAgQoCfwJ/AXcqKpLsxJAVljyiG6qyobdG5IVdy3dupSDRw4CUK5IueOJpEXFFjSr2IyShUr6G7QxmaSq9J3cl5HLRzK9x3Ta1WjnWyzZkTyCqTCfCYxX1S+9nV4KdALeA4YBLbISgIldIkLVklWpWrIqXeu66ewTjyayYtuKZMVdU1dPPf6cWmVqJUsoDU5rQP68+f16CcYEbcT3I3h/+fs8dv5jviaO7BLMlccKVa2fYtmPqtpARJaraqNwBpgeu/KIDbsP7mbJliXJEsq2f7cBUChfoRPFXV6RV9USVa24y0SUZVuXcfaIs7kg7gKmd5/u+7hVOVVsNQOYBYzxFnUDLgHaAUtUtUlWAsgKSx6xSVVZv3t9smSybOuy48VdpxY9NVkyaVahGSUKlfA5ahOrdh3YRdO3m5J4LJHvb/6eskXK+h1SjhVbdQf+A3zm3Z/vLcsLdM3Kzo3JDBEhrmQccSXj6FavG+CKu37868dklfFTVk9xj0c4q+xZyYq76p9Wn3x5YrKbk8lBx/QYvT7rxaY9m5jbZ25EJI7sYk11Ta6168Cuk4q7ksY0K5yvME0rNE12hWJjd5ns9uy8Z3lw1oMMbTeUO1rc4Xc4x+VUsdWZwL1AHAFXKqp6YVZ2nB0seZhQqCp//PPH8WSyePNilm1dxqGjhwA4/ZTTkyWT+ArxFC9Y3OeoTbSa/cdsLv7wYrrW7crojqMj6odJTiWPH4A3gaXA0aTlfjbRTWLJw2TV4aOHXXFXwNXJ6h2rAVfcVbtc7WQJpd6p9ay4y2Ro857NNHm7CaULl2bJjUs4pcApfoeUTE4lj6Wq2jQrOwkXSx4mHHYe2MmSzUuS1Z/sOLADgCL5i9C0fNNknRkrFa8UUb8qjb8SjybSZmQblv+5nMU3Lo7IcfRyqsJ8iojcCnwKHEpaqKo7s7JjYyJV6cKlaVujLW1rtAVccdfaXWuTdWYcungohxccBqD8KeWTVcbHV4iPuhFSTfZ54KsHmL9xPqM7jo7IxJFdgrny+COVxaqqZ4QnpODZlYfxy6Ejh/jhrx+SFXf9tvM3wBV3NTq9EW91eItmFZv5HKnJSRN+mUDncZ25rdltvHb5a36HkyYbGNGSh4kgO/bvON66673l77Ht32183OljrjrrKr9DMzlg9Y7VxL8dT51ydfim9ze+DHgYrLAmDxG5UFW/FpGOqa1X1YlZ2XF2sORhItVf+/7iyjFXsmTzEl5u+zJ3tbzL75BMGO1P3E/L4S3ZsncLy25eRpUSVfwOKV3hrvO4APgauCKVdQr4njyMiVSnnXIas3vNpufEngz8ciBrd63lpbYv+T4shcl+qsot027hp20/8UXPLyI+cWSXNJOHqv7H+9snu3cqIv8H9McloRVAH6A8bgiUMrhmwder6uHs3rcxOaVI/iKM6zKOQTMH8fLCl1m3ex2jO46maIGifodmstE7y97hgx8+YPAFg7m0+qV+h5Nj0iu2uju9J6rqS5naoUhFYB5QR1UPiMhYYDpwOTBRVceIyJvAD6r6RnrbsmIrEy1eX/w6d35xJ41Pb8zU7lM5/ZTT/Q7JZIOlW5Zy9rtn0yauDdN7TCeP5PE7pKBkR7FVeq+0WAa3rMgHFBaRfEARYCtwITDeWz8SuDqL+zAmYtzW/DYmXTuJlX+vpMXwFvy87We/QzJZtPPATjqP68xpRU/jo44fRU3iyC7pFVs9Ho4dqupmEXkR2AAcAGbgiqn+UdUj3sM2ARXDsX9j/NLhzA7M7T2XDh934Jx3z2FC1wlcdMZFfodlMuGYHuOGT29g857NzOs7L1cNeBisNFOliNzn/X1VRIamvGV2hyJSCrgKqAZUAIrihncP9vk3iUiCiCRs3749s2EY44umFZqyqP8iKhWvRLtR7Xh/+ft+h2Qy4dl5zzJtzTRebvsyzSs29zscX6R3nbXS+5uAuzJIecusi4E/VHW7Nw/6ROAcoKRXjAVQCdic2pNV9W1VjVfV+HLlymUhDGP8UaVEFeb3nU/ruNb0mdSHx2Y/RjT3t4o1s9bO4tHZj3Jdveu4tdmtfofjm/SKraZ4f0dm8z43AC1FpAiu2OoiXIKaDXTGtbjqBUzK5v0aEzFKFCrB9O7TGTB1AE/OfZI//vmD4VcMj+iOZcYNeHjdhOuoVaYWb1/xdkyPaZbh2FYiUg64H6gDFEpantkh2VV1kYiMB5YBR4DvgbeBacAYEXnKWzYiM9s3Jlrkz5uf4VcO54xSZ/DI7EfYuHsjn3b7lFKFS/kdmklF4tFEuo7vyv7E/UzoOiHiRsrNacE0DxiFK8KqBjwOrAOWZGWnqvofVT1LVeup6vWqekhV16pqc1WtoapdVPVQxlsyJrqJCA+f/zCjOo5iwaYFtBrRirW71vodlknFfTPv47uN3zHiyhHULlfb73B8F0zyKKOqI4BEVf1GVfvimtUaY7JJ9/rdmXn9TLb9u42Ww1uyaNMiv0MyAcb9PI4hi4ZwR/M7jk99HOuCSR6J3t+tItJeRBoDpcMYkzEx6fyq57Og3wKKFSxG65GtmbjSRgCKBKv+XkXfyX1pWaklL176ot/hRIxgksdTIlICuAc3He1w4P/CGpUxMapW2Vos7LeQRqc3ovPYzry04CVrieWjfw//S6exnSiUrxDjuoyjQN4CfocUMdLr5/Gc929hVd2tqj+pahtVbaqqk3MoPmNiTrmi5fj6hq/pWLsj98y4h9un386RY0cyfqLJVqrKgGkD+GX7L4zuOJpKxSv5HVJESe/K43Jx7dAezKlgjDFO4fyFGdtlLPe2updhCcO4eszV7Du8z++wYspbS9/iox8/4vHWj3NJ9Uv8DifipJc8vgB2AQ1EZE/Aba+I7Mmh+IyJWXkkDy9c+gLDLh/G5799zvnvnc+WvVv8DismJGxJ4K4v7uKyGpfx8PkP+x1OREozeajqIFUtCUxT1eIBt2KqWjznQjQmtt3S7BamXDeF1TtW03J4S1b8tcLvkHK1Hft30HlsZ04/5XQ+vObDmBvwMFgZHhVVtTk0jfHZ5TUv59s+33Lk2BHOfe9cZv4+0++QcqVjeozrP72erfu2Mr7LeMoUKeN3SBHLUqoxUaJx+cYs6r+IqiWqcvnoyxmxzAZhyG5Pz32az3/7nCFth9CsYjO/w4loljyMiSKVS1RmXt95XFjtQvpP6c8jXz9iTXmzyczfZ/KfOf+hR/0eDIgf4Hc4ES/d5CEieUVkVE4FY4zJWPGCxZl63VT6N+7P098+TY+JPTh0xEbzyYqNuzfSfWJ36pSrw1sd3orpAQ+Dle7AiKp6VESqikgBm0/cmMiRP29+3r7ibaqXrs6Dsx5k055NfNrtUyujz4TDRw/TdXxXDh45yISuE2yO+SBlOKousBaYLyKTgX+TFmZ2DnNjTPYQER449wHiSsbR67NetBrRis97fE710tX9Di2qDJoxiIWbFjK281hqla3ldzhRI5g6j9+Bqd5js2sOc2NMNrm23rXMumEWOw7soOWIlizYuMDvkKLGJz99wtDFQ7mrxV10qdvF73CiigRb2SYipwCoasR0c42Pj9eEhAS/wzAmIqzZsYbLRl3Gpj2b+PCaD+1kmIFf//6VZu80o8FpDZjda3ZMjVslIktVNT4r28jwykNE6onI98DPwM8islRE6mZlp8aY7FezTE0W9FtA0wpN6Tq+Ky/Mf8FaYqVh3+F9dBrbicL5CjO289iYShzZJZhiq7eBu1W1qqpWxY2u+054wzLGZEa5ouWYdcMsutbtyn1f3cet0261QRVTUFVunnozv/79Kx93+piKxSv6HVJUCqbCvKiqzk66o6pzRMSaIxgToQrlK8THnT6mWslqPDf/OdbvXs8nnT+hWEGrqgR4I+ENRq8YzVNtnuKiMy7yO5yoFcyVx1oReVRE4rzbI7gWWMaYCJVH8vDsxc/yVoe3mPH7DM5//3w279nsd1i+W7x5MQO/GEj7mu158DwbMDwrgkkefYFywERgAlDWW2aMiXA3Nb2Jqd2n8tvO32gxvAU//PmD3yH55u/9f9NlXBcqFq/IB9d8YAMeZlEwAyPuUtU7VbWJNxHUQFXdlRPBGWOyrl2NdszrMw+Ac987ly9/+9LniHLe0WNH6TmxJ3/u+5NxXcZRurDNpJ1VlnqNiQENT2/Iwv4LqV6qOu1Ht+ftpW/7HVKOemruU3z5+5cMbTeU+ApZaqFqPJY8jIkRlYpX4ts+33JJ9Uu4eerNPPDVAxzTY36HFXZf/vYlj3/zONc3uJ6bmt7kdzi5hiUPY2JIsYLFmHLdFG5uejPPzX+O6yZcx8EjB/0OK2w27N5Aj4k9qHtqXd7s8KYNeJiNMmyqKyJDU1m8G0hQ1UnZH5IxJpzy5cnHG+3foHqp6tz31X1s3rOZz679jLJFyvodWrY6fPQwXcd15fDRw0zoOoEi+Yv4HVKuEsyVRyGgEbDGuzUAKgH9RGRI2CIzxoSNiDDonEGM7TyWhC0JtBrRijU71vgdVra658t7WLR5Ee9e9S5nljnT73BynWCSRwOgjaq+qqqvAhcDZwHXAJeGMzhjTHh1qduFr3t9za4Du2g1ohXzN8z3O6RsMeanMby25DX+r+X/0blOZ7/DyZWCSR6lgFMC7hcFSqvqUcBmoDEmyp1d+WwW9l9I6cKlueiDi/jkp0/8DilLftn+C/0n9+ecyufw3MXP+R1OrhVM8ngeWC4i74nI+8D3wAveECVfhTM4Y0zOqFG6Bgv6LaBZxWZcO+Fanpv3XFQOqrjv8D46j+1M0QJFGdtlLPnz5vc7pFwrwwpzVR0hItOB5t6ih1R1i/f/oLBFZozJUWWKlGHm9TPpM6kPD8x6gN93/c7rl78eNSdgVeXGKTeyascqvrr+KyoUq+B3SLlasE118wDbgV1ADRE5Pys7FZGSIjJeRH4VkZUi0kpESovITBFZ4/0tlZV9GGNCVyhfIUZ1HMVD5z7EO8ve4YqPr2DPoT1+hxWU15e8zpifxvBUm6doU62N3+HkehlOBiUizwHdcPN5JPUoUlW9MtM7FRkJfKuqw0WkAFAEeAjYqarPisgDQClVvT+97dhkUMaEz/BlwxkwdQB1ytVheo/pVCpeye+Q0rRw00LOf+982tZoy6RrJ9m4VRnIjsmggkkeq4AGqpotleMiUgJYDpyhATv39tNaVbeKSHlgjqqmO6GwJQ9jwmvG7zPoPLYzxQoWY1r3aTQ6vZHfIZ1k+7/bafJ2E/Lnyc/Sm5ZSqrAVWmQkR2YSxA2/np2FntVwRWDvicj3IjLcq3w/TVW3eo/5EzgtG/dpjMmES6tfyvy+88kjeTjvvfOYvma63yElc/TYUXpM7MH2f7czvut4Sxw5KJjksR/X2uotERmadMvCPvMBTYA3VLUx8C/wQOADvCuSVC+JROQmEUkQkYTt27dnIQxjTDDqn1afRf0XUbN0Ta74+AreTHjT75COe+KbJ5i5diavXvYqTco38TucmBJM8pgMPAl8BywNuGXWJmCTqi7y7o/HJZO/vOIqvL/bUnuyqr6tqvGqGl+uXLkshGGMCVaFYhWY22cu7Wq045Zpt3DfzPt8H1Txi9++4Mm5T9KrYS/6N+nvayyxKJimuiOzc4eq+qeIbBSRWqq6CrgI+MW79QKe9f7auFnGRJBTCpzCpGsncefnd/LCdy/wxz9/8MHVH1A4f+Ecj2X9P+vpMbEH9U+rz7D2w2zAQx+kmTxEZKyqdhWRFSQvQhJcyVKDLOz3DmCU19JqLdAHdxU0VkT6AeuBrpnZcGJiIps2beLgwdw7UqhJW6FChahUqRL580dH34Roky9PPl6//HWql6rOoJmD2LRnE5OvnUy5ojlXCnDoyCG6jOvCkWNHGN9lvA146JP0rjzu8v52yO6dqupyILWa/izPRr9p0yaKFStGXFyc/RqJMarKjh072LRpE9WqVfM7nFxLRLjn7HuIKxlHz0970nJES6Z3n06tsuk2jsw2d395N0u2LGFC1wnULFMzR/ZpTpZmnUdAy6e/gY2quh4oCDQEtqT1PL8dPHiQMmXKWOKIQSJCmTJl7Kozh3Sq04nZvWaz99BeWo1oxbfrvw37PkevGM2whGHc0+oeOtbuGPb9mbQFU2E+FygkIhWBGcD1wPvhDCqrLHHELnvvc1bLSi1Z2H8hpxY9lYs/vJjRK0aHbV8/b/uZG6fcyHlVzuOZi54J235McIJJHqKq+4GOwDBV7QLUDW9YJjsMGTKE/fv3h/Scb7/9lrp169KoUSMOHDiQbN3QoUOpXbs2PXr0SPP5CQkJ3HnnnQC8//773H777aEHbqLKGaXO4Lt+39GyUkt6TOzB03OfzvZBFfce2kunsZ0oVqAYn3T+JGrG28rNgkoeItIK6AFM85blDV9Ise3IkSPZtq3MJI9Ro0bx4IMPsnz5cgoXTt6KZtiwYcycOZNRo0al+fz4+HiGDs1cN6DsfO0mZ5UuXJoZPWfQvX53Hpn9CP0n9yfxaGK2bFtV6T+lP2t2rmFM5zGUL1Y+W7ZrsiaY5DEQeBD4VFV/FpEzgNlhjSqKrVu3jrPOOosePXpQu3ZtOnfufPwEvnTpUi644AKaNm1K27Zt2brVVSu1bt2agQMHEh8fzyuvvMKSJUs4++yzadiwIc2bN2fv3r0cPXqUQYMG0axZMxo0aMBbb70FwJw5c2jdujWdO3c+vl9VZejQoWzZsoU2bdrQps3Jg8TNmjWLxo0bU79+ffr27cuhQ4cYPnw4Y8eO5dFHHz3p6mLAgAGsXbuWyy67jJdffpnFixfTqlUrGjduzNlnn82qVauOx9Ohw8ltLHr37s348eOP3z/llFOOP/68887jyiuvpE6dOmm+ThP5CuYryEfXfMQj5z3Cu8vfpf3o9uw+uDvL23118auM/Xks/73wv7SOa531QE32UNWgb7hkUzyU54Tz1rRpU03pl19+OWlZTvrjjz8U0Hnz5qmqap8+ffSFF17Qw4cPa6tWrXTbtm2qqjpmzBjt06ePqqpecMEFesstt6iq6qFDh7RatWq6ePFiVVXdvXu3JiYm6ltvvaVPPvmkqqoePHhQmzZtqmvXrtXZs2dr8eLFdePGjXr06FFt2bKlfvvtt6qqWrVqVd2+fftJMR44cEArVaqkq1atUlXV66+/Xl9++WVVVe3Vq5eOGzcu1dcWuL2kuFRVZ86cqR07dlRV1dmzZ2v79u1VVfW9997T2267LdXtFi1a9PjjixQpomvXrlVVTfN1hsLvz4BRHbFshOZ7Ip/WG1ZP1/+zPtPbmb9hvuZ7Ip9e+fGVeuzYsWyMMLYBCZrF82+GnQRFZDQwADgKLAGKi8grqvpCGHNa9hg4EJYvz95tNmoEQ4ak+5DKlStzzjnnANCzZ0+GDh1Ku3bt+Omnn7jkkksAOHr0KOXLn7j87tatGwCrVq2ifPnyNGvWDIDixYsDMGPGDH788cfjv953797NmjVrKFCgAM2bN6dSpUpeeI1Yt24d5557bprxrVq1imrVqnHmmW5e5169evH6668zcODAoA/D7t276dWrF2vWrEFESEzMfBFF8+bNjzetTet1WtPb6NK3cV+qlKhCp7GdaDG8BdO6Twt5+JBt/26j67iuVClRhZFXj7TGEBEmw+QB1FHVPSLSA/gcNw7VUiDyk4dPUn7IRQRVpW7duixYsCDV5xQtWjTdbaoqr776Km3btk22fM6cORQsWPD4/bx58+ZI3cGjjz5KmzZt+PTTT1m3bh2tW7dO9/H58uXj2DE3nMWxY8c4fPjw8XWBrz2t12miz8VnXMz8vvNpP7o95793PmM6j6HDmcF1Gzt67CjdJ3Tn7/1/s6DfAkoWKhneYE3Igkke+UUkP3A18JqqJopIdMxPmcEVQrhs2LCBBQsW0KpVK0aPHs25555LrVq12L59+/HliYmJrF69mrp1kzdcq1WrFlu3bmXJkiU0a9aMvXv3UrhwYdq2bcsbb7zBhRdeSP78+Vm9ejUVK1ZMN45ixYqxd+9eypYte9I+1q1bx2+//UaNGjX48MMPueCCC0J6jbt37z6+//fffz/Dx8fFxbF06VK6du3K5MmT07xSSet1ZpRcTWSqd2o9FvZbSIePO3DVmKsY2m4otzW/LcPnDZ4zmFl/zGL4FcNpXL5xDkRqQhVMhflbwDqgKDBXRKoC0TG1mE9q1arF66+/Tu3atdm1axe33HILBQoUYPz48dx///00bNiQRo0a8d1335303AIFCvDJJ59wxx130LBhQy655BIOHjxI//79qVOnDk2aNKFevXrcfPPNGV5h3HTTTbRr1+6kCvNChQrx3nvv0aVLF+rXr0+ePHkYMGBASK/xvvvu48EHH6Rx48ZBXenceOONfPPNNzRs2JAFCxakmQwy8zpNZCtfrDzf9P6G9jXbc/vnt3PPl/ekO6ji9DXTeerbp+jTqA/9mvTLwUhNKDKcDCrVJ4nkU1Xfv9GpTQa1cuVKateu7VNErrVVhw4d+Omnn3yLIdb5/RkwqTt67CgDvxjIa0teo2Ptjnx4zYcnjUu17p91NHmrCVVKVGFBvwW+DLoYC7JjMqhgiq0Qkfa4joGFAhY/kZUdG2NiS948eRl62VCql67O3V/eTZs9bZhy3RROLXoqcGLAw6N6lPFdx1viiHAZFluJyJu4OczvwI2o2wWoGua4olZcXJxddRiTBhFhYMuBTOg6gRV/raDl8Jb8+vevAAz8YiAJWxIYefVIapSu4XOkJiPB1Hmcrao3ALtU9XGgFXBmeMMyxuRm19S+hjm95/Bv4r+0GtGKQTMG8ebSNxl09iCuPutqv8MzQQgmeSQNcLRfRCoAiYCND2CMyZLmFZuzsN9CTpdivLjgRc4v3oD/XvRfv8MyQQqmzmOqiJTE9etYhpsY6p1wBmWMiQ3VPp3Nd09u4Y3G0H/dJvJ13gqVK/sdlglChlceqvqkqv6jqhNwdR1nqepj4Q/NGJNrqcKjj0K/fpRqdSEP/W8xp/6TCF26QEAHUhO5gqkwLyQid4vIRGA00FdECmX0POO/7B6SPVy2bNlC586dc2RfJgIcOgQ9e8JTT0G/fjBtGjRrBu++C4sWwb33+h2hCUIwdR4f4Jrpvgq8BtQBPgxnULEskodkD5cKFSokG3HX5GI7d8Ill8Do0fD00/DOO5A033znzm48uldfhTFjfA3TBCGjkROBX4JZ5sctUkfVrVWrlnbv3l3POuss7dSpk/7777+qqpqQkKDnn3++NmnSRC+99FLdsmWLqrpRde+66y5t2rSpvvjii7p48WJt1aqVNmjQQJs1a6Z79uzRI0eO6L333qvx8fFav359ffPNN1XVjUp7wQUXaKdOnY7v99ixY/rKK69o/vz5tV69etq6deuT4vzqq6+0UaNGWq9ePe3Tp48ePHhQ33nnHS1VqpTGxcVp9+7dg35djz/+uMbHx2vdunX1xhtvPD766SuvvKK1a9fW+vXra7du3VRVdc6cOdqwYUNt2LChNmrUSPfs2aN//PGH1q1bV1XdSLzXXHONtm3bVmvUqKGDBg06HsPw4cO1Zs2a2qxZM+3fv//xEXtT8vszYNLw22+qtWqpFiigOnp06o85fFj17LNVixZVtfcxbMiGUXWDSR4fAS0D7rcAPsjqjrPjFqnJg1w4JHtar0tVdceOHccf17NnT508ebKqqpYvX14PHjyoqqq7du1SVdUOHToc38bevXs1MTHxpORRrVo1/eeff/TAgQNapUoV3bBhg27evFmrVq2qO3bs0MOHD+u5555rySOafPedatmyqqVLq86dm/5jN21SLVdOtXZt1b17cya+GJMdySOY1lZNge9EZIN3vwqwSkRWuAsXbZCNF0LZauAXA1n+5/Js3Waj0xsxpN2QdB+TW4dkT+113XvvvcyePZvnn3+e/fv3s3PnTurWrcsVV1xBgwYN6NGjB1dffTVXX301AOeccw533303PXr0oGPHjsfjDnTRRRdRokQJAOrUqcP69ev5+++/ueCCCyhdujQAXbp0YfXq1enGayLEhAmujqNiRZg+Hc7MoJtYxYrw8cdw6aVw000wahTYcOwRJ5jk0S7sUeQyuXVI9tRe18GDB7n11ltJSEigcuXKDB48mIMHDwIwbdo05s6dy5QpU3j66adZsWIFDzzwAO3bt2f69Omcc845fPnllxQqlLz9hR9DzJswUIX//Q/uuw9atoRJk6BcueCee9FF8MQT8MgjcM45cFvGI/GanJVh8lDV9TkRSDhkdIUQLrl1SPbUXldSoihbtiz79u1j/PjxdO7cmWPHjrFx40batGnDueeey5gxY9i3bx87duygfv361K9fnyVLlvDrr7/SqFGjDPfdrFkzBg4cyK5duyhWrBgTJkygfv36GT7P+OTIEbjzTnjjDVcR/sEHEGoDjAcfhAUL4P/+D+LjoUWL8MRqMiWY1lYmRLl1SPbUXlfJkiW58cYbqVevHm3btj1e3Hb06FF69uxJ/fr1ady4MXfeeSclS5ZkyJAh1KtXjwYNGpA/f34uu+yyoI5pxYoVeeihh2jevDnnnHMOcXFxx4u2TITZtw+uusoljkGD4JNPQk8cAHnyuKRTsaLr//H339kfq8m8tCpDgIJZrVAJ9y1SK8yTKn9zk0h4XXu9ytPExETt0KGDTpw4MdXH+f0ZiGmbNqk2aqSaJ4/qG29kzzYTElwLrbZtVY8cyZ5txjiyocI8vSuPBQAiYn06TEQYPHgwjRo1ol69elSrVu14JbyJED/+6Oo2fvsNpk6FECcYS1PTpq7vx5dfuo6FJiKkV+dRQES6A2eLSMeUK1V1YvjCil65dUj2SHhdL774oq/7N+mYMcPVbRQrBt9+C0HUY4Xkxhth/nx4/HGXoGyOe9+llzwGAD2AksAVKdYpYMnDGON6id9yC9St64YaSaX5dZaJuDqU77+HHj1g2TKoUiX792OClmbyUNV5wDwRSVDVETkYU5ap6knNSk1scMW5JkccO+aa0j7zjLsSGDsWvH5JYVGkCIwf71pedekCc+dCQLNuk7OCaW31oYjcKSLjvdsdIpI/7JFlUqFChdixY4edRGKQqrJjx46T+o2YMDh4ELp3d4njxhthypTwJo4kZ54J778PixfDPfeEf38mTcF0EhwG5Pf+AlwPvAH0z8qORSQvkABsVtUOIlINGAOUAZYC16tqyGMzV6pUiU2bNrF9+/ashGeiVKFChVLttW6y0Y4drinu/Pnw7LOuE2BOXul37Ah33w0vvQRnn+2SmMlxktEvdBH5QVUbZrQs5B2L3A3EA8W95DEWmKiqY7x5039Q1TfS20Z8fLwmJCRkJQxjTCh++w0uvxw2bICRI8EbVifHJSbChRe6uo8lS6BOHX/iiFIislRV47OyjWCKrY6KSPWAnZ4BHM3KTkWkEtAeGO7dF+BCIGlc7pHA1VnZhzEmm333nWvptHMnzJrlX+IAN4z7J5/AKadAp06wd69/scSoYJLHIGC2iMwRkW+Ar4GsFjYOAe4Djnn3ywD/qGpSl+lNQPpjbxhjcs7Yse6XfqlSbsgQb4BMX1Wo4Ob9WL3a1btYPWeOCmYa2llATeBO4A6glqrOzuwORaQDsE1Vl2by+TeJSIKIJFi9hjFhpgrPP++uMuLjXeKoWdPvqE5o08Z1HPzkE3jtNb+jiSlBjW2lqodU9UfvdiiL+zwHuFJE1uEqyC8EXgFKikhSBX4lYHMasbytqvGqGl8u2BE6jTGhO3LE9RK//36XPL76ClIMshkR7r8fOnRwra8WLvQ7mpiR4wMjquqDqlpJVeOAa4GvVbUHMBtImsi6FzApp2Mzxnj27oUrroC334YHHnDTxkZqE+ikARQrVXL9P6xEIkdE0qi69wN3i8hvuDqQqOqYaEyusWkTnHcezJzpksczz7gTdCQrVcpNOrV9u+uBfjRLbXpMEDL8RIjTU0Qe8+5XEZHm2bFzVZ2jqh28/9eqanNVraGqXbKheMwYE6rly928GWvXuqFGbrzR74iC17ixq/eYOdNNJGXCKpifE8OAVsB13v29wOthi8gY44/PP3dXHHnywLx50Tn4YL9+0Ls3PPkkfPGF39HkasEkjxaqehtwEEBVdwEFwhqVMSZnvfWWq+OoUcNVOjdo4HdEmSMCr78O9eu74qv1UTsRasQLJnkkekOJKICIlONE/wxjTDQ7dsy1VhowAC691A02mMH0xhGvSBFX/3HkiBsm/pCVgIdDMMljKPApcKqIPA3MA/4b1qiMMeF34ABce63rxzFgAEye7ObjyA1q1HADKCYkuDnQTbbLcGBEVR0lIkuBiwABrlbVlWGPzBgTPtu3u8ENFyyAF15wfSRy2zQG11wD994LL77oesT36OF3RLlKhslDREoD24CPA5blV9XEcAZmjAmT1avd4IabN8O4ca5oJ7d65hlYtAhuusnNbli3rt8R5RrBFFstA7YDq4E13v/rRGSZiDQNZ3DGmGw2bx60agW7d8PXX+fuxAGQL58buqRYMRtAMZsFkzxmAperallVLQNcBkwFbuXEHB/GmEg3ZgxcdJEbYmThQpdEYkH58u61r1njmvLaAIrZIpjk0VJVv0y6o6ozgFaquhCwOSCNiXSqrvjmuutcB8DvvoPq1TN+Xm7SujX897+umG7oUL+jyRWCSR5bReR+Eanq3e4D/vKa71qTXWMiWWKi6yX+0EMuecycCWXK+B2VP+67zzUSuPdel0BNlgSTPLrjRrn9zLtV8ZblBbqGKzBjTBbt2QPt28OIEfDww/DRR1AwhgsLRFzz3apVoWtX2LbN74iiWjBNdf/GzeORmt+yNxxjTLbYuNEljpUrXfLo29fviCJDyZIwfryr7+neHb78EvLm9TuqqBTMwIjlROQFEZkuIl8n3XIiOGNMJixb5uo21q+H6dMtcaTUqJEbwmTWLBg82O9oolYwxVajgF+BasDjwDpgSRhjMsZk1rRpcP75ronqvHlwySV+RxSZ+vZ1t6eecgnWhCyY5FFGVUcAiar6jar2xc3+Z4yJJMOGwZVXQq1arilu/fp+RxTZXnvNXYX07Anr1vkdTdQJamBE7+9WEWkvIo2B0mGMyRgTimPHYNAguO02uOwy+OYbqFDB76giX+HCrv7j2DHXWfLgQb8jiirBJI+nRKQEcA9wLzAcGBjOoIwxQTpwwLUcevFFlzw++wxOOcXvqKJH9eowciQsXQoDB/odTVQJJnnsUtXdqvqTqrZR1abAznAHZozJwLZtcOGFMHEivPQSvPqqq+swobnqKtcH5K234MMP/Y4magSTPF4NcpkxJqesWgUtW7ppY8ePd8OO57ZRcXPS00/DBRfAzTfDihV+RxMV0vyZIiKtgLOBciJyd8Cq4rgOgsYYP8ydC1df7a4y5sxxzXJN1uTL58a/atzYDaCYkADFi/sdVURL78qjAHAKLsEUC7jtAXL5UJzGRKhRo1zz21NPdS2qLHFkn9NPdyPwrl3rmvHaAIrpSvPKQ1W/Ab4RkfdV1SYCNsZPqq5o5dFHXfHKxIlQ2ho9Zrvzz4dnn3Wt14YMsVkI0xFM7VpBEXkbiAt8vKpaXw9jckJioiuLf+891ydh+PDYHqMq3O65xw2ceN990Ly5m4XQnCSY5DEOeBPXRPdoeMMxxiSze7frg/DVV/DYY244DasYDy8Rl6jj410z6O+/d8WEJplgkscRVX0j7JEYY5Jbv94NbrhqlTuZ9e7td0Sxo0QJ14qtZUs3lP2MGTaAYgrBNNWdIiK3ikh5ESmddAt7ZMbEsqVL3Ylr0yb44gtLHH5o2BDeeMNN1/vYY35HE3GCufLo5f0dFLBMgTOyPxxjDFOmwLXXuuliv/oK6tb1O6LY1bs3zJ/vZiFs1Qo6dPA7ooiR4ZWHqlZL5WaJw5hweO0114ejTh1YtMgSRyR49VXX/+P66+GPP/yOJmIEM59HERF5xGtxhYjUFBFLv8Zkp6NHXbPQO+5wv27nzHH9Doz/ChVy9R9gAygGCKbO4z3gMK63OcBm4KmwRWRMrNm/352UhgyBO+90fTiKFvU7KhPojDPggw/cRFt33ul3NBEhmORRXVWfxxuaXVX3A5luKygilUVktoj8IiI/i8hd3vLSIjJTRNZ4f0tldh/GRI2//oI2bWDSJJc8XnnFWvVEqiuugAcegHfecSPxxrhgksdhESmMqyRHRKoDh7KwzyPAPapaB2gJ3CYidYAHgFmqWhOY5d03JvdaudK1qFqxAj79FO66y++ITEaefNIl+wED4Mcf/Y7GV8Ekj/8AXwCVRWQU7sR+X2Z3qKpbVXWZ9/9eYCVQEbgKSErnI4GrM7sPYyLenDlw9tmuyOqbb9yw4Cby5csHH38MpUq5ARR37/Y7It8E09pqJtAR6A18DMSr6pzs2LmIxAGNgUXAaaq61Vv1J3BaduzDmIjz4Ydw6aVQvrxrUdWsmd8RmVCcdhqMHetaXsXwAIrBtLa6BtfLfJqqTgWOiMjVWd2xiJwCTAAGquqewHWqqnjFZKk87yYRSRCRhO3bt2c1DGNyjio88QTccAOce64bPykuzu+oTGacey48//yJibhiUFDFVqp6/NpMVf/BFWVlmojkxyWOUao60Vv8l4iU99aXB7al9lxVfVtV41U1vly5clkJw5icc/gw9OkD//mPSx5ffAElS/odlcmK//s/V3R1//3w7bd+R5PjgkkeqT0m03NdiogAI4CVqhqYsidzojd7L2BSZvdhTET55x9o18610Hn8cXj/fShQwO+oTFaJwLvvuma83brBn3/6HVGOCiZ5JIjISyJS3bu9BCzNwj7PAa4HLhSR5d7tcuBZ4BIRWQNc7N03JrqtW+cqxufNc/0EHnvMRsXNTYoXhwkT3A+E666DI0f8jijHBHMFcQfwKPAJrh5iJnBbZneoqvNIu5/IRZndrjERZ8kS1zfg0CE3Kmvr1n5HZMKhfn14803o1ctN1vXMM35HlCPSTR4ikheYqqptcigeY3KHSZPcL9HTToPZs6F2bb8jMuF0ww1uAMVnn3UDKF55pd8RhV26yUNVj4rIMREpEVhpbowJkJjoOowtWgSLF7u/v/7qmuBOmeISiMn9XnkFEhJcIlm2zNWF5GLBFFvtA1aIyEzg36SFqmoDvJjYo+omaVq06MRt2bITg+Wdeiq0aOGG8r7jDihSxNdwTQ5KGkCxaVM3Vtn8+VC4sN9RhU0wyWOidzMm9uze7eouApPFNq8VeaFC0KQJ3HKLSxgtWkDVqlYhHsuqVXOdQDt0cD8ehg/3O6KwyTB5qOpIb2yrKqq6KgdiMsYfR464caYCE8Wvv57oQVyrlmtym5QoGjSA/Pn9jdlEnvbt4aGH3ARS55zj+vfkQhkmDxG5AngRKABUE5FGwBOqmvtrhEzupQobNyZPFEuXwoEDbn3Zsi5BXHed+9usmRvPyJhgPPEELFwIt97qJpJq1MjviLJdMMVWg4HmwBwAVV0uIrm7JsjkPnv2nCh+SqrUTurUVbCgK366+eYTVxVxcVb8ZDIvb143gGLjxq7+IyEh140oEEzySFTV3ZL8i3QsTPEYk3VHjsBPPyW/qli58kTx05lnwiWXJC9+sh7fJrudeiqMGwcXXOCKriZOzFU/SIJJHj+LSHcgr4jUBO4EvgtvWMYESRU2bTq5+Gn/fre+TBmXILp1O1H8VLq0vzGb2HH22fDCC24crBdfhEGD/I4o2wTbw/xh3ARQo4EvsWlojV/27nVFAIHJYqs3kn+BAq6YoH//E1cVZ5yRq37tmSh0111uBOUHH3SfyfPP9zuibJFm8hCRQsAAoAawAmilqrEzcIvx35Ej8PPPJ+ooFi1y95OKn2rUgAsvPJEoGjZ09RfGRBIR12T3hx/cFfCyZW4ulyiX3pXHSNy85d8ClwG1gYE5EJOJVakVP/3r9UstXRqaN3dDYLdo4f4vU8bfeI0JVtIAii1awLXXwqxZblbCKJZe9HVUtT6AiIwAFudMSCYm7Nt3cvHTli1uXf78rvipb98TVxXVq1vxk4lu9erBW2/B9dfDww/Dc8/5HVGWpJc8EpP+UdUjYl9ck1lHj8IvvyRPFD//DMe8RnvVq7sRZ5MSRaNGVvxkcqeePd2wJc8/7yrTo3ju+vSSR0MRSZoeVoDC3n3BzRRbPOzRmei0ZUvyRJGQ4K40wHW0a94crrnmRPFT2bL+xmtMThoyxH0nevVyRbPVq/sdUaakmTxUNW9OBmKi1L//ui9CYKX2pk1uXf78rhK7V68TVxU1a1rxk4ltBQu6/h9Nmrg6vAULonIAxeiusTE56+hR19ku8Krip59OFD9VqwbnnnsiUTRu7AYPNMYkFxcHH33kxsG67TY3nW2Uic3kMXGim0faBG/PHtfEcO9ed79kSVfkdNVV7m+LFlCunK8hGhNVLr8cHnkEnnrKDaDYr5/fEYUkNpPH3r0nilZMcAoVcq1EAouf8uTxOypjotvgwW4Axdtuc8VYjRv7HVHQRJM6XEWh+Ph4TUhI8DsMY4zJvO3bXeIoUMBVoOfAAIoislRV47OyDfvpaIwxfipXDsaOhQ0bXOOSY9Ex7qwlD2OM8VurVvC//8HkyW4gxShgycMYYyLBHXdA165uFsI5c/yOJkOWPIwxJhIkDaB45plu/Kuk0aIjlCUPY4yJFMWKwfjxrkVot26QmJjxc3xiycMYYyJJ3brwzjvw7beuCCtCWfIwxphI07073Hqrm33w00/9jiZVljyMMSYSvfSSG72hd29Ys8bvaE5iycMYYyJRwYKu/0e+fNC5M+zf73dEyVjyMMaYSFW1KowaBStWuGKsCBoRxJKHMcZEsnbt4LHHYORI15Q3QkRU8hCRdiKySkR+E5EH/I7HGGMiwqOPwqWXuo6Ey5b5HQ0QQclDRPICrwOXAXWA60Skjr9RGWNMBMib1xVfnXqqm0Bq1y6/I4qc5AE0B35T1bWqehgYA0TvBL/GGJOdypZ1MxBu3gw33OD7AIqRlDwqAhsD7m/ylhljjAE3l85LL8HUqfDqq76GEnWTQYnITcBNAFWqVPE5GmOMyWG33QYHDriOhD6KpCuPzUDlgPuVvGXJqOrbqhqvqvHlbNpTY0ysEYFBg3yf9jmSkscSoKaIVBORAsC1wGSfYzLGGJOKiCm2UtUjInI78CWQF3hXVX/2OSxjjDGpiJjkAaCq04HpfsdhjDEmfZFUbGWMMSZKWPIwxhgTMksexhhjQmbJwxhjTMgseRhjjAmZaASNDx8qEdkOrM/k08sCf2djOLmdHa/Q2PEKnR2z0GTleFVV1Sz1Mozq5JEVIpKgqvF+xxEt7HiFxo5X6OyYhcbv42XFVsYYY0JmycMYY0zIYjl5vO13AFHGjldo7HiFzo5ZaHw9XjFb52GMMSbzYvnKwxhjTCZZ8jDGGBOyiBpVN1xEpHQQDzumqv+EO5ZoICJ3B/Gwf1X1rbAHEwVEpGMQDzvojRod80SkSRAPS1TVFWEPJkpE4jksJuo8ROQgsAWQdB6WV1VtXltARLYCb5D+8eqhqmfmUEgRTUR2AJNI/3idr6rVcyikiCYie3GTv6V3vKqpalzORBT5IvEcFhNXHsBKVW2c3gNE5PucCiYKfKiqT6T3ABEpmlPBRIHPVbVveg8QkY9yKpgosERVL0zvASLydU4FEyUi7hwWK1cehVT1YFYfY4wxfhCR2qq6MoPH5Og5LCaSB4CICNAcqOgt2gws1lg5ACESkbbA1SQ/XpNU9QvfgopgInIWcBXJj9fkjL7wsUpESgDtSH68vrR6x9SJyFJVbSois1T1Ir/jgRhJHiJyKTAMWIP7kAJUAmoAt6rqDL9ii0QiMgQ4E/gA2OQtrgTcAKxR1bt8Ci0iicj9wHXAGJIfr2uBMar6rF+xRSIRuQH4DzCD5N/HS4DHVfUDv2KLVF6R1DjgFuDllOtV9aUcjylGksdK4DJVXZdieTVguqrW9iWwCCUiq1OrDPeu3larak0fwopYIrIaqKuqiSmWFwB+tuOVnIisAlqkvMoQkVLAImuIcTIRqYUrCRgIvJlyvao+nsMhxUyFeT5O/CIMtBnIn8OxRIODItJMVZekWN4MsHqhkx0DKnDy9ADlvXUmOQFS+9V6jPRbE8UsVV0FPCciP6rq537HA7GTPN4FlojIGGCjt6wyrlhhhG9RRa7ewBsiUowTSbcysNtbZ5IbCMwSkTWc+HxVwRWL3u5XUBHsaWCZiMwg+fG6BHjSt6iiw9ci0h2II+D8nVHryHCIiWIrcK0VSL1C8xf/oopsInI6AcdLVf/0M55IJiJ5OLlBxhJVPepfVJHLK6Jqy8kV5rv8iyryicgXuB9xS4Hjny1V/V+OxxIrycMYY6KdiPykqvX8jgNsbCtEZLDfMUQTEVnmdwzRRESm+h1DNBERG5Y9fd+JSH2/gwC78kBErlDVKX7HYXInESmvqlv9jiNaiEhTVV3qdxyRSkR+wdWl/QEcwmt8oKoNcjyWWE8eJm0ichrJ6zz+8jOeaJA0gJ2q7vQ7FpP7iEjV1JarasqWfmEXE62tRCQf0A+4BtekErwe08CIlO3zY52INMK1JS9BQCcuEfkH16nSiq4CiEgV4HngIuAft0iKA18DD6TsXxTrvN7lD+L6LZyKa7a7Dfd9fNZ6mZ9MRIqr6h5gr9+xJImJKw8R+Rj3pR5J8h7AvYDSqtrNp9AikogsB25W1UUplrcE3lLVhr4EFqFEZAEwBBif1LpKRPICXYCBqtrSx/Aijoh8iUusI5Na8Hkt+3oBF6nqpX7GF4lEZKqqdhCRP3DJNrA/jKrqGTkeU4wkj1R7TGe0LlaJyJq0ekWLyG+qWiOnY4pkGRyvNNfFKhFZpaq1Ql1nIktMFFsBO0WkCzBBVY/B8Xb5XQBrV36yz0VkGm5sq8BOlTcANjDiyZaKyDDclW3g8eoF2FD/J1svIvfhrjz+guP1a705cfxMhIuVK4844DngQk4ki5LAbFyZ9B/+RBa5ROQyUu9UabPhpeCNYdWPVI4Xrk7tkF+xRSKvg+ADuON1qrf4L9zxes4aG0SHmEgegUSkDICq7vA7FmOMiVYx10lQVXcEJg4RucTPeCKRiOQVkZtF5EkROTvFukf8iitSiUgREblPRAaJSCER6SUik0XkeRE5xe/4ooHNHBh9Yu7KIyUR2WBzlycnIsOBIsBi4HrgG1W921u3TFWb+BlfpBGRsbiy+sJALWAl8AlwJXC6ql7vY3gRR0R+TLkIN3/MKgA/OrxFK2+6CYDXVfW1nNx3TFSYi8jktFYBZXIylijRPOkLLCKvAcNEZCJuwiMbMvtkZ6pqV2++k63AxaqqIjIP+MHn2CLROmAP8BRwAPeZ+ha4wseYopKq1vaK4nO8OXhMJA/gPKAnsC/F8qSpaU1yBZL+UdUjwE0i8hiubb4Vw6TBSxjTk6Y29u7H9qV9KlT1ShG5BngbeFFVJ4tIoh+9pKNNaqM+eMXw03I6llhJHguB/ar6TcoV3qxmJrkEEWkXOF+5qj4hIluAN3yMK1IliMgpqrpPVfsmLRSR6kRQj+BIoqqfevN5PCki/Qj4wWJOFomjPsR8nYcx4SQiovYlS5eINARaqepJ06saJxJHfbDkYYwxES4SR32IlWIrY4yJZhE36oNdeRhjTBSItFEfLHmYoIlIeWCnDbcRHDteJjeLuR7mgURkpIi8ISIRMSdwFPgQ+FVEXvQ7kChhxysEIrLSu93udyzRRERu8mO/sV7n8RpQBdeL+n6fY4l4qnqx1xGujt+xRAM7XqHxs8NblPOl464VW5lUeSe95iQvX11szU5TZ8crdDbNcXSLieRh016GRkQuBYYBawjokATUwHVImuFXbJHIjldo0urwhpvt06Y5ToOItMWdwwJ/oEwK7Mybo/HESPKwaS9D4A22dlnKubdFpBowXVVr+xJYhLLjFZpI7PAW6URkCG7wyA9IPpX2DcAaVb0rx2OKkeRh016GQETWALW9ca0ClxcAfrFpaJOz4xWaSOzwFunSmi7bKy5d7cdUx7FSYW7TXobmXWCJiIwheYeka4ERvkUVuex4hSbiOrxFgYMi0kxVl6RY3gw46EdAsXLlYdNehkhEapN6h6Rf/IsqctnxCk2kdXiLdCLSBDcoaTFOFFtVBnYDt6nq0hyPKRaShzHG5AZeXW1gC7U//YolpjsJwvGMboIkIoP9jiGa2PEKjV8d3qKFqv6pqku9K407/YwlVuo80nMLcKPfQUSRHL88jnJ2vEJjM1WmQkSGprL4BhE5BUBVczyRWLGVMcZEOBHZCHwDzOBEgn0RuBdAVUfmeEyxkjy8joLtSF5B96V1EDyZiOQD+gHXABW8xZtxnSpHqGqiX7FFIjteoYu0Dm+RTkSKAU/iGvzcq6pbRGStqp7hW0yxkDxE5AbgP7isHdij9RLgcVX9wK/YIpGIfIzr7TuS5B2SegGlVbWbT6FFJDteoYnEDm/RQkSa4q44pgG3q2qcb7HESPJYBbRIeZXhNeFdlFrnm1iWVoekjNbFKjteoYnEDm/RxDtOt+Km7u3pVxyx0tpKcONZpXQMq6BLzU4R6SIixz8fIpJHRLoBu3yMK1LZ8QrNQRFplspy3zq8RTovYQCgzuspE0fgY3JCrLS2ehpYJiIzONGjtQqu2OpJ36KKXNcCzwHDRCTp5FcSmO2tM8nZ8QpNb+ANrxw/ZYe33j7FFOlmi8gEXL3QhqSF3hA45+KKSGcD7+dUQDFRbAXHi6jacnKFuf0yTIc3vwKqusPvWKKBHa/gRVKHt0gnIoWAvkAPoBqujq0wrvRoBjBMVb/P0ZhiIXmIiGQ0r0IwjzEgIpeo6ky/44g0IlIcKKeqv6dY3kBVf/QprIjlJQ5U9U8RKQecB/xqw7lkTETyA2WBA362Fo2VOo/ZInKHiFQJXCgiBUTkQhEZibvsMxmzgf5SEJGuwK/ABBH5OUV5/vv+RBW5RORmYAGwUERuAaYC7YFPRaSfr8FFAVVNVNWtfncziJUrj4i75ItkIjI5rVXAhapaNCfjiXTe/BSXqepWEWmOa4L6oKp+KiLfq2pjfyOMLCKyAmiB+w6uB2p4VyClgNmq2sjP+ExwYqLCXFUP4mZ6GxYpl3wR7jygJ7AvxfKkqVZNcnlVdSuAqi4WkTbAVBGpTOqt/GJdoqruB/aLyO9JdR2quktE7HhFiZhIHoG83r5b/Y4jwi0E9qvqNylXeH1mTHJ7RaR6Un2HdwXSGvgMqOtjXJFKRSS/911sn7TQKyGIlaL0qBcTxVbGhJOINMQl2zUplucHuqrqKH8ii0xe3eOWVGZerIibkfErfyIzobDkYU5irdNCY8crNHa8cge7RDSpsdZpobHjFRo7XrmAXXmYk6TROq0QkBdrnXYSO16hseOVO1jyMOmy1mmhseMVGjte0cuShzHGmJBZnYcxxpiQWfIwxhgTMkseJiKIyFERWS4iP4nIFBEpGYZ9tBaRqdm4vYEiUiTg/vTsiFtE3heRztmwncEicm8Ij38oq/s0scOSh4kUB1S1karWA3YCt/kdkDjpfUcGAseTh6peHuWVvpY8TNAseZhItABvngcRmSMi8d7/ZUVknfd/bxGZKCJfiMgaEXk+tQ2JSDsR+VVElgEdA5Yn+1XuXfHEebdVIvIB8BNQWUTeEJEEb8Tcx73H3wlUwPVZmO0tWyciZb3/7/a2+ZOIDPSWxYnIShF5x9vWDBEpnMYxuNjb52oR6RDwml8LiHmqNwxK0utcJiI/iMisVI7DjSLyuYgUFpGeIrLYu9J7S0TyisizQGFv2SgRKSoi07zt/SRuVkRjjou5sa1MZBORvMBFBDf0eyOgMXAIWCUir6pq0kyRSf0J3gEuBH4DPgkyjJpAL1Vd6G3nYVXd6cU2S9wcHUNF5G6gjar+neI1NAX64EaOFWCRiHyDm5K2JnCdqt4oImOBTsBHqcQQhxuEsjouQdVIK1hx82G8A5yvqn+ISOkU62/HzZp5NXAG0A04R1UTRWQY0ENVHxCR25NGtBWRTrghRNp790sEd+hMrLArDxMpCosb2vxP4DQgmAmnZqnqbm/U5F+AqinWnwX8oaprvKEuUjtJp2Z9UuLwdPWuXL7HDXRYJ4Pnnwt8qqr/quo+YCJupGK8eJZ7/y/FJYnUjFXVY954WWu915KWlsBcVf0DQFV3Bqy7AbgM6Kyqh3CJuSmwxDveF+ESSkorgEtE5DkROU9Vd6f3gk3sseRhIsUB71dvVdyv9aQ6jyOc+JwWSvGcQwH/HyW0K+nA7abc9r9J/4hINeBe4CJVbQBMSyWOUAQbc8oOWEr6MadlBS5BVfLuCzDSq19qpKq1VHXwSTtXXQ008Z7/lIg8FsS+TAyx5GEiijfPw53APSKSD1iH+6UMEGoLpF+BOBGp7t2/LmDdOtzJERFpghsmIzXFcclkt4ichvsVn2QvUCyV53wLXC0iRUSkKHCNtywUXUQkjxf7GcAqL+ZG3vLKnJhbZSFwvpfoSFFs9T1wMzBZRCoAs4DOInJq0mNFJOmKLVFcj2+8x+5X1Y+AF/COlTFJrM7DRBxV/V5EfsSd7F8ExorITbhf/aFs52DS80RkP+4EnnSynwDcICI/A4uA1Wls4wcR+R6XiDYC8wNWvw18ISJbVLVNwHOWicj7wGJv0XDvNcWFEP4G7/nFgQHea5kP/IErolsJLPP2t917nRO91mHbcHUcSfHM8xoHTPOWPwLM8B6biLvKW++9nh+9IroPgBdE5Jj3mFtCiN3EABuexBhjTMis2MoYY0zILHkYY4wJmSUPY4wxIbPkYYwxJmSWPIwxxoTMkocxxpiQWfIwxhgTMksexhhjQvb/p3Nnga4qMoAAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot the two series on the same graph\n",
+    "plt.plot(joined.index.astype(str), joined['f_pct'], color='red', label='percent of failure')\n",
+    "plt.plot(joined.index.astype(str), joined['p_pct'], color='green', label='percent of passing')\n",
+    "\n",
+    "# set x and y axis labels\n",
+    "plt.xlabel('Run duration buckets')\n",
+    "plt.ylabel('Percentage of passing or failing')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# set title and legend\n",
+    "plt.title('Percentage contribution of failing and passing to their sum')\n",
+    "plt.legend()\n",
+    "\n",
+    "# show the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8d9238c-61ee-4c74-91f7-e59beb6a99de",
+   "metadata": {},
+   "source": [
+    "### Test 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "312197ac-f8e1-4809-9150-b2d73db871a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_id = \"37149895\" # Spell Check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "14c66d99-1e9d-4217-b972-3f62730e8d1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_train = pd.read_csv(\"../data/processed/{}passing_train.csv\".format(test_id))\n",
+    "failing_train = pd.read_csv(\"../data/processed/{}failing_train.csv\".format(test_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "aa70f554-47ff-477e-af99-36c674f3f46f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranges = np.arange(0, max(passing_train['run_duration'])+1, 10).tolist()\n",
+    "ranges.append(np.inf)\n",
+    "passing_train['run_duration_ranges'] = pd.cut(passing_train['run_duration'], bins=ranges)\n",
+    "failing_train['run_duration_ranges'] = pd.cut(failing_train['run_duration'], bins=ranges)\n",
+    "p_vc = pd.DataFrame(passing_train['run_duration_ranges'].value_counts().sort_index())\n",
+    "f_vc = pd.DataFrame(failing_train['run_duration_ranges'].value_counts().sort_index())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "5fe127a2-b58a-4bf1-a42a-f7592c499f52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAFHCAYAAAC4ZhcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhWElEQVR4nO3deZhcZZ328e9NQkQWCUsbIyEEAdlUggTEnRdEQUXCO7KJGsbMRHEZcCV4OYjb+4KDCjOMKCMMQRwWUQRBQYwggwKSyJ4AYUmGJUuzRAj78ps/ztPkpFLVVd1V1aefzv25rr66zlLn/Orp7rvPec6miMDMzPKzVtUFmJnZ4DjAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QAfRiTdLmmPquuokqQDJN0vaYWknauuZzhIbfG6quuw4ccBPkQkLZT0nppxh0u6pm84InaMiKuaLGeSpJA0ukulVu1E4LMRsX5E3Fg7MX32J1OoPSjp+5JGdbqIUjuvSF9LJV0iae9Or6tmvVdJ+ofyuNQW93ZhXQslPZ0+3xJJZ0pav9Prse5xgNsqhsE/hi2A25vMs1NErA+8GzgY+EQX6xmb1rUTcAVwoaTDB7OgYdC29eyXPt9kYGfgmGrLsYFwgA8j5a10SbtJmiPp8bT19/0029Xp+/K05fRWSWtJ+pqkRZKWSTpL0oal5X48TXtE0j/XrOc4SRdIOlvS48Dhad3XSlouabGkUySNKS0vJH1a0gJJT0j6lqStJP051Xt+ef6az1i3VkmvkLQCGAXcLOmeZu0VEXcDf6IIn9X2aEq1bp1enynp3yVdmuq+XtJWrfxsImJJRJwMHAecIGmt2uWX1vHt9HoPSQ9IOlrSEuA/JW2UtuR7JT2WXk9I838HeCdwSvrZnlLnM2yY2qw3teHXSrUcLukaSSemZd8nad9WPx9weV9bpuXNlHRPaqt5kg4oTet3XZK2lHR1eu/vU7ufXZq+e/p9WS7pZpW6DtOy703vvU/SYa18hjVSRPhrCL6AhcB7asYdDlxTbx7gWuBj6fX6wO7p9SQggNGl930CuBt4XZr3l8BP07QdgBXAO4AxFF0Uz5fWc1wankrxD/2VwC7A7sDotL75wFGl9QVwEfAqYEfgWWB2Wv+GwDxgWoN2aFhradlb99OOL08HtgMWA5+v15515j8TeATYLX22nwHnNljPau2cxr8ujd++Xr1pHd9Or/cAXgBOAF6R2nYT4O+AdYENgJ8Dvyq9/yrgH/r5DGeltt8g1XgXML30+Z8H/pHiH+ERwEOAmv1OAhOAW4GTS9MPBF6bfi8OBp4ExreyLorf3xMpfufeATwOnJ2mbZZ+Du9Py947DfcA66V5t03zjgd2rPrvd7h+VV7AmvKV/lhWAMtLX0/ROMCvBr4BbFqznNWChSI8P10a3jb9cY0GjgXOKU1bF3iOVQP86ia1HwVcWBoO4O2l4bnA0aXh7wEnNVhWw1pLy24W4I+nMAngHOAVadrhNA/wn5SmvR+4o8F6VmvnNH6d8uevrZfVA/w5YJ1+Ps9k4LHS8FU0CHCKoHwO2KE07ZPAVaXPf3fNzzqA1zT5nXwizTebosuoUa03Afs3WxcwkeIf17ql6WezMsCPpvRPO427HJhGEeDLKf7JvbKqv9dcvtyFMrSmRsTYvi/g0/3MOx14PXCHpBskfbCfeV8LLCoNL6II73Fp2v19EyLiKYqtnbL7ywOSXp927ZekbpX/B2xa856lpddP1xludDCsv1pb9ea0/IOBt1D80bdqSen1UzSus5HN0vdHW5y/NyKe6RuQtK6kH6fuj8cp/lGPVWsHYjcF1mb19tusNPzy50s/a+j/M06NiA0o/tlsR+nnnLrebkrdHMuBN7Dq70Gjdb0WeLQ0Dlb9HdsCOLBvuWnZ76DYun+S4uf6KWBx6u7arp/612gO8GEqIhZExKHAqyl2wS+QtB7FVk6thyj+KPr0bQEtpehimNA3QVLfbvwqq6sZPhW4A9gmIl4FfBXQ4D9Ny7W2LArnU+yqH5tGP0mxJQiApNe0V2pdBwDLgDvT8FPldVJsga5Sas3wFyn2Ot6S2vZdabwazF/2MMXeSm37PdhS5f2IiD9S7D2cCCBpC+A/gM8Cm6QNjtto7fdgMbCxpHK7bF56fT/FFvjY0td6EXF8quXyiNibovvkjlSH1eEAH6YkfVRST0S8RLFLCfAS0Ju+l88LPgf4fDpwtD7FFvN5EfECcAGwn6S3pQOLx9H8j3ADim6KFWnr54gOfaxmtQ7G8cA/prC+GdhR0mRJ61B81o6QNE7SZ4GvA8eknwsU3QofkTRK0j4UZ8b0ZwOKPZTlkjZOyytbyqo/25dFxIvA+cB3JG2QQvYLFN0TnXASsLeknSj2aoLi9w1Jf0+xBd5URCwC5gDHSRoj6a3AfqVZzqb4nXxfard10gHfCamd908bK89SdPG8tPpaDBzgw9k+wO0qzsw4GTgkIp5Ou6XfAf6Udj93B84AfkqxO34f8AzwOYCIuD29Ppdiy2gFxRbks/2s+0vARyj6Rv8DOK+Dn6thrYMREbemZX05Iu4Cvgn8HlgAXNPfe1u0XNKTFAf43g8cGBFnlKYfSRFOy4HDgF81Wd5JFAczHwauAy6rmX4y8OF0Zse/1nn/5yj2NO6l+Hz/RdGmbYuIXoqDpMdGxDyKYxnXUvxTeSPFGT+tOgx4K0V33bcpfoeeTeu5H9ifYs+ul2KL/MsUebQWxT+lhyi6qd5NZzcgRpS+I8a2hkhbvcspukfuq7gcW0NIOo/igHHtHoe1wVvgawBJ+6WDZ+tR9HHeSnEGgllXSNpVxbUBa6Wupf1pvndiA+QAXzPsT7FL+hCwDUV3jHe9rJteQ3FK5ArgX4Ejos6tEaw97kIxM8uUt8DNzDLlADczy9SQ3h1t0003jUmTJg3lKs3Msjd37tyHI6KndvyQBvikSZOYM2fOUK7SzCx7khbVG+8uFDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFNDeiGPWa4mzby06hIqtfD4D1RdgtXhLXAzs0w5wM3MMuUANzPLlAPczCxTTQNc0raSbip9PS7pKEkbS7pC0oL0faOhKNjMzApNAzwi7oyIyRExGdgFeAq4EJgJzI6IbYDZadjMzIbIQLtQ9gLuiYhFFA/KnZXGzwKmdrAuMzNrYqABfghwTno9LiIWp9dLgHEdq8rMzJpqOcAljQE+BPy8dloUj7av+3h7STMkzZE0p7e3d9CFmpnZqgayBb4v8NeIWJqGl0oaD5C+L6v3pog4LSKmRMSUnp7VHulmZmaDNJAAP5SV3ScAFwPT0utpwEWdKsrMzJprKcAlrQfsDfyyNPp4YG9JC4D3pGEzMxsiLd3MKiKeBDapGfcIxVkpZmZWAV+JaWaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplq9aHGYyVdIOkOSfMlvVXSxpKukLQgfd+o28WamdlKrW6BnwxcFhHbATsB84GZwOyI2AaYnYbNzGyINA1wSRsC7wJOB4iI5yJiObA/MCvNNguY2p0Szcysnla2wLcEeoH/lHSjpJ9IWg8YFxGL0zxLgHHdKtLMzFbXSoCPBt4MnBoROwNPUtNdEhEBRL03S5ohaY6kOb29ve3Wa2ZmSSsB/gDwQERcn4YvoAj0pZLGA6Tvy+q9OSJOi4gpETGlp6enEzWbmRktBHhELAHul7RtGrUXMA+4GJiWxk0DLupKhWZmVtfoFuf7HPAzSWOAe4G/pwj/8yVNBxYBB3WnRDMzq6elAI+Im4ApdSbt1dFqzMysZb4S08wsUw5wM7NMOcDNzDLlADczy5QD3MwsUw5wM7NMOcDNzDLlADczy5QD3MwsUw5wM7NMOcDNzDLlADczy5QD3MwsUw5wM7NMOcDNzDLlADczy5QD3MwsUw5wM7NMOcDNzDLlADczy1RLDzWWtBB4AngReCEipkjaGDgPmAQsBA6KiMe6U6aZmdUayBb4/4mIyRHR93T6mcDsiNgGmJ2GzcxsiLTThbI/MCu9ngVMbbsaMzNrWasBHsDvJM2VNCONGxcRi9PrJcC4jldnZmYNtdQHDrwjIh6U9GrgCkl3lCdGREiKem9MgT8DYOLEiW0Va2ZmK7W0BR4RD6bvy4ALgd2ApZLGA6Tvyxq897SImBIRU3p6ejpTtZmZNQ9wSetJ2qDvNfBe4DbgYmBamm0acFG3ijQzs9W10oUyDrhQUt/8/xURl0m6AThf0nRgEXBQ98o0M7NaTQM8Iu4Fdqoz/hFgr24UZWZmzflKTDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8tUywEuaZSkGyVdkoa3lHS9pLslnSdpTPfKNDOzWgPZAj8SmF8aPgH4QURsDTwGTO9kYWZm1r+WAlzSBOADwE/SsIA9gQvSLLOAqV2oz8zMGmh1C/wk4CvAS2l4E2B5RLyQhh8ANutsaWZm1p+mAS7pg8CyiJg7mBVImiFpjqQ5vb29g1mEmZnV0coW+NuBD0laCJxL0XVyMjBW0ug0zwTgwXpvjojTImJKREzp6enpQMlmZgYtBHhEHBMREyJiEnAI8IeIOAy4Evhwmm0acFHXqjQzs9W0cx740cAXJN1N0Sd+emdKMjOzVoxuPstKEXEVcFV6fS+wW+dLMjOzVvhKTDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFMOcDOzTDnAzcwy5QA3M8uUA9zMLFNNA1zSOpL+IulmSbdL+kYav6Wk6yXdLek8SWO6X66ZmfVpZQv8WWDPiNgJmAzsI2l34ATgBxGxNfAYML1rVZqZ2WqaBngUVqTBtdNXAHsCF6Txs4Cp3SjQzMzqa6kPXNIoSTcBy4ArgHuA5RHxQprlAWCzBu+dIWmOpDm9vb0dKNnMzKDFAI+IFyNiMjAB2A3YrtUVRMRpETElIqb09PQMrkozM1vNgM5CiYjlwJXAW4GxkkanSROABztbmpmZ9aeVs1B6JI1Nr18J7A3MpwjyD6fZpgEXdalGMzOrY3TzWRgPzJI0iiLwz4+ISyTNA86V9G3gRuD0LtZpZmY1mgZ4RNwC7Fxn/L0U/eFmZlYBX4lpZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmWrlqfSbS7pS0jxJt0s6Mo3fWNIVkhak7xt1v1wzM+vTyhb4C8AXI2IHYHfgM5J2AGYCsyNiG2B2GjYzsyHSNMAjYnFE/DW9fgKYD2wG7A/MSrPNAqZ2qUYzM6tjQH3gkiYBOwPXA+MiYnGatAQY19nSzMysPy0HuKT1gV8AR0XE4+VpERFANHjfDElzJM3p7e1tq1gzM1uppQCXtDZFeP8sIn6ZRi+VND5NHw8sq/feiDgtIqZExJSenp5O1GxmZrR2FoqA04H5EfH90qSLgWnp9TTgos6XZ2ZmjYxuYZ63Ax8DbpV0Uxr3VeB44HxJ04FFwEFdqdDMzOpqGuARcQ2gBpP36mw5ZmbWKl+JaWaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWqVYupbcRYNLMS6suoVILj/9A1SWYdZy3wM3MMuUANzPLlAPczCxTDnAzs0w5wM3MMuUANzPLlAPczCxTDnAzs0w5wM3MMtXKU+nPkLRM0m2lcRtLukLSgvR9o+6WaWZmtVrZAj8T2Kdm3ExgdkRsA8xOw2ZmNoSaBnhEXA08WjN6f2BWej0LmNrZsszMrJnB9oGPi4jF6fUSYFyH6jEzsxa1fRAzIgKIRtMlzZA0R9Kc3t7edldnZmbJYAN8qaTxAOn7skYzRsRpETElIqb09PQMcnVmZlZrsAF+MTAtvZ4GXNSZcszMrFWtnEZ4DnAtsK2kByRNB44H9pa0AHhPGjYzsyHU9Ik8EXFog0l7dbgWMzMbAF+JaWaWKQe4mVmmHOBmZplygJuZZarpQUwzs3ZNmnlp1SVUauHxH+jKcr0FbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplqK8Al7SPpTkl3S5rZqaLMzKy5QQe4pFHAvwP7AjsAh0raoVOFmZlZ/9rZAt8NuDsi7o2I54Bzgf07U5aZmTXTToBvBtxfGn4gjTMzsyHQ9WdiSpoBzEiDKyTd2e11dsmmwMNVF5GxSttPJ1S15o5x+7Un9/bbot7IdgL8QWDz0vCENG4VEXEacFob6xkWJM2JiClV15Ert1973H7tGant104Xyg3ANpK2lDQGOAS4uDNlmZlZM4PeAo+IFyR9FrgcGAWcERG3d6wyMzPrV1t94BHxG+A3HapluMu+G6hibr/2uP3aMyLbTxFRdQ1mZjYIvpTezCxTDnAzs0x1/TzwHEnauIXZXoqI5d2uJUeSvtDCbE9GxI+7XkyGJP3fFmZ7Jh2Dshpr0t+v+8DrkPQM8BCgfmYbFRETh6ikrEhaDJxK/+13WES8fohKyoqkR4CL6L/93hURWw1RSVlZk/5+vQVe3/yI2Lm/GSTdOFTFZOinEfHN/maQtN5QFZOh30bEJ/qbQdLZQ1VMhtaYv19vgdchaZ2IeKbdecxs6EnaPiLmN5lnRPz9OsAbkCSKOy723aDrQeAv4QZriaT3AVNZtf0uiojLKisqI5K2o7i7Z7n9Lm4WTAaS5kbELpJmR8ReVdfTTQ7wOiS9F/ghsICV93eZAGwNfDoifldVbTmQdBLweuAsirtUQtF+HwcWRMSRFZWWBUlHA4dS3KK53H6HAOdGxPFV1ZaD1D3yc+AI4Ae10yPi+0NeVJc4wOuQNB/YNyIW1ozfEvhNRGxfSWGZkHRXvQOUaa/mrojYpoKysiHpLmDHiHi+ZvwY4Ha3X/8kbUux93cU8KPa6RHxjSEuqWt8ELO+0azc8il7EFh7iGvJ0TOSdo2IG2rG7wpk3+84BF4CXgssqhk/Pk2zfkTEncAJkm6JiN9WXU83OcDrOwO4QdK5rHxoxeYUu7CnV1ZVPg4HTpW0ASv/EW4O/C1Ns/4dBcyWtICVv38TKbrwPltVURn6g6SPAJMoZV2zM6Ry4i6UBiRtT/2DSPOqqyovkl5Dqf0iYkmV9eRE0lqsfhD9hoh4sbqq8iLpMoqNhrnAy+0WEd+rrKgOc4Cb2Ygk6baIeEPVdXST74UyQJKOq7qGnEn6a9U15EzSJVXXkJE/S3pj1UV0k7fAB0jSfhHx66rrsDWTpPERsbjqOnIgaR7FcYP7gGcpLq2PiHhTpYV1kAPcukbSOFbtA19aZT056rsxU0Q8WnUtuZFU90HAEVF7dk+2fBZKHZJGA9OBAyhO54J0JSFweu35ubYqSZMpzr/dkNKFUJKWU1wI5W6UfkiaCHwX2AtYXozSq4A/ADNrr0+wVUl6VUQ8DjxRdS3d5i3wOiSdQ/GHM4tVr4SbBmwcEQdXVFoWJN0EfDIirq8Zvzvw44jYqZLCMiHpWuAk4IK+s04kjQIOBI6KiN0rLG/Yk3RJRHxQ0n1AsOpdCSMiXldRaR3nAK+j0ZWEzaZZQdKCRlcLSro7IrYe6ppy0qT9Gk6zNY+7UOp7VNKBwC8i4iV4+bzcA4HHKq0sD7+VdCnFvVDKF0J9HPDNrJqbK+mHFHuA5fabBoyI26BaZ3gLvA5Jk4ATgD1ZGdhjgSsp+iDvq6ayfEjal/oXQvkpMk2ke55Mp077URyDebaq2mx4cYA3IWkTgIh4pOpazMzKfCFPExHxSDm8Je1dZT05kDRK0iclfUvS22qmfa2qunIhaV1JX5H0ZUnrSJom6WJJ35W0ftX12fDhAB8438yquR8D7wYeAf5NUvn+y608sHdNdyYwDtgSuJTiLo7/QnE2xanVlZU3SfPT14i5IZi7UOqQdHGjScCeEeHnOfYj3cbzTen1aIqHY2xK8ZCC65o9r3BNJ+mmiJic7p++GBgfEZGGbx5JVxIOtdQluntEXFp1LZ3gs1DqeyfwUWBFzfi+x6xZ/8b0vYiIF4AZko6luBDFXQAtSqH9m77H+KVhb3G1qN6VwKk7dESENzjAG7kOeCoi/lg7QdKdFdSTmzmS9ik//zIivinpIdwF0Io5ktaPiBXlp9NL2oo14OrCdq1JVwK7C8UsI5LkB2v3b026EtgHMc0y4vBuyXq14Q0QEdcBI+r4lbtQzGykWWOuBHYXipmNOGvKlcAOcBsyksYDj/pS8MFx+1kt94EPgKRZkk6VNKKfs9dFPwXukHRi1YVkyu3XJkkzqq6hk9wHPjCnABOBjwFHV1xLdiLiPelilB2qriVHbr+OUPNZ8uEuFOuKFDS7sWof5F98FkVr3H7WCgd4HZI2BI4BpgKvpniqxzKKR6odHxHLKysuA5LeS3H5/AJKF1JQPGD20xHxu6pqy4Hbr32S3kfx91v+B3hR+eKykcABXoekyyku+54VEUvSuNdQ3FB/r4h4b5X1DXeS5gP71j67UdKWwG8iYvtKCsuE2689kk4CXk9xGmH5kYgfBxZExJEVldZxDvA6JN0ZEdsOdJoVJC0Atk/3QSmPHwPM8yPV+uf2a0+jxx6mbqm7RtIj6XwQs75Fkr5CsQW+FF6+Mc7hrLwwwBo7A7hB0rmseiHFIfh2vK1w+7XnGUm7RsQNNeN3BZ6poqBu8RZ4HZI2AmZSXAjw6jR6KcUjrU6IiEerqi0Xkran/oUU86qrKh9uv8GT9GaKm6ZtwMoulM2BvwGfiYi5VdXWaQ5wMxuR0nGr8u1kl1RZTzf4Qp4BSv/dbZAkHVd1DTlz+7UmhTdpa/t/gLdJGnHnzzvAB+6IqgvI3IjZfa2I268JSZ8ErgWuk3QEcAnwAeBCSdMrLa7D3IViZiOKpFuBtwCvBBYBW0fEknRs68qImFxlfZ3ks1AaSBfz7MOqB5Eu90U8zaXnYE4HDgBem0Y/SHEh1OkR8XxVteXA7de25yPiKeApSff09X1HxGMj7ZF03gKvQ9LHga8Dv2PVK+H2Br4REWdVVVsOJJ0DLAdmseqFFNOAjSPi4IpKy4Lbrz2S5lI8uPh5SRMi4oE0fh3g+pH0RB4HeB3puZdvqd3aTrtg19e7SMBWanQhRbNpVnD7tUfSROChOhdCbUZxgdTvq6ms83wQsz5R3P+k1kuMsLuZdcmjkg6U9PLvl6S1JB0MPFZhXblw+7Xn/trwBoiIB/vCO12VmT33gdf3HeCvkn7HyivhJlJ0oXyrsqrycQhwAvBDSX2BMxa4Mk2z/rn92nOlpF9Q3Lzqf/pGplsRvIOiK+pK4Mxqyuscd6E0kLpL3sfqBzG9BTQAkjYBiIhHqq4lR26/gUt93Z8ADgO2pDiesA4wiuK41g8j4sbKCuwgB3gdktTsvsutzGOrk7R3RFxRdR3DnaRXAT0RcU/N+DdFxC0VlZUdSWsDmwJPj8QzyNwHXt+Vkj6XDoa8TNIYSXtKmkWxG2YD55sxNSHpIOAO4BeSbpe0a2nymdVUlaeIeD4iFo/E8Ab3gTeyD8Uu2DnpHszLKS4KWItiF+ykkbIL1g2SLm40CdhkKGvJ1FeBXSJisaTdgJ9KOiYiLsQH0a3EXShNjPRdsG5IB94+CqyonQScFxHjhr6qfEi6NSLeWBoeT3E5+Czg8Ijw/XgM8BZ4U+mqt8VV15GZ64CnIuKPtRPSOfbWvyckbdXX/522xPcAfgXsWGFdNsx4C9xsmJG0E8U/wAU149cGDoqIn1VTmQ03DnDrOJ/F0x63n7XKZ6FYN/gsnva4/awl3gK3jluTLqToBreftcoBbl3ls3ja4/az/jjAzcwy5T5wM7NMOcDNzDLlALdBkfSipJsk3Sbp15LGdmi5V0m6U9Itku6QdEqnlp2Wv4ekt5WGP5WewNTucidJejq1yTxJZ6X+a7OucYDbYD0dEZMj4g3Ao8BnOrjswyLiTcCbgGcpngXZsvRMyUb2AF4O8Ij4UQcfkXdPemDuGykegXZQh5ZrVpcD3DrhWtJ909MW9JT0elNJC9PrwyX9UtJlkhZI+m6zhUbEc8BXgImSdkpbubf1TZf0JUnHldZ7kqQ5wJGS9pN0vaQbJf1e0jhJk4BPAZ9PW8rvlHScpC+lZUyWdF3a+r8w3RO+b9knSPqLpLskvbNJ3S8Cfym1yWq1pPHHSTojLf9eSf9U+mz/nPZErpF0TqnGrVIbzpX035K2S+MPTHtDN0u6ulnb2sjgALe2SBoF7AU0ugNh2WTgYIot1IMlbd7sDSkMbwa2a2H5YyJiSkR8D7iG4sG2OwPnAl+JiIXAj4AfpL2H/655/1nA0Wnr/1aKB1v3GR0RuwFH1YxfTTqP+y3AZWnUarWUZt+O4sEhuwFfl7R2un3s3wE7AfsCU0rznwZ8LiJ2Ab4E/DCNPxZ4X3pg74f6q89GDt/MygbrlZJuotjKnA+08pCG2RHxNwBJ84AtWPnIuv60egvV80qvJwDnpTv5jQHu63cF0obA2NINuGYBPy/N8sv0fS4wqcFitkptsiVwaenBC/3VcmlEPAs8K2kZMA54O8XjwJ4BnpH061Tj+hTdPz/Xykc6viJ9/xNwpqTzS7XaCOctcBusp1N/7xYUAdvXB/4CK3+v1ql5z7Ol1y/SwgZE2sJ/I8U/ifKy6y3/ydLrfwNOSbdl/WSdeQeqr/b+6u7rA98K2EVS35Zwf7UMpE3WApanvYe+r+0BIuJTwNeAzYG5So9is5HNAW5tiYingH8CvpgOHi4EdkmTP9zOstNZHP+f4injtwBLgVdL2kTSK4AP9vP2DSmeYwqr3jfkCWCDOp/jb8Bjpf7tjwGr3Q63FRHxMDATOKZJLY38CdhP0jppq/uDabmPA/dJOhCKG1qpuHMhKm4/e31EHAv0UgS5jXAOcGtbui/HLcChwInAEZJupLgEfDB+JukW4DZgPWD/tJ7ngW9SHCC8guKxY40cR9HVMBd4uDT+18ABfQcxa94zDfiXtO7JaV2D9Stg3bSORrXUFRE3UBxTuAX4LUV//N/S5MOA6ZJuBm4ntU2q+9Z0kPfPFMcNbITzpfRmw5Ck9SNihaR1gauBGRHx16rrsuHFBzHNhqfTJO1A0V8+y+Ft9XgL3MwsU+4DNzPLlAPczCxTDnAzs0w5wM3MMuUANzPLlAPczCxT/wvbIG39KqgGlgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.bar(p_vc.index.astype(str), p_vc['run_duration_ranges'].values)\n",
+    "\n",
+    "# set the x-axis label and title\n",
+    "plt.xlabel('Run Duration Ranges')\n",
+    "plt.title('Histogram of Run Duration Ranges')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# display the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "617f09b1-7af2-402d-8cfb-359c79afbeb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAFHCAYAAAC4ZhcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAf5UlEQVR4nO3deZhcZZ328e9NQohAAIEWkRCCqGzKIg3izsUioDDAOyIgKhmZicKg4KgsjoNxe19QVJhhRDPKAMIEBEFRlEUEGRSQhJ0ECEKQJYFmCRD25ff+cZ4mpyvVVdVV1X366dyf6+orVeecPudXT7rvfs5zNkUEZmaWnxWqLsDMzNrjADczy5QD3MwsUw5wM7NMOcDNzDLlADczy5QDfJSRdLukHaquo0qS9pF0v6Qlkrauup7RILXFm6uuw0YXB/gIkrRA0s4106ZJurr/fURsHhFXNlnPVEkhafwwlVq1E4DDImLViLixdmb67M+kUHtQ0vcljet2EaV2XpK+Hpb0G0m7dHtbNdu9UtI/lqeltrhnGLa1QNJz6fMtknSapFW7vR0bHg5wW8Yo+MOwAXB7k2W2jIhVgQ8C+wGfHsZ61kjb2hK4DLhA0rR2VjQK2raePdPn2wrYGjim2nKsVQ7wUabcS5e0naTZkp5Kvb/vp8WuSv8uTj2nd0taQdJXJd0n6RFJZ0havbTeT6V5j0n6t5rtzJB0nqQzJT0FTEvbvkbSYkkLJZ0saUJpfSHpUEnzJT0t6ZuSNpL051Tvz8vL13zGurVKWknSEmAccLOkvzZrr4i4G/gTRfgss0dTqvUt6fVpkv5T0kWp7uskbdTK/01ELIqIk4AZwPGSVqhdf2kb30qvd5D0gKSjJC0C/lvS61NPvk/SE+n15LT8t4H3Ayen/9uT63yG1VOb9aU2/GqplmmSrpZ0Qlr3vZJ2b/XzAZf0t2Va39GS/praaq6kfUrzGm5L0oaSrkrf+/vU7meW5m+ffl4WS7pZpaHDtO570vfeK+nAVj7Dcici/DVCX8ACYOeaadOAq+stA1wDfDK9XhXYPr2eCgQwvvR9nwbuBt6clj0f+FmatxmwBHgfMIFiiOKl0nZmpPd7U/xRfx2wDbA9MD5tbx5wRGl7AfwKWA3YHHgBuDxtf3VgLnDQIO0waK2ldb+lQTu+Nh/YBFgIfKFee9ZZ/jTgMWC79NnOAs4eZDvLtHOa/uY0fdN69aZtfCu93gF4GTgeWCm17VrA3wMrA5OAc4Fflr7/SuAfG3yGM1LbT0o13gUcXPr8LwH/RPGH8BDgIUDNfiaBycCtwEml+fsCb0o/F/sBzwDrtrItip/fEyh+5t4HPAWcmeatl/4fPpzWvUt63wOskpbdOC27LrB51b+/o/Gr8gKWp6/0y7IEWFz6epbBA/wq4OvA2jXrWSZYKMLz0NL7jdMv13jgWGBWad7KwIsMDPCrmtR+BHBB6X0A7y29nwMcVXr/PeDEQdY1aK2ldTcL8KdSmAQwC1gpzZtG8wD/SWneh4E7BtnOMu2cpk8sf/7aelk2wF8EJjb4PFsBT5TeX8kgAU4RlC8Cm5XmfQa4svT57675vw7gjU1+Jp9Oy11OMWQ0WK03AXs12xYwheIP18ql+WeyNMCPovRHO027BDiIIsAXU/yRe11Vv685fHkIZeTtHRFr9H8BhzZY9mDgbcAdkq6XtEeDZd8E3Fd6fx9FeK+T5t3fPyMinqXo7ZTdX34j6W1p135RGlb5v8DaNd/zcOn1c3XeD3YwrFGtrXpnWv9+wLsofulbtaj0+lkGr3Mw66V/H29x+b6IeL7/jaSVJf04DX88RfGHeg21diB2bWBFlm2/9UrvX/t86f8aGn/GvSNiEsUfm00o/T+nobeb0jDHYuDtDPw5GGxbbwIeL02DgT9jGwD79q83rft9FL37Zyj+Xz8LLEzDXZs0qH+55QAfxSJifkQcALyBYhf8PEmrUPRyaj1E8UvRr78H9DDFEMPk/hmS+nfjB2yu5v0pwB3AWyNiNeArgNr/NC3X2rIo/JxiV/3YNPkZip4gAJLe2Fmpde0DPALcmd4/W94mRQ90QKk1779IsdfxrtS2H0jTNcjyZY9S7K3Utt+DLVXeQET8kWLv4QQASRsA/wUcBqyVOhy30drPwUJgTUnldlm/9Pp+ih74GqWvVSLiuFTLJRGxC8XwyR2pDqvhAB/FJH1CUk9EvEqxSwnwKtCX/i2fFzwL+EI6cLQqRY/5nIh4GTgP2FPSe9KBxRk0/yWcRDFMsST1fg7p0sdqVms7jgP+KYX1zcDmkraSNJHis3aFpHUkHQZ8DTgm/b9AMazwcUnjJO1GcWZMI5Mo9lAWS1ozra/sYQb+374mIl4Bfg58W9KkFLL/QjE80Q0nArtI2pJiryYoft6Q9A8UPfCmIuI+YDYwQ9IESe8G9iwtcibFz+Suqd0mpgO+k1M775U6Ky9QDPG8uuxWzAE+uu0G3K7izIyTgP0j4rm0W/pt4E9p93N74FTgZxS74/cCzwOfA4iI29Prsyl6RksoepAvNNj2l4CPU4yN/hdwThc/16C1tiMibk3r+nJE3AV8A/g9MB+4utH3tmixpGcoDvB9GNg3Ik4tzT+cIpwWAwcCv2yyvhMpDmY+ClwLXFwz/yTgo+nMjn+v8/2fo9jTuIfi8/0PRZt2LCL6KA6SHhsRcymOZVxD8UflHRRn/LTqQODdFMN136L4GXohbed+YC+KPbs+ih75lykyaQWKP0oPUQxTfZDudiDGjP6jxbYcSb3exRTDI/dWXI4tJySdQ3HAuHaPw9rkHvhyQtKe6eDZKhRjnLdSnIFgNiwkbavi2oAV0tDSXjTfO7EhcIAvP/ai2CV9CHgrxXCMd79sOL2R4pTIJcC/A4dEnVsjWPs8hGJmlin3wM3MMuUANzPL1IjeGW3ttdeOqVOnjuQmzcyyN2fOnEcjoqd2+ogG+NSpU5k9e/ZIbtLMLHuS7qs33UMoZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZahrgkk5V8dzC2+rM+2J6Vl/tjf7NzGyYtdIDP43itqYDSFof+BDwty7XZGZmLWga4BFxFfUfHfUD4EgaPz3EzMyGSVsX8kjaC3gwIm6WGj/YRdJ0YDrAlClT2tmcWeWmHn1R1SVUasFxH6m6BKtjyAcx0zPuvsLSZxA2FBEzI6I3Inp7epa5EtTMzNrUzlkoGwEbAjdLWkDxsNwbhunhsWZmNoghD6Gk5w++of99CvHeiHi0i3WZmVkTrZxGOIvioaYbS3pA0sHDX5aZmTXTtAceEQc0mT+1a9WYmVnLfCWmmVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWKQe4mVmmHOBmZplygJuZZcoBbmaWqVaeSn+qpEck3Vaa9l1Jd0i6RdIFktYY1irNzGwZrfTATwN2q5l2GfD2iNgCuAs4pst1mZlZE00DPCKuAh6vmXZpRLyc3l4LTB6G2szMrIFujIF/GvhdF9ZjZmZD0FGAS/pX4GXgrAbLTJc0W9Lsvr6+TjZnZmYlbQe4pGnAHsCBERGDLRcRMyOiNyJ6e3p62t2cmZnVGN/ON0naDTgS+GBEPNvdkszMrBWtnEY4C7gG2FjSA5IOBk4GJgGXSbpJ0o+GuU4zM6vRtAceEQfUmfzTYajFzMyGwFdimpllygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llqmmASzpV0iOSbitNW1PSZZLmp39fP7xlmplZrVZ64KcBu9VMOxq4PCLeClye3puZ2QhqGuARcRXweM3kvYDT0+vTgb27W5aZmTXT7hj4OhGxML1eBKzTpXrMzKxFHR/EjIgAYrD5kqZLmi1pdl9fX6ebMzOzpN0Af1jSugDp30cGWzAiZkZEb0T09vT0tLk5MzOr1W6AXwgclF4fBPyqO+WYmVmrWjmNcBZwDbCxpAckHQwcB+wiaT6wc3pvZmYjaHyzBSLigEFm7dTlWszMbAh8JaaZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpYpB7iZWaYc4GZmmXKAm5llygFuZpapjgJc0hck3S7pNkmzJE3sVmFmZtZY2wEuaT3g80BvRLwdGAfs363CzMyssU6HUMYDr5M0HlgZeKjzkszMrBVtB3hEPAicAPwNWAg8GRGXdqswMzNrbHy73yjp9cBewIbAYuBcSZ+IiDNrlpsOTAeYMmVK+5VaR6YefVHVJVRqwXEfqboEs67rZAhlZ+DeiOiLiJeA84H31C4UETMjojcient6ejrYnJmZlXUS4H8Dtpe0siQBOwHzulOWmZk108kY+HXAecANwK1pXTO7VJeZmTXR9hg4QER8Dfhal2oxM7Mh8JWYZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZ6ijAJa0h6TxJd0iaJ+nd3SrMzMwaG9/h958EXBwRH5U0AVi5CzWZmVkL2g5wSasDHwCmAUTEi8CL3SnLzMya6WQIZUOgD/hvSTdK+omkVbpUl5mZNdFJgI8H3gmcEhFbA88AR9cuJGm6pNmSZvf19XWwOTMzK+skwB8AHoiI69L78ygCfYCImBkRvRHR29PT08HmzMysrO0Aj4hFwP2SNk6TdgLmdqUqMzNrqtOzUD4HnJXOQLkH+IfOSzIzs1Z0FOARcRPQ251SzMxsKHwlpplZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlqmOA1zSOEk3SvpNNwoyM7PWdKMHfjgwrwvrMTOzIegowCVNBj4C/KQ75ZiZWas67YGfCBwJvNp5KWZmNhRtB7ikPYBHImJOk+WmS5otaXZfX1+7mzMzsxqd9MDfC/ydpAXA2cCOks6sXSgiZkZEb0T09vT0dLA5MzMrazvAI+KYiJgcEVOB/YE/RMQnulaZmZk15PPAzcwyNb4bK4mIK4Eru7EuMzNrjXvgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZcoCbmWXKAW5mlikHuJlZphzgZmaZajvAJa0v6QpJcyXdLunwbhZmZmaNje/ge18GvhgRN0iaBMyRdFlEzO1SbWZm1kDbPfCIWBgRN6TXTwPzgPW6VZiZmTXWlTFwSVOBrYHrurE+MzNrrpMhFAAkrQr8AjgiIp6qM386MB1gypQpnW7OzDI09eiLqi6hcguO+0jX19lRD1zSihThfVZEnF9vmYiYGRG9EdHb09PTyebMzKykk7NQBPwUmBcR3+9eSWZm1opOeuDvBT4J7CjppvT14S7VZWZmTbQ9Bh4RVwPqYi1mZjYEvhLTzCxTDnAzs0w5wM3MMuUANzPLlAPczCxTDnAzs0w5wM3MMuUANzPLlAPczCxTDnAzs0w5wM3MMuUANzPLlAPczCxTDnAzs0w5wM3MMuUANzPLlAPczCxTDnAzs0w5wM3MMuUANzPLlAPczCxTHQW4pN0k3SnpbklHd6soMzNrru0AlzQO+E9gd2Az4ABJm3WrMDMza6yTHvh2wN0RcU9EvAicDezVnbLMzKyZTgJ8PeD+0vsH0jQzMxsB44d7A5KmA9PT2yWS7hzubQ6TtYFHqy4iY5W2n46vastd4/brTOW/vx224Qb1JnYS4A8C65feT07TBoiImcDMDrYzKkiaHRG9VdeRK7dfZ9x+nRmr7dfJEMr1wFslbShpArA/cGF3yjIzs2ba7oFHxMuSDgMuAcYBp0bE7V2rzMzMGupoDDwifgv8tku1jHbZDwNVzO3XGbdfZ8Zk+ykiqq7BzMza4Evpzcwy5QA3M8vUsJ8HniNJa7aw2KsRsXi4a8mRpH9pYbFnIuLHw15MhiT9nxYWez4dg7Iay9Pvr8fA65D0PPAQoAaLjYuIKSNUUlYkLQROoXH7HRgRbxuhkrIi6THgVzRuvw9ExEYjVFJWlqffX/fA65sXEVs3WkDSjSNVTIZ+FhHfaLSApFVGqpgM/S4iPt1oAUlnjlQxGVpufn/dA69D0sSIeL7TZcxs5EnaNCLmNVlmTPz+OsAHIUkUd1zsv0HXg8Bfwg3WEkm7AnszsP1+FREXV1ZURiRtQnF3z3L7XdgsmAwkzYmIbSRdHhE7VV3PcHKA1yHpQ8APgfksvb/LZOAtwKERcWlVteVA0onA24AzKO5SCUX7fQqYHxGHV1RaFiQdBRxAcYvmcvvtD5wdEcdVVVsO0vDIucAhwA9q50fE90e8qGHiAK9D0jxg94hYUDN9Q+C3EbFpJYVlQtJd9Q5Qpr2auyLirRWUlQ1JdwGbR8RLNdMnALe7/RqTtDHF3t8RwI9q50fE10e4pGHjg5j1jWdpz6fsQWDFEa4lR89L2jYirq+Zvi2Q/bjjCHgVeBNwX830ddM8ayAi7gSOl3RLRPyu6nqGkwO8vlOB6yWdzdKHVqxPsQv708qqysc04BRJk1j6h3B94Mk0zxo7Arhc0nyW/vxNoRjCO6yqojL0B0kfB6ZSyrpmZ0jlxEMog5C0KfUPIs2trqq8SHojpfaLiEVV1pMTSSuw7EH06yPileqqyoukiyk6DXOA19otIr5XWVFd5gA3szFJ0m0R8faq6xhOvhfKEEmaUXUNOZN0Q9U15EzSb6quISN/lvSOqosYTu6BD5GkPSPi11XXYcsnSetGxMKq68iBpLkUxw3uBV6guLQ+ImKLSgvrIge4DRtJ6zBwDPzhKuvJUf+NmSLi8apryY2kug8Cjojas3uy5bNQ6pA0HjgY2IfidC5IVxICP609P9cGkrQVxfm3q1O6EErSYooLoTyM0oCkKcB3gJ2AxcUkrQb8ATi69voEG0jSahHxFPB01bUMN/fA65A0i+IX53QGXgl3ELBmROxXUWlZkHQT8JmIuK5m+vbAjyNiy0oKy4Ska4ATgfP6zzqRNA7YFzgiIravsLxRT9JvImIPSfcCwcC7EkZEvLmi0rrOAV7HYFcSNptnBUnzB7taUNLdEfGWka4pJ03ab9B5tvzxEEp9j0vaF/hFRLwKr52Xuy/wRKWV5eF3ki6iuBdK+UKoTwG+mVVzcyT9kGIPsNx+BwFj4jao1h3ugdchaSpwPLAjSwN7DeAKijHIe6upLB+Sdqf+hVB+ikwT6Z4nB1On/SiOwbxQVW02ujjAm5C0FkBEPFZ1LWZmZb6Qp4mIeKwc3pJ2qbKeHEgaJ+kzkr4p6T01875aVV25kLSypCMlfVnSREkHSbpQ0nckrVp1fTZ6OMCHzjezau7HwAeBx4D/kFS+/3IrD+xd3p0GrANsCFxEcRfH71KcTXFKdWXlTdK89DVmbgjmIZQ6JF042Cxgx4jw8xwbSLfx3CK9Hk/xcIy1KR5ScG2z5xUu7yTdFBFbpfunLwTWjYhI728eS1cSjrQ0JLp9RFxUdS3d4LNQ6ns/8AlgSc30/sesWWMT+l9ExMvAdEnHUlyI4iGAFqXQ/m3/Y/zSe/e4WlTvSuA0HDomwhsc4IO5Fng2Iv5YO0PSnRXUk5vZknYrP/8yIr4h6SE8BNCK2ZJWjYgl5afTS9qI5eDqwk4tT1cCewjFLCOS5AdrN7Y8XQnsg5hmGXF4t2SV2vAGiIhrgTF1/MpDKGY21iw3VwJ7CMXMxpzl5UpgB7iNGEnrAo/7UvD2uP2slsfAh0DS6ZJOkTSmn7M3jH4G3CHphKoLyZTbr0OSplddQzd5DHxoTgamAJ8Ejqq4luxExM7pYpTNqq4lR26/rlDzRfLhIRQbFilotmPgGORffBZFa9x+1goHeB2SVgeOAfYG3kDxVI9HKB6pdlxELK6suAxI+hDF5fPzKV1IQfGA2UMj4tKqasuB269zknal+P0t/wH8VfnisrHAAV6HpEsoLvs+PSIWpWlvpLih/k4R8aEq6xvtJM0Ddq99dqOkDYHfRsSmlRSWCbdfZySdCLyN4jTC8iMRPwXMj4jDKyqt6xzgdUi6MyI2Huo8K0iaD2ya7oNSnj4BmOtHqjXm9uvMYI89TMNSd42lR9L5IGZ990k6kqIH/jC8dmOcaSy9MMAGdypwvaSzGXghxf74drytcPt15nlJ20bE9TXTtwWer6Kg4eIeeB2SXg8cTXEhwBvS5IcpHml1fEQ8XlVtuZC0KfUvpJhbXVX5cPu1T9I7KW6aNomlQyjrA08C/xwRc6qqrdsc4GY2JqXjVuXbyS6qsp7h4At5hij9dbc2SZpRdQ05c/u1JoU3qbf9N+A9ksbc+fMO8KE7pOoCMjdmdl8r4vZrQtJngGuAayUdAvwG+AhwgaSDKy2uyzyEYmZjiqRbgXcBrwPuA94SEYvSsa0rImKrKuvrJp+FMoh0Mc9uDDyIdIkv4mkuPQfzYGAf4E1p8oMUF0L9NCJeqqq2HLj9OvZSRDwLPCvpr/1j3xHxxFh7JJ174HVI+hTwNeBSBl4Jtwvw9Yg4o6raciBpFrAYOJ2BF1IcBKwZEftVVFoW3H6dkTSH4sHFL0maHBEPpOkTgevG0hN5HOB1pOdevqu2t512wa6rd5GALTXYhRTN5lnB7dcZSVOAh+pcCLUexQVSv6+msu7zQcz6RHH/k1qvMsbuZjZMHpe0r6TXfr4krSBpP+CJCuvKhduvM/fXhjdARDzYH97pqszseQy8vm8DN0i6lKVXwk2hGEL5ZmVV5WN/4Hjgh5L6A2cN4Io0zxpz+3XmCkm/oLh51d/6J6ZbEbyPYijqCuC0asrrHg+hDCINl+zKsgcx3QMaAklrAUTEY1XXkiO339Clse5PAwcCG1IcT5gIjKM4rvXDiLixsgK7yAFehyQ1u+9yK8vYsiTtEhGXVV3HaCdpNaAnIv5aM32LiLilorKyI2lFYG3gubF4BpnHwOu7QtLn0sGQ10iaIGlHSadT7IbZ0PlmTE1I+hhwB/ALSbdL2rY0+7RqqspTRLwUEQvHYniDx8AHsxvFLtisdA/mxRQXBaxAsQt24ljZBRsOki4cbBaw1kjWkqmvANtExEJJ2wE/k3RMRFyAD6JbiYdQmhjru2DDIR14+wSwpHYWcE5ErDPyVeVD0q0R8Y7S+3UpLgc/HZgWEb4fjwHugTeVrnpbWHUdmbkWeDYi/lg7I51jb409LWmj/vHv1BPfAfglsHmFddko4x642SgjaUuKP4Dza6avCHwsIs6qpjIbbRzg1nU+i6czbj9rlc9CseHgs3g64/azlrgHbl23PF1IMRzcftYqB7gNK5/F0xm3nzXiADczy5THwM3MMuUANzPLlAPc2iLpFUk3SbpN0q8lrdGl9V4p6U5Jt0i6Q9LJ3Vp3Wv8Okt5Tev/Z9ASmTtc7VdJzqU3mSjojjV+bDRsHuLXruYjYKiLeDjwO/HMX131gRGwBbAG8QPEsyJalZ0oOZgfgtQCPiB918RF5f00PzH0HxSPQPtal9ZrV5QC3briGdN/01IPuTa/XlrQgvZ4m6XxJF0uaL+k7zVYaES8CRwJTJG2Zerm39c+X9CVJM0rbPVHSbOBwSXtKuk7SjZJ+L2kdSVOBzwJfSD3l90uaIelLaR1bSbo29f4vSPeE71/38ZL+IukuSe9vUvcrwF9KbbJMLWn6DEmnpvXfI+nzpc/2b2lP5GpJs0o1bpTacI6k/5W0SZq+b9obulnSVc3a1sYGB7h1RNI4YCdgsDsQlm0F7EfRQ91P0vrNviGF4c3AJi2sf0JE9EbE94CrKR5suzVwNnBkRCwAfgT8IO09/G/N958BHJV6/7dSPNi63/iI2A44omb6MtJ53O8CLk6TlqmltPgmFA8O2Q74mqQV0+1j/x7YEtgd6C0tPxP4XERsA3wJ+GGafiywa3pg7981qs/GDt/Mytr1Okk3UfQy5wGtPKTh8oh4EkDSXGADlj6yrpFWb6F6Tun1ZOCcdCe/CcC9DTcgrQ6sUboB1+nAuaVFzk//zgGmDrKajVKbbAhcVHrwQqNaLoqIF4AXJD0CrAO8l+JxYM8Dz0v6dapxVYrhn3O19JGOK6V//wScJunnpVptjHMP3Nr1XBrv3YAiYPvHwF9m6c/VxJrveaH0+hVa6ECkHv47KP5IlNddb/3PlF7/B3Byui3rZ+osO1T9tTequ38MfCNgG0n9PeFGtQylTVYAFqe9h/6vTQEi4rPAV4H1gTlKj2Kzsc0Bbh2JiGeBzwNfTAcPFwDbpNkf7WTd6SyO/0fxlPFbgIeBN0haS9JKwB4Nvn11iueYwsD7hjwNTKrzOZ4EniiNb38SWOZ2uK2IiEeBo4FjmtQymD8Be0qamHrde6T1PgXcK2lfKG5opeLOhai4/ex1EXEs0EcR5DbGOcCtY+m+HLcABwAnAIdIupHiEvB2nCXpFuA2YBVgr7Sdl4BvUBwgvIzisWODmUEx1DAHeLQ0/dfAPv0HMWu+5yDgu2nbW6VtteuXwMppG4PVUldEXE9xTOEW4HcU4/FPptkHAgdLuhm4ndQ2qe5b00HeP1McN7AxzpfSm41CklaNiCWSVgauAqZHxA1V12Wjiw9imo1OMyVtRjFefrrD2+pxD9zMLFMeAzczy5QD3MwsUw5wM7NMOcDNzDLlADczy5QD3MwsU/8fdRHNdJiN/8IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.bar(f_vc.index.astype(str), f_vc['run_duration_ranges'].values)\n",
+    "\n",
+    "# set the x-axis label and title\n",
+    "plt.xlabel('Run Duration Ranges')\n",
+    "plt.title('Histogram of Run Duration Ranges')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# display the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "f46853a5-8e8a-4b31-860b-75841b250b89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_vc['prefix_sum'] = p_vc['run_duration_ranges'][::-1].cumsum()[::-1]\n",
+    "f_vc['prefix_sum'] = f_vc['run_duration_ranges'][::-1].cumsum()[::-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "26f71648-5ff0-4249-8c57-cd9c02983bf4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>95</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>15</td>\n",
+       "      <td>95</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>73</td>\n",
+       "      <td>80</td>\n",
+       "      <td>84.210526</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, inf]</th>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
+       "      <td>7.368421</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 10.0]                     0          95             100.000000\n",
+       "(10.0, 20.0]                   15          95             100.000000\n",
+       "(20.0, 30.0]                   73          80              84.210526\n",
+       "(30.0, inf]                     7           7               7.368421"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(p_vc['prefix_sum'])\n",
+    "p_vc['prefix_sum_percentage'] = p_vc['prefix_sum'] / max_duration * 100\n",
+    "p_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "fa3616bc-7a58-4cf5-9abe-35f338be1a46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 10.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>24</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(10.0, 20.0]</th>\n",
+       "      <td>8</td>\n",
+       "      <td>24</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(20.0, 30.0]</th>\n",
+       "      <td>14</td>\n",
+       "      <td>16</td>\n",
+       "      <td>66.666667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, inf]</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>8.333333</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 10.0]                     0          24             100.000000\n",
+       "(10.0, 20.0]                    8          24             100.000000\n",
+       "(20.0, 30.0]                   14          16              66.666667\n",
+       "(30.0, inf]                     2           2               8.333333"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(f_vc['prefix_sum'])\n",
+    "f_vc['prefix_sum_percentage'] = f_vc['prefix_sum'] / max_duration * 100\n",
+    "f_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "8ef243fe-4fc7-4d1e-a9a2-a60cad698339",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# join dataframes a and b on their index\n",
+    "joined = f_vc.join(p_vc, how='outer', lsuffix='_f', rsuffix='_p')\n",
+    "\n",
+    "total = joined[['prefix_sum_f', 'prefix_sum_p']].sum(axis=1)\n",
+    "joined['f_pct'] = joined['prefix_sum_f'] / total * 100\n",
+    "joined['p_pct'] = joined['prefix_sum_p'] / total * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "6d9b5da3-21d6-43c0-a237-67e74fb582cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAFHCAYAAAC7/dtHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA+IElEQVR4nO3dd5xU9dn//9ebupQFBFakLaAILk2MSCwk9tgT9bYlmmCJWBINXxNb7iS3muS+Ncnv1pg7Go3etmjsxhqjMWC5YwM1FhBQBKUXAeksy/X743Nmd3Z2ZvfssjNn2L2ej8c8ZubU65Q513zO53POkZnhnHPOZWqTdADOOeeKkycI55xzWXmCcM45l5UnCOecc1l5gnDOOZeVJwjnnHNZeYJwWUn6iqRZad/nSTqsGaf/gaSDmmt6MecpSXdIWiXpjRzD/ELSCklLYkzvD5J+Gn0+SNKCtH4FX76mkGSShiYdB+w46wxA0lRJ323iuH+VNLG5Y8qHdkkHIGke0AeoAtYDfwW+b2brkowrRdJVwFAzOyPpWJqLJAN2N7OPcg1jZi8Dw5tpfncCC8zsJ2nTH9kc026kCcDhwAAzW5/ZU1I58ENgkJkta2hiZnZ+Pf2SWL4dWr7WmaQzge+a2YQmjn8VzXgMMLOjmmM6hVAsJYjjzKwr8CVgHPCTBoavJfpnWCzLssOTlPgfhzwZBMzLlhwi5cDKOMnBuXwout+emSX6AuYBh6V9/zXwVPR5X+CfwGrgX8BBacNNBX4J/B+wERgKjASeBz4HlgI/joZtA1wBfAysBB4Eekb9BgMGTAQ+BVYA/x71OxLYAlQC64B/Rd3PAmYCa4G5wHkZy3QZsBhYBHw3mv7QqF9H4DfRvJYCfwA61bN+zk2b1wzgS1H3imgdrAY+AL6eNs6dwO+Bp6PxXgd2i/q9FMWzPlqmU4GDgAXA5cAS4J5Ut4ztdGUUwyrgDqAk6ncm8EpG3BZtk0nR+tsSze/JzO0erZMbovW1KPrcMeqXiu2HwLJovZ5Vz/rqBzwR7QMfAedG3c8BNhFKquuAqzPGO4ywH22L+t8ZdX8oWidronU3MmM9/yI9zmz7NXAVYZ+7O9oeHwDj0ob9EvB21O8h4IHUdLMs327APwj78QrgXqBHxnx/BLwbxfxAajtF/S+lZt88m7R9M8u8pgL/BbwBfAE8TvS7ibFujo72lbXAQuBHUffewFOE/fZz4GWgTb7WGeF3kr7dV0fdu0fTXg7MJ/wpbZNl/FzHgKnAzwnHn7XAc0DvtPEaOnZ9N+2383/A9dE2zbYM44Fp0TZYCvx3tn0uxzp8CPhTFON7wDDC73gZ8BnwtXqPz/k8+Md5ZSzQwGhH+DnQP1phRxMO8IdH38vSVvKnhKTQDigl7Pg/BEqi71+Ohv0B8BowgHAwugX4c9RvMOFH8kegE7AnsBmoSFvJf8qI+RjCD1XAgcAGag7cRxJ+NCOBztHGSU8Q1xMOYD2jGJ8E/ivHujmZ8OPaJ5rXUMK/4PaEg9+PgQ7AIdEOMDztwLUy2rHaEQ4i92cevNO+HwRsBa6L1k+nzJ0v2k7vR9uoJ2GnTh0czyRHgsg8kObY7tdE22dnoIzww/p5RmzXRMt9dLS+d8qxzl4Cbor2gbGEA8AhueLMGLfWMkfdzo62UyqJvZPWr3q5cqyv9B/qpij2toSD7mtRvw6EA9QPouU7kXBAypUghhJ+Cx2jdfUScEPGfN8gJMqehD8X56ftm0uBUUAX4L7MfSFjXlMJ+19q+EdI+y00sG4WA1+JPu9Eze/jvwh/itpHr68AyvM6q7PdCcnh8Sj+wcBs4Jwc419F3WPAVMIfzmGE38tU4NqoX5xjV3qC2ApcRPit1vmzCLwKfDv63BXYt579Nds6PCKa9t3AJ8C/R+vtXOCTeo/P23Nwb45XtEDrCJl2PuHH3Ynwb/aejGH/BkxMW8nXpPX7JvB2jnnMBA5N+96X8I+gHTUJYkBa/zeA03LtHFmm/xfgB9Hn/yXtgE/4Qaf+TYvwz323tP775dpI0fL+IEv3rxCSUJu0bn8Groo+3wncltbvaODDtO/ZEsQWav/TrLXzRdvp/IxpflzPD7AxCeJj4Oi0fkcQTgWl4tgItEvrv4zoR5IxzYGEf4qlad3+i5rSQJ04M8avtcxZ+veIlqt75nLlWF/pP9S/p/UbAWyMPn+VcBBWWv9XMtdXPTEdT9p+H833jLTvvwL+kLZvXpvWb1jmvpAx7akZw4+I9pO2MdbNp8B5QLeM4a4hHJjrzDNf6yxzuxMSzhZgRFq384CpOca/iuwJ4idp3y8Eno0+xzl2pSeITxvYxi8BV5NWQsm1v2ZZh8+n9TuOcKxtG30vjbZZj1zzLpbz9sebWQ8zG2RmF5rZRsI/5ZMlrU69CJWMfdPG+yzt80DCgSabQcBjadOZSTiQ9EkbJr3VygZCps5K0lGSXpP0eTS9owlFZwj/3NLjSv9cRihVTE+L5dmoeza5lqkf8JmZbUvrNp/wz6XRyxNZbmabGhgmfVnmR3E0h37R9HJNe6WZbU37nmt5+gGfm9najGn1zzJsgyS1lXStpI8lfUH48UHNtm6MzO1REp1v7gcstOgXG/mMHCT1kXS/pIVRTH/KEk+ubZ+5b6av81wyh28P9I6xbv6N8LuYL+lFSftF3X9NKP0+J2mupCvqmXezrLMsekfLkbnPNXY/ybWe4xy70jUU+zmEZP6hpDclHduIGJemfd4IrDCzqrTvUM+xoVgSRDafEbJwj7RXFzO7Nm2YzB1k13qmdVTGtErMbGGMONLngaSOhKL2b4A+ZtYDeIZQOoBQtB6QNsrAtM8rCBtlZFoc3S1U0OeKe7cs3RcBAzMq5ssJ/6qayhoepNaylEdxQCgVdU71kLRLI6e9iPCjyjbtxlgE9JRUmjGtpq6XbwHfINRPdCeUNqFmWzeHxUB/SenTHJhrYOA/CetztJl1A85oRDyLqbsNG5I5fCVhP6533ZjZm2b2DcJpw78Q6hMws7Vm9kMz2xX4OnCJpENjxp++HI1ZZ5n734poOTL3uVz7SZzfRro4x67Y0zezOWb2TcK6vA54WFIX6v7u2pL7z2aTFHOC+BNwnKQjon8rJVFb8wE5hn8K6CtpsqSOkkolfTnq9wfgl5IGAUgqk/SNmHEsBQanHYw7EM65Lge2SjoK+Fra8A8CZ0mqkNQZ+GmqR/SP/4/A9ZJ2jmLpL+mIHPO+DfiRpL2jllpDo2V4nfCP5TJJ7aO248cB9zdimXIl0/p8T9IAST0J5zEfiLr/CxgpaaykEkLRtjHz+zPwk2i79AZ+Rtj+jWJmnxHqL/4r2l/GEP59NXpakVJCfdRKwg/xP5s4nfq8SijNfl9Su2i/HN9ATOuANZL6Eyqd43oQOFPSiGjf/I8Y45yRNvw1wMPRP9Cc60ZSB0mnS+puZpWEytVtUb9jo/1YhMrtqlS/RmjsOlsKDJDUASCK/0HCMaE0+k1dQu79JPMY0JDGHrvqJekMSWXR8WN11Hkbod6kRNIxktoTKto7NmUeuRRtgoh+7N8gVMQuJ2TlS8kRc3Ra4XDCgXIJMAc4OOr9W0LF8HOS1hIqRL+cbTpZPBS9r5T0VjSfiwk72CrCP6kn0uL4K3AjMIVQlH4t6rU5er881T0qmv+dHNcbmNlDhJZa9xEqof9CaEWyJVrOowj/hm4CvmNmH8ZcpquAu6Li7ykxxyGK4zlCy62PgV9Ecc4mHDz+Tljvr2SMdzswIprfX7JM9xeEVhrvElpavJWadhN8k/BvdhHwGPAfZvb3Jk7rbsKph4WEFjmv1T9440Xb8kRCIltNKBE8Rc3+kulqQgueNYRWao82Yl5/JVQm/4OwD/4jxmj3EOpalhAq/i+Ouje0br4NzIv28fOB06PuuxP2k3WEA/1NZjYl7jJEy9HYdfYPQuOXJZJWRN0uIvwDn0vYX+8j1NFkU+sYECO+Rh27YjgS+EDSOsKx7DQz22hmawh1H7cRtsN6Qou/ZpNqPeDyRFIFofVPx4zz6M5lJel1QsXyHQnHMZVQOXtbknHEUSzrrKUp2hLEjkzSCdFprp0I5wyf9OTgcpF0oKRdotMlE4ExhMYLLgdfZ4XhCSI/ziM0xfyYcK70gmTDcUVuOKEeZzXhOp6TzGxxohEVP19nBeCnmJxzzmXlJQjnnHNZeYJwzjmXVXHdOTCH3r172+DBg5MOwznndijTp09fYWZNvnhuh0gQgwcPZtq0aUmH4ZxzOxRJcW6nkpOfYnLOOZeVJwjnnHNZeYJwzjmXlScI55xzWXmCcM45l5UnCOecc1l5gnDOOZfVDnEdhHNu+23dtpWl65ayaO2iWq+FaxeyaO0iOrfvzIiyEVT0rmBE2QiG9x5O5/adG56wa7E8QTi3gzMzVmxYkfPAn3otXb+UbVb74W1t1IZduu5C3659WV+5nidmPUFV9MhiIQb3GExFWQUjeo8IyaOsgoreFXQv6Z7EoroC8wThXJEyM77Y/EWDB/5FaxdRua2yzvi9O/emX2k/+pX2Y+wuY6s/p179S/uzc5edadumbfU4W6q2MGflHGaumMmM5TOq31+Y+wKbq2oe2NavtF+t0kbqc1mXZn0kskvYDnG773HjxpnfasO1JBsrN8Y68K+vXF9n3G4du1Uf4DMP+qnuu3TdhY7tmu/xxFXbqvhk9SchaSyfyYwV0fvyGbVi7N25d3XSSE8e/Ur7ER5D7QpJ0nQzG9fk8T1BONd8KqsqWbJuSYMH/lWbVtUZt6RdSc4Df6pb39K+dO3QNYEly87MWPDFAmYsn1GrxDFj+Yxay9itYzcqeldUn66qKAvJY3CPwbSRt5XJF08QzhXANtvG8vXLGzzwL1u/DKP2b6qt2tK3tG+9B/5+pf3oUdKjxfzLNjOWrV9WK2GkPi9Zt6R6uE7tOjG89/BaJY6K3hUM7TmU9m3bJ7gELYMnCOe2g5mxetPqBg/8i9ctZuu2uo8V37nLzg0e+Mu6lPm/5DSrNq5i5oqZ1aeoUqer5q+pufFouzbtGNZrWJ3TVcN6DaNT+04JRr9jKeoEIen/Ad8FDHgPOAvoC9wP9AKmA982sy31TccThGuK9VvWN3jgX7R2ERu3bqwzbo+SHg0e+Hfpuov/y21G67asY9aKWXVOVX286uPq1ldC7LrTrrVLHFHLqtKOpQkvQfEp2gQhqT/wCjDCzDZKehB4BjgaeNTM7pf0B+BfZnZzfdPyBOHSbanawuK1i+s98C9cu5AvNn9RZ9zO7TvXOfBnfu9b2tfb/xeRzVs3M3vl7Dotq2avnM2Wqpr/lgO6DQiV4ml1HBW9K+jVuVeC0SdrexNEvpu5tgM6SaoEOgOLgUOAb0X97wKuAupNEK51qNpWxbL1yxo88K/YsKLOuO3btK8+wI8oG8Fhux6WtQTQrWO3FnOev7Xo2K4jo/uMZnSf0bW6b922lbmr5tZpWXXrW7eyoXJD9XA7d9k5a8uqXbru4vtCA/KWIMxsoaTfAJ8CG4HnCKeUVptZ6mTuAqB/vmL4+9y/s+CLBfmavGuiyqpKlq5fWufAv2TdkqwXcvXp0od+pf0o717OvgP2zXrg79W5l5/nb2VS9RTDeg3j+D2Or+6+zbbx6ZpPq+s4UiWO+967jzWb11QP171j97rXcpRVUN693PelSD5PMe0EPAKcCqwGHgIeBq4ys6HRMAOBv5rZqCzjTwImAZSXl+89f37jn5x3zH3H8MycZ5q6CC7PenXqlfM0T+rVp2sf2rXx6znd9jMzlqxbkrVl1bL1y6qH69y+M3v03qNOy6rdeu62w+2LxVwHcTJwpJmdE33/DrAfcDKwi5ltlbQfIWEcUd+0mloHsXTd0qwVkC5ZbdWWsi5llLQrSToU5wBYuWFl1pZVn33xWfUwHdp2yNmyqjkvSmxOxVwH8Smwr6TOhFNMhwLTgCnASYSWTBOBx/MVQJ+uffI1aedcC9Krcy8mlE9gQvmEWt3Xbl7Lhys+rFXaeGvxWzw84+Hq613aqA277bRbnZZVe/Teo6guamyKfDdzvZpwimkr8DahyWt/QnLoGXU7w8w255wI3orJOVdcNlZuzNmyKv16mfLu5VlbVu3UaaeCxFm0p5iakycI59yOoLKqko9XfVynZdXMFTPZtHVT9XC7dN2lzo0OR5SNYOcuOzdry6piPsXknHOtSvu27dmj9x7s0XsPqKjpvs22MX/1/DqV4/e8e0+t63V2KtmpzqmqCeUTEjtV5SUI55xLiJmxaO2irC2rUtf7zLhwBhVlFQ1MKTsvQTjn3A5KEv279ad/t/4ctuthtfotX7+cmStmMrTn0ISi8wThnHNFqaxLWeIPYPLLBZ1zzmXlCcI551xWDZ5iktQzS+e1Zlb3IbjOOedajDgliLeA5cBsYE70eZ6ktyTtnc/gnHPOJSdOgngeONrMeptZL+Ao4CngQuCmfAbnnHMuOXESxL5m9rfUFzN7DtjPzF4DivMOVc4557ZbnGauiyVdTrh/EoR7Ky2V1BbYlns055xzO7I4JYhvAQOAv0Sv8qhbW+CUfAXmnHMuWQ2WIMxsBXBRjt4fNW84zjnnikWcZq7DgB8Bg9OHN7ND8heWc865pMWpg3gI+ANwG1CV33Ccc84VizgJYquZ3Zz3SJxzzhWVOJXUT0q6UFJfST1Tr7xH5pxzLlFxShATo/dL07oZsGvzh+Occ65YxGnFNKQQgTjnnCsuOROEpEPM7B+STszW38wezV9YzjnnklZfCeJA4B/AcVn6GeAJwjnnWrCcCcLM/iN6P6spE5Y0HHggrdOuwM+Au6Pug4F5wClmtqop83DOOZc/9Z1iuqS+Ec3svxvoPwsYG02rLbAQeAy4AnjBzK6VdEX0/fLGhe2ccy7f6jvFVNqM8zkU+NjM5kv6BnBQ1P0uYCqeIJxzrujUd4rp6macz2nAn6PPfcxscfR5CdCnGefjnHOumdR3iukyM/uVpN8RKqVrMbOL48xAUgfg68CVWaZhkupMOxpvEjAJoLy8PM6snHPONaP6TjHNjN6nbec8jgLeMrOl0felkvqa2WJJfYFl2UYys1uBWwHGjRuXNYk455zLn/pOMT0Zvd+1nfP4JjWnlwCeIFydfW30/vh2Tt8551wexLnddxmhEnkEUJLqHud235K6AIcD56V1vhZ4UNI5wHz8oUPOOVeU4tyL6V7CdQvHAOcT/vUvjzNxM1sP9MrotpLQqsk551wRi3M3115mdjtQaWYvmtnZgD8syDnnWrg4JYjK6H2xpGOARYDf7ts551q4OAniF5K6Az8Efgd0A/5fXqNyzjmXuPqug7jOzC4HOpnZGmANcHDBInPOOZeo+uogjpYkslzg5pxzruWr7xTTs8AqoKukL9K6i3ARdLe8Ruaccy5ROUsQZnapmfUAnjazbmmvUk8OzjnX8jXYzNXMvlGIQJxzzhWXONdBOOeca4U8QTjnnMuq3gQhqa2kewsVjHPOueJRb4IwsypgUPRMB+ecc61InCup5wL/J+kJYH2qY0PPpHbOObdji5MgPo5ebWje51Q755wrYg0miNSzqSV1jb6vy3dQzjnnktdgKyZJoyS9DXwAfCBpuqSR+Q/NOedckuI0c70VuMTMBpnZIMJdXf+Y37Ccc84lLU6C6GJmU1JfzGwq0CVvETnnnCsKsVoxSfopcE/0/QxCyybnnHMtWJwSxNlAGfAo8AjQO+rmnHOuBYvTimkVcHFTJi6pB3AbMAowQmKZBTwADAbmAadE83DOOVdE8n0vpt8Cz5rZHsCewEzgCuAFM9sdeCH67pxzrsjkLUFEz7H+KnA7gJltMbPVwDeAu6LB7gKOz1cMzjnnmi6fJYghwHLgDklvS7pNUhegj5ktjoZZAvTJYwzOOeeaqME6CEk3Zum8BphmZo83MO0vAReZ2euSfkvG6SQzM0mWY76TgEkA5eXlDYXpnHOumcUpQZQAY4E50WsMMAA4R9IN9Yy3AFhgZq9H3x8mJIylkvoCRO/Lso1sZrea2TgzG1dWVhYjTOecc80pznUQY4ADolt/I+lm4GVgAvBerpHMbImkzyQNN7NZwKHAjOg1Ebg2eq+vFOKccy4hcRLETkBXwmklCFdR9zSzKkmbGxj3IuDe6HkSc4GzCKWWByWdA8wHTmlS5M455/IqToL4FfCOpKmACC2T/jOqcP57fSOa2TvAuCy9Dm1cmM455wotzoVyt0t6BhgfdfqxmS2KPl+at8icc84lKm4z1zaEJqurgKGSvpq/kJxzzhWDOM1crwNOJTwPYlvU2YCX8hiXc865hMWpgzgeGG5mDVVIO+eca0HinGKaC7TPdyDOOeeKS5wSxAZCK6YXgOpShJk16Q6vzjnndgxxEsQT0cs551wrEqeZ610NDeOcc67lyZkgJD1oZqdIeo/Qaqm6F+E+e2PyHp1zLpbKykoWLFjApk2bkg7FJaCkpIQBAwbQvn3zVhfXV4L4QfR+bLPO0TnX7BYsWEBpaSmDBw9GUtLhuAIyM1auXMmCBQsYMmRIs047ZyumtGc2rAA+M7P5QEfCk+EW5RrPOVd4mzZtolevXp4cWiFJ9OrVKy+lxzjNXF8CSiT1B54Dvg3c2eyROOe2iyeH1itf2z5OgpCZbQBOBG4ys5OBkXmJxjnnttMNN9zAhg0bGjXOyy+/zMiRIxk7diwbN26s1e/GG2+koqKC008/Pef406ZN4+KLQ8v/O++8k+9///uND7wIxUoQkvYDTgeejrq1zV9IzrnWZuvWrc02raYkiHvvvZcrr7ySd955h06dOtXqd9NNN/H8889z77335hx/3Lhx3HhjtodvNqw5l725xUkQk4ErgcfM7ANJuwJT8hqVc26HMm/ePPbYYw9OP/10KioqOOmkk6oP0tOnT+fAAw9k77335ogjjmDx4lC9edBBBzF58mTGjRvHb3/7W9588032339/9txzT8aPH8/atWupqqri0ksvZZ999mHMmDHccsstAEydOpWDDjqIk046qXq+ZsaNN97IokWLOPjggzn44IPrxPnCCy+w1157MXr0aM4++2w2b97MbbfdxoMPPshPf/rTOqWE888/n7lz53LUUUdx/fXX88Ybb7Dffvux1157sf/++zNr1qzqeI49tm57njPPPJOHH364+nvXrl2rh//KV77C17/+dUaMGJFzORNnZrFfhITSrTHjNMdr7733NudcbjNmzEh0/p988okB9sorr5iZ2VlnnWW//vWvbcuWLbbffvvZsmXLzMzs/vvvt7POOsvMzA488EC74IILzMxs8+bNNmTIEHvjjTfMzGzNmjVWWVlpt9xyi/385z83M7NNmzbZ3nvvbXPnzrUpU6ZYt27d7LPPPrOqqirbd9997eWXXzYzs0GDBtny5cvrxLhx40YbMGCAzZo1y8zMvv3tb9v1119vZmYTJ060hx56KOuypU8vFZeZ2fPPP28nnniimZlNmTLFjjnmGDMzu+OOO+x73/te1ul26dKlevjOnTvb3LlzzcxyLmdjZNsHgGm2HcfeOHdzvQ84H6gC3gS6Sfqtmf06j3nLOddUkyfDO+807zTHjoUbbqh3kIEDB3LAAQcAcMYZZ3DjjTdy5JFH8v7773P44YcDUFVVRd++favHOfXUUwGYNWsWffv2ZZ999gGgW7duADz33HO8++671f/C16xZw5w5c+jQoQPjx49nwIABUXhjmTdvHhMmTMgZ36xZsxgyZAjDhg0DYOLEifz+979n8uTJsVfDmjVrmDhxInPmzEESlZWVscfNNH78+OpmqbmWs7mbrTZWnFttjDCzLySdDvwVuAKYDniCcM5Vy2xJIwkzY+TIkbz66qtZx+nSpUu90zQzfve733HEEUfU6j516lQ6duxY/b1t27YFOZf/05/+lIMPPpjHHnuMefPmcdBBB9U7fLt27di2LTwlYdu2bWzZsqW6X/qy51rOpMVJEO0ltSfc9vt/zKxSkjUwjnMuKQ3808+XTz/9lFdffZX99tuP++67jwkTJjB8+HCWL19e3b2yspLZs2czcmTthpDDhw9n8eLFvPnmm+yzzz6sXbuWTp06ccQRR3DzzTdzyCGH0L59e2bPnk3//v3rjaO0tJS1a9fSu3fvOvOYN28eH330EUOHDuWee+7hwAMPbNQyrlmzpnr+d955Z4PDDx48mOnTp3PKKafwxBNP5Cxx5FrOhhJovsWppL4FmAd0AV6SNAj4Ip9BOed2PMOHD+f3v/89FRUVrFq1igsuuIAOHTrw8MMPc/nll7PnnnsyduxY/vnPf9YZt0OHDjzwwANcdNFF7Lnnnhx++OFs2rSJ7373u4wYMYIvfelLjBo1ivPOO6/BksKkSZM48sgj61RSl5SUcMcdd3DyySczevRo2rRpw/nnn9+oZbzsssu48sor2WuvvWKVWM4991xefPFF9txzT1599dWcB/ymLGchKNRjNHIkqZ2ZFSz6cePG2bRp0wo1O+d2ODNnzqSioiKx+c+bN49jjz2W999/P7EYWrts+4Ck6WY2rqnTjHOKCUnHEC6OK0nrfE2M8eYBawkV3FvNbJyknsADwGBCyeQUM1vVqKidc87lXYOnmCT9gfBM6osId3I9GRjUiHkcbGZj07LYFcALZrY78EL03Tm3Axs8eLCXHlqgOHUQ+5vZd4BVZnY1sB8wbDvm+Q0g9YyJuwiV384554pMnASRujHJBkn9gEqgbz3DpzPgOUnTJU2KuvWxmjvFLgH6xI7WOedcwcSpg3hKUg/CdQ9vEQ76f4w5/QlmtlDSzsDzkj5M72lmlqvJbJRQJgGUl5fHnJ1zzrnm0mAJwsx+bmarzewRQt3DHmb2szgTN7OF0fsy4DFgPLBUUl+A6H1ZjnFvNbNxZjaurKws3tI455xrNnEqqUskXSLpUeA+4GxJJTHG6yKpNPUZ+BrwPvAEMDEabCLweFODd865TM19u+98WbRoESeddFJB5tVUceog7iY0cf0d8D/ACOCeGOP1AV6R9C/gDeBpM3sWuBY4XNIc4LDou3OuFSvm233nS79+/Wrd6bUYxUkQo8zsHDObEr3OJcYDg8xsrpntGb1Gmtkvo+4rzexQM9vdzA4zs8+3dyGcc8lqqbf7rm+5rrnmGvbZZx9GjRrFpEmTUne85sYbb2TEiBGMGTOG0047DYAXX3yRsWPHMnbsWPbaay/Wrl3LvHnzGDVqFBBu23HiiSdy5JFHsvvuu3PZZZdVx3D77bczbNgwxo8fz7nnnlvYhxE1dLtX4E/AvmnfvwzcvT23kG3sy2/37Vz9/Hbf+bndd67lMjNbuXJl9XBnnHGGPfHEE2Zm1rdvX9u0aZOZma1atcrMzI499tjqaaxdu9YqKyvtk08+sZEjR5pZuEX4kCFDbPXq1bZx40YrLy+3Tz/91BYuXGiDBg2ylStX2pYtW2zChAnVtxLPlMjtvoG9gX9K+jT6Xg7MkvReyC82prmTlnOu6SY/O5l3lrzTrNMcu8tYbjjyhnqHaam3+862XD/60Y+YMmUKv/rVr9iwYQOff/45I0eO5LjjjmPMmDGcfvrpHH/88Rx//PEAHHDAAVxyySWcfvrpnHjiidVxpzv00EPp3r07ACNGjGD+/PmsWLGCAw88kJ49ewJw8sknM3v27HrjbU5xEsSReY/CObfDa6m3+862XJs2beLCCy9k2rRpDBw4kKuuuopNmzYB8PTTT/PSSy/x5JNP8stf/pL33nuPK664gmOOOYZnnnmGAw44gL/97W+UlNRu65PE7csb0mCCMLP5hQjEOdc8Gvqnny8t9Xbf2ZYrlQx69+7NunXrePjhhznppJPYtm0bn332GQcffDATJkzg/vvvZ926daxcuZLRo0czevRo3nzzTT788EPGjh3b4Lz32WcfJk+ezKpVqygtLeWRRx5h9OjRDY7XXOJUUjvnXINa6u2+sy1Xjx49OPfccxk1ahRHHHFE9amxqqoqzjjjDEaPHs1ee+3FxRdfTI8ePbjhhhsYNWoUY8aMoX379hx11FGx1mn//v358Y9/zPjx4znggAMYPHhw9WmoQsh5u29JHc1sc8EiqYff7tu5+vntvvOjGJZr3bp1dO3ala1bt3LCCSdw9tlnc8IJJ9QZLh+3+66vBPFqNIM41zw455zLg6uuuoqxY8cyatQohgwZUl3xXQj11UF0kPQtYH9JJ2b2NLNH8xeWc25H0lJv910My/Wb3/wmsXnXlyDOB04HegDHZfQzwBOEc861YDkThJm9QrhVxjQzu72AMTnnmsDM6jTJdK1Drrrk7RWnFdM9ki6W9HD0ukhS+7xE45xrkpKSElauXJm3A4UrXmbGypUr61xX0RziXCh3E9A+egf4NnAz8N1mj8Y51yQDBgxgwYIFLF++POlQXAJKSkqyXp29veIkiH3MbM+07/+I7tDqnCsS7du3Z8iQIUmH4VqYOKeYqiTtlvoiaVegKn8hOeecKwZxShCXAlMkzQVEeKrcWXmNyjnnXOLi3IvpBUm7A8OjTrOK5Qpr55xz+ROnBEGUEN7NcyzOOeeKiN+szznnXFaeIJxzzmXVYIJQcIakn0XfyyWNz39ozjnnkhSnBHETsB/wzej7WuD3eYvIOedcUYiTIL5sZt8DNgGY2SqgQ9wZSGor6W1JT0Xfh0h6XdJHkh6QFHtazjnnCidOgqiU1JZwB1cklQHbGjGPHwAz075fB1xvZkOBVcA5jZiWc865AomTIG4EHgN2lvRL4BXgP+NMXNIA4Bjgtui7gEOAh6NB7gKOb1zIzjnnCiHOhXL3SpoOHEq4kvp4M5vZwGgpNwCXAaXR917AajNLPVR2AZD1CeSSJgGTAMrLy2POzjnnXHOJ04qpJ7AM+DNwH7A0zu2+JR0LLDOz6U0JzMxuNbNxZjaurKysKZNwzjm3HeJcSf0WMJBQXyDCE+aWSFoKnFtPAjgA+Lqko4ESoBvwW6CHpHZRKWIAsHD7FsE551w+xKmDeB442sx6m1kv4CjgKeBCap4RUYeZXWlmA8xsMHAa8A8zOx2YApwUDTYReHw74nfOOZcncRLEvmb2t9QXM3sO2M/MXgM6NmGelwOXSPqIUCfhjzN1zrkiFOcU02JJlwP3R99PJdRDtCVmc1czmwpMjT7PBfxKbOecK3JxShDfItQV/CV6lUfd2gKn5Csw55xzyYrTzHUFcFGO3h81bzjOOeeKRYMJIrpy+jJgJKE1EgBmdkge43LOOZewOKeY7gU+BIYAVwPzgDfzGJNzzrkiECdB9DKz24FKM3vRzM4m3C7DOedcCxanFVNl9L5Y0jHAIqBn/kJyzjlXDOIkiF9I6g78EPgd4YroyfkMyjnnXPLiJIhVZrYGWAMcDCDpgLxG5ZxzLnFx6iB+F7Obc865FiRnCULSfsD+QJmkS9J6dSNcJOecc64Fq+8UUwegazRMaVr3L6i52Z5zzrkWKmeCMLMXgRcl3Wlm8wsYk3POuSIQp5K6o6RbgcHpw/uV1M4517LFSRAPAX8gPFe6Kr/hOOecKxZxEsRWM7s575E455wrKnGauT4p6UJJfSX1TL3yHplzzrlExSlBTIzeL03rZsCuzR+Oc865YhHneRBDChGIc8654tLgKSZJnSX9JGrJhKTdJR2b/9Ccc84lKU4dxB3AFsJV1QALgV/kLSLnnHNFIU6C2M3MfkV0228z2wCooZEklUh6Q9K/JH0g6eqo+xBJr0v6SNIDkjps1xI455zLizgJYoukToSKaSTtBmyOMd5m4BAz2xMYCxwpaV/gOuB6MxsKrALOaUrgzjnn8itOgvgP4FlgoKR7gRcIz6iulwXroq/to5cRnkb3cNT9LuD4RsbsnHOuAOK0Ynpe0lvAvoRTSz8wsxVxJi6pLTAdGAr8HvgYWG1mW6NBFgD9mxK4c865/IrTiukEwtXUT5vZU8BWScfHmbiZVZnZWGAAMB7YI25gkiZJmiZp2vLly+OO5pxzrpnEOsUUPVEOADNbTTjtFFs0zhRgP6CHpFTJZQChVVS2cW41s3FmNq6srKwxs3POOdcM4iSIbMM0eGpKUpmkHtHnTsDhwExCokg9T2Ii8HisSJ1zzhVUnFttTJP034Q6BIDvEeoVGtIXuCuqh2gDPGhmT0maAdwv6RfA28DtTYjbOedcnsVJEBcBPwUeILRCep6QJOplZu8Ce2XpPpdQH+Gcc66I1Zsgon//T5nZwQWKxznnXJGotw7CzKqAbZK6Fyge55xzRSLOKaZ1wHuSngfWpzqa2cV5i8o551zi4iSIR6OXc865ViTOldR3Rc1Uy81sVgFics45VwTiXEl9HPAO4X5MSBor6Yk8x+Wccy5hcS6Uu4rQLHU1gJm9gz9u1DnnWrw4CaIy/VYbkW35CMY551zxiFNJ/YGkbwFtJe0OXAz8M79hOeecS1qcEsRFwEjCA4DuA9YAk/MYk3POuSKQswQhqQQ4n/Ash/eA/dKe4+Ccc66Fq68EcRcwjpAcjgJ+U5CInHPOFYX66iBGmNloAEm3A28UJiTnnHPFoL4SRGXqg59acs651qe+EsSekr6IPgvoFH0XYGbWLe/ROeecS0zOBGFmbQsZiHPOueISp5mrc865VijOhXLOOecKwQyWLIEZM2DmzPB+7bXQLZkz+p4gnHOu0LZtg08/rUkCqfcZM2BN2p2NuneH730PRo5MJExPEM45ly9bt8LcuXWTwIcfwoYNNcPtvDOMGAHf+lZ4r6gI77vsAlJi4XuCcM657bV5M8yeXTsJzJwZum3ZUjPcwIHh4D9pUk0SqKiAXr2Si70eeUsQkgYCdwN9AANuNbPfSuoJPAAMBuYBp5jZqnzF4ZxzzWbduvDvP/PU0Mcfh9NGEP7x77prOPgffXR4HzEC9tgDSkuTjb+R8lmC2Ar80MzeklQKTI+ea30m8IKZXSvpCuAK4PI8xuGcc42zalXdJDBzJsyfXzNMu3YwbBiMGQOnnVZTGhg2DDp1Si72ZpS3BGFmi4HF0ee1kmYC/YFvAAdFg90FTCVfCeKhh8L5P1dc2rSBPn2gX7+aV/fuiZ5rda2QGSxbVjcJzJgRWhKllJSEf/8HHADnnltzami33aB9++TiL4CC1EFIGgzsBbwO9ImSB8ASwimo/LjzTnjmmbxN3jWjzp1rJ4zUq3//2t87d046UrejMYPPPsveYmhV2tnt0tJw4D/qqNr1A4MGQdvWed1w3hOEpK7AI8BkM/tCaf8SzcwkWY7xJgGTAMrLy5s280cfrTkv6IrH1q2wdCksWlTzWriw5vO0aeH7xo11x+3evW7SyEwku+wCHToUfrlcsqqq4JNPsrcYWreuZrjevcPB/5RTarcY6tfPS7EZZJb1+Nw8E5faA08BfzOz/466zQIOMrPFkvoCU81seH3TGTdunE2bNi1vcboiZBbag6cnkcxEknptzXIvybKyhhNJWVmr/We4Q9uyBebMqdtiaNas0JoopX//2iWB1HtZWXKxF5ik6WY2rqnj57MVk4DbgZmp5BB5ApgIXBu9P56vGNwOTIIePcJrxIjcw23bBitW1J9I3norlFgy/wy1bRtKGw0lkp128n+WSdiwIXuLoY8+CqUFCNtl8OCwj3zta7VbDHXvnmj4LUHeShCSJgAvEx44lDrP82NCPcSDQDkwn9DM9fP6puUlCLfdtm4NFY8NlUg+z7IrduyYu04kvVvXroVfrpZgzZrsLYbmzatJ6m3bwu6715QEUqWB4cO9Xqoe21uCyOsppubiCcIVzMaNsHhx/Ylk4UJYv77uuKWlDSeSvn1DwmmNli/P3mJo0aKaYTp2DAf99CQwYgQMHer1Sk1QtKeYnNshdeoULnLaddf6h1u7Nnt9SKrbK6+E9/SraFN69Wo4key8c2hnv6MxC+sgW4uhlStrhuvaNRz8Dz+8dv3AkCFeL1REdsA90LkiUFoaznPvsUfuYczCKav6Esl774VTX5mt7bJdK5ItmfTunUz9SFVVuGgsMwnMnBmSZ8pOO4UbzZ14Yu0SwYABXq+zA/AE4Vy+SKG00KtXuNo2l6qqcMFWrkQyfz68+mqojM/UoUM4bdVQIunWrWkH5MrKUCmceWroww9h06aa4fr2DQf/iRNrlwh23tkTwQ7ME4RzSWvbNhxg+/atf7jNm0NpI1ci+eADeP55+OKLuuN26dLwRYjr1tUuCcyYEZqTpjcjHjQoHPwPOaQmCVRUhJKCa3E8QTi3o+jYMRygBw2qf7h160JFe65E8vrr4XN6CSBdmzahUriiAo4/vqZEMHy4t9RqZTxBONfSdO0amoTuvnvuYcxg9era9SGdO4dEsPvurbellavFE4RzrZEUTgulKpGdy6JN0gE455wrTp4gnHPOZeUJwjnnXFaeIJxzzmXlCcI551xWniCcc85l5QnCOedcVp4gnHPOZbVDPA9C0nLCw4WaojeQ5S5nLkG+TYqTb5fis73bZJCZNfkZqztEgtgekqZtzwMzXPPzbVKcfLsUn6S3iZ9ics45l5UnCOecc1m1hgRxa9IBuDp8mxQn3y7FJ9Ft0uLrIJxzzjVNayhBOOecawJPEM4557JqUQ8MktQzxmDbzGx1vmNxgaRLYgy23sxuyXswrpqkE2MMtsnMnsl7MA4ozuNXi6qDkLQJWASonsHamll5gUJq9SQtBm6m/m1yupkNK1BIDpC0Enic+rfLV81stwKF1OoV4/GrRZUggJlmtld9A0h6u1DBOADuMbNr6htAUpdCBeOq/dXMzq5vAEl/KlQwDijC41dLK0GUmNmm7R3GOecKTVKFmc1sYJiCHr9aVIIAkCRgPNA/6rQQeMNa2oLuQCQdARxP7W3yuJk9m1hQDkl7AN+g9nZ5oqGDlMsPSdPNbG9JL5jZoUnHAy0sQUj6GnATMIewswMMAIYCF5rZc0nF1lpJugEYBtwNLIg6DwC+A8wxsx8kFFqrJuly4JvA/dTeLqcB95vZtUnF1lpFp48eAi4Ars/sb2b/XfCYWliCmAkcZWbzMroPAZ4xs4pEAmvFJM3OVgEdlfRmm9nuCYTV6kmaDYw0s8qM7h2AD3y7FJ6k4YSS9mTgD5n9zezqAofU4iqp21HzbyjdQqB9gWNxwSZJ+5jZmxnd9wG8Lig524B+1L2Nft+onyswM5sFXCfpXTP7a9LxQMtLEP8LvCnpfuCzqNtAQrH59sSiat3OBG6WVEpN8h4IrIn6uWRMBl6QNIea30o54XTs95MKygHwD0nfAgaTdoxuqDVgPrSoU0wQWgKQveJtRnJROUm7kLZNzGxJkvE4kNSGug063jSzquSicpKeJfyBmg5Ubwsz+/8KHktLSxDOObcjk/S+mY1KOg5oRfdiknRV0jG42iS9lXQMri5JTyUdQyv3T0mjkw4CWlEJQtJxZvZk0nE4V+wk9TWzxUnH0VpJmkGoC/oE2Ey49YaZ2ZiCx9JaEoRLlqQ+1K6DWJpkPK5G6iZxZvZ50rE4kDQoW3czy2xxlnctqhWTpHbAOcAJhCZ8EF21C9ye2ebb5Z+ksYQ23d1Ju3hR0mrCxYt+mikBksqBXwGHAqtDJ3UD/gFckXktkcs/Sd3M7AtgbdKxpLSoEoSkPxN29ruofXXoRKCnmZ2aUGitlqR3gPPM7PWM7vsCt5jZnokE1spJehW4AXg41WpJUlvgZGCyme2bYHitkqSnzOxYSZ8ARu27upqZ7VrwmFpYgsh61W5D/Vz+SJqT66pcSR+Z2dBCx+Qa3C45+7nWpUWdYgI+l3Qy8IiZbYPqtt4nA6sSjaz1+qukpwn3Ykq/ePE7gN+sLznTJd1EKG2nb5eJgN8S3wEtrwQxGLgOOISahNADmEI4r/pJMpG1bpKOIvvFi/60soRE91w6hyzbhVBftzmp2FzxaFEJIp2kXgBmtjLpWJxzbkfUYi+UM7OV6clB0uFJxtNaSWor6TxJP5e0f0a/nyQVV2snqbOkyyRdKqlE0kRJT0j6laSuScfnikOLTRBZ+M36knELcCCwEvidpPR72p+YTEgOuBPoAwwBnibcXffXhJYzNycXlsskaWb0KvhNFFvUKSZJT+TqBRxiZv7s4wKLbl08JvrcjvBAp96Eh9W81tAzeF1+SHrHzMZGz+VYDPQ1M4u+/yuJq3ZdbtEp833N7OlCzreltWL6CnAGsC6je+oxpK7wOqQ+mNlWYJKknxEuyPJTGQmLksIzqUfyRt9bzr/GHVC2uw5Ep8sLmhyg5SWI14ANZvZiZg9JsxKIx8E0SUemP3/azK6RtAg/lZGkaZK6mtk6Mzs71VHSbhTRlbytSTHedaBFnWJyzm0/STI/MBRcMd51oDVVUjvnYvDkkJgumckBwMxeAxKpP21pp5icc25HVXR3HfBTTM45VySK7a4DniBcIiT1BT73WzoUF98uLl2rqIOQdJekmyUVxXNeHQD3AB9K+k3SgbhafLsUIUmTkphva6mD+B+gHPg2cHnCsTjAzA6LLsoakXQsroZvl6KlhgfJw0z9FJPLt+iAM57a51Xf8NYyyfLt4hrSohKEpO7AlcDxwM6EpzItIzxy9FozW51YcK2UpK8Rbq8xh7SLfwgPZb/QzJ5LKrbWzLdLcZJ0BOH4lZ60H0+/0LSg8bSwBPE3wi0c7jKzJVG3XQgPQTnUzL6WZHytkaSZwFGZzziWNAR4xswqEgmslfPtUnwk3QAMIzRzTX9k8neAOWb2g4LH1MISxCwzG97Yfi5/JM0BKqL7MKV37wDM8EeOJsO3S/HJ9Vjk6FTg7CQeA9vSKqnnS7qMUIJYCtU3vjqTmgtPXGH9L/CmpPupffHPafgt2JPk26X4bJK0j5m9mdF9H2BTEgG1tBLETsAVhAtNdo46LyU8RvE6M/s8qdhaM0kVZL/4Z0ZyUTnfLsVF0pcIN7AspeYU00BgDfA9M5te8JhaUoJwzrkdXVRvmn677yVJxdIqLpSD6uzsioikq5KOwdXl2yU5UXIgKi18CuwvKbFrUlpNggAuSDoAV0fBi8wuFt8uCZB0HvAq8JqkC4CngGOAxySdk0hMforJOeeSJ+k94MtAJ2A+MNTMlkR1q1PMbGyhY2pprZhSF8sdSe2Kt7/5RXLJiJ5DfQ5wAtAv6ryQcPHi7WZWmVRsrZlvl6JUaWYbgA2SPk7VPZjZqqQeA9uiShCSvgP8B/Acta8OPRy42szuTiq21krSn4HVwF3UvvhnItDTzE5NKLRWzbdL8ZE0HdjXzColDTCzBVH3EuD1JJ4o19ISxCzgy5mlhaiI9nq2i1BcfuW6+Kehfi6/fLsUH0nlwKIsFy/2J1zU+PdCx9TSKqlFuP9Spm0kdDdEx+eSTpZUva9JaiPpVGBVgnG1dr5dis9nmckBwMwWppJDdFV1wbS0OohfAm9Jeo6aq0PLCaeYfp5YVK3bacB1wE2SUgeeHsCUqJ9Lhm+X4jNF0iOEm/N9muoY3f5kAuH03xTgzkIF1KJOMUH16aQjqFtJ7f+KEiapF4CZrUw6FlfDt0txiOoazgZOB4YQ6ohKgLaEetWbzOztgsbUkhKEJDV0L/s4w7jCkHS4mT2fdBytlaRuQJmZfZzRfYyZvZtQWA6Q1B7oDWxMsgVmS6uDmCLpoqiyp5qkDpIOkXQXoZjmioPfFC4hkk4BPgQekfSBpH3Set+ZTFQuxcwqzWxx0s3zW1odxJGEItqfo/varyZcdNKGUES7odBFtNZO0hO5egG9ChmLq+XHwN5mtljSeOAeSVea2WN4gw4XaVGnmNIVSxGttYsqQM8A1mX2Ah4wsz6Fj8pJes/MRqd970u4tcNdwJlm5vcucy2uBFEtuhJ0cdJxOF4DNpjZi5k9outWXDLWStotVf8QlSQOAv4CjEwwLldEWmwJwjmXm6Q9CYl7Tkb39sApZnZvMpG5YuIJwuWVtywrTr5dXBwtrRWTKz7esqw4+XZxDfIShMurYrz4x/l2cfF4gnAF4y3LipNvF5eLJwjnnHNZeR2Ec865rDxBOOecy8oThCsoSVWS3pH0vqQnJfXIwzwOkvRUM05vsqTOad+faY64Jd0p6aRmmM5Vkn7UiOF/vL3zdK2DJwhXaBvNbKyZjQI+B76XdEAK6vstTAaqE4SZHb2DV+Z6gnCxeIJwSXqV6LkdkqZKGhd97i1pXvT5TEmPSnpW0hxJv8o2IUlHSvpQ0lvAiWnda/27jkoug6PXLEl3A+8DAyXdLGladHfTq6PhLwb6Ea4bmBJ1myepd/T5kmia70uaHHUbLGmmpD9G03pOUqcc6+CwaJ6zJR2btsz/kxbzU9FtMFLL+Zakf0l6Ict6OFfSXyV1knSGpDeiEtstktpKuhboFHW7V1IXSU9H03tf4YlyzgEt+F5MrrhJagscSrxbfo8F9gI2A7Mk/c7MUk8MTLXp/yNwCPAR8EDMMHYHJprZa9F0/t3MPo9ie0HhuQg3SroEONjMVmQsw97AWcCXCTcffF3Si4RHdu4OfNPMzpX0IPBvwJ+yxDAYGA/sRkhCQ3MFK6ksWs6vmtknknpm9P8+4emJxwO7AqcCB5hZpaSbgNPN7ApJ3zezsdE4/0Z4DvIx0ffu8Vadaw28BOEKrZOkd4AlQB8gzgODXjCzNWa2CZgBDMrovwfwiZnNiW4Nke1AnM38VHKInBKVQN4m3LBuRAPjTwAeM7P1ZrYOeBT4StTvEzN7J/o8nZAIsnnQzLZF90SaGy1LLvsCL5nZJwBm9nlav+8ARwEnmdlmQvLdG3gzWt+HEpJGpveAwyVdJ+krZramvgV2rYsnCFdoG6N/r4MI/7pTdRBbqdkfSzLG2Zz2uYrGlXzTp5s57fWpDwrPD/kRcKiZjQGezhJHY8SNOfNCJKP+mHN5j5CEBkTfBdwV1feMNbPhZnZVnZmbzQa+FI3/C0k/izEv10p4gnCJMLMNwMXADyW1A+YR/vECNLZlz4fAYEm7Rd+/mdZvHuEAiKQvEW4rkU03QsJYI6kP4d94ylqgNMs4LwPHS+osqQtwQtStMU6W1CaKfVdgVhTz2Kj7QMIpKAi3Tv9qlMzIOMX0NnAe8ISkfsALwEmSdk4NKylV8qpUuHqaaNgNZvYn4NdE68o58DoIlyAze1vSu4QD+m+AByVNIvx7b8x0NqXGk7SBcJBOHdAfAb4j6QPgdWB2jmn8S9LbhGTzGfB/ab1vBZ6VtMjMDk4b5y1JdwJvRJ1ui5ZpcCPC/zQavxtwfrQs/wd8QjidNhN4K5rf8mg5H41aXS0j1Dmk4nklqpB/Our+E+C5aNhKQmltfrQ870an0+4Gfi1pWzTMBY2I3bVwfqsN55xzWfkpJuecc1l5gnDOOZeVJwjnnHNZeYJwzjmXlScI55xzWXmCcM45l5UnCOecc1l5gnDOOZfV/w/+o0HHiccixgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot the two series on the same graph\n",
+    "plt.plot(joined.index.astype(str), joined['f_pct'], color='red', label='percent of failure')\n",
+    "plt.plot(joined.index.astype(str), joined['p_pct'], color='green', label='percent of passing')\n",
+    "\n",
+    "# set x and y axis labels\n",
+    "plt.xlabel('Run duration buckets')\n",
+    "plt.ylabel('Percentage of passing or failing')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# set title and legend\n",
+    "plt.title('Percentage contribution of failing and passing to their sum')\n",
+    "plt.legend()\n",
+    "\n",
+    "# show the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2283c2da-308e-4925-b367-9f9d561dbcc8",
+   "metadata": {},
+   "source": [
+    "In the above graph we see that most of the tests are passing. The above graph is largely impacted by the number of passing and failing tests amongst all tests ie it is impacted by the number of passes and failures.\n",
+    "\n",
+    "If we want to ignore the aspect of the number of tests passing and failing and only focus on the trend within the failing tests and the trens within the passing tests, we can get percent of percentages. Lets see how that graph looks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "66e49103-427a-4c2b-9222-df285f90eab6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# join dataframes a and b on their index\n",
+    "joined = f_vc.join(p_vc, how='outer', lsuffix='_f', rsuffix='_p')\n",
+    "\n",
+    "total = joined[['prefix_sum_percentage_f', 'prefix_sum_percentage_p']].sum(axis=1)\n",
+    "joined['f_pct'] = joined['prefix_sum_percentage_f'] / total * 100\n",
+    "joined['p_pct'] = joined['prefix_sum_percentage_p'] / total * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "ea2e25a5-86ef-414e-828f-6cee585754df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYkAAAFHCAYAAABUP7B5AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABXvElEQVR4nO3deZxN9f/A8dfbvkYiWRIlspOllLIleyTaKFQURb4tWn4tpOXbSvpKShktkohIStlbLaWQrUKFbNkZxsz798fnjK4xy50x9547976fj8d9zJ2zvu899573PZ/zWURVMcYYY1KTy+8AjDHGRC5LEsYYY9JkScIYY0yaLEkYY4xJkyUJY4wxabIkYYwxJk2WJEyqROQyEVkb8P9GEbkiG7e/SkSaZdf2gtyniMg4EdktIovTWOZJEdkpIn8Hsb3XRORR73kzEfkrYF7YX19WiIiKSGW/44Cc854BiMh8Ebkti+vOEpGe2R1TqOTxOwAR2QiUBhKBg8As4C5VPeBnXMlEZAhQWVV7+B1LdhERBc5X1V/TWkZVFwFVs2l/ccBfqvpIwPZrZMe2M6kJ0Aoor6oHU84UkQrAvcA5qro9o42p6h3pzPPj9eVooXrPRKQXcJuqNsni+kPIxnOAqrbNju2ES6RcSXRU1SLAhUAD4JEMlj+B9wsxUl5Ljicivv94CJFzgI2pJQhPBWBXMAnCmFCIyO+eqvr6ADYCVwT8/zzwiff8YuAbYA/wE9AsYLn5wFPA18BhoDJQA/gC+AfYBjzsLZsLeBD4DdgFTAJKePMqAgr0BP4AdgL/581rAxwFEoADwE/e9N7AamA/8Dtwe4rXNBjYCmwBbvO2X9mblx94wdvXNuA1oGA670+fgH39AlzoTa/mvQd7gFXAVQHrxAGjgJneet8D53nzFnrxHPRe03VAM+Av4AHgb+Cd5GkpjtNDXgy7gXFAAW9eL+CrFHGrd0z6eu/fUW9/M1Ied+89GeG9X1u85/m9ecmx3Qts997X3um8X2WB6d5n4Fegjzf9ViAed8V6ABiaYr0rcJ+jJG9+nDf9Q+892eu9dzVSvM9PBsaZ2ucaGIL7zL3tHY9VQIOAZS8EfvTmfQh8kLzdVF7fecBc3Od4J/AeUDzFfu8DfvZi/iD5OHnz7+ffz+YtBHw2U9nXfOAZYDGwD/gY73sTxHvTzvus7Ac2A/d500sCn+A+t/8Ai4BcoXrPcN+TwOO+x5tezNv2DmAT7odprlTWT+scMB8Yhjv/7AdmAyUD1svo3HVbwHfna2C4d0xTew2NgKXeMdgGvJTaZy6N9/BD4F0vxhVAFdz3eDvwJ3BlhufoUJ38g32keFFnex+GYUA5701rhzvJt/L+LxXwRv+BSwx5gKK4D/+9QAHv/4u8Ze8GvgPK405IY4D3vXkVcV+UN4CCQB3gCFAt4I1+N0XM7XFfVgGaAof49+TdBvfFqQEU8g5QYJIYjjuJlfBinAE8k8Z70w33BWvo7asy7tdwXtwJ8GEgH9DC+xBUDTh57fI+XHlwJ5KJKU/gAf83A44Bz3rvT8GUH0DvOK30jlEJ3Ac7+QTZizSSRMqTaRrH/Qnv+JwJlMJ9uYaliO0J73W3897v09N4zxYCr3qfgbq4k0CLtOJMse4Jr9mbdot3nJIT2fKAecdfVxrvV+CXNd6LPTfuxPudNy8f7iR1t/f6uuBOSmklicq470J+771aCIxIsd/FuGRZAvcD446Az+Y2oCZQGJiQ8rOQYl/zcZ+/5OWnEPBdyOC92Qpc5j0/nX+/H8/gfhjl9R6XARLi9+yk445LEB978VcE1gG3prH+EE4+B8zH/eisgvu+zAf+680L5twVmCSOAQNw39WTfjAC3wI3ec+LABen83lN7T1s7W37bWAD8H/e+9YH2JDhOTqrJ/fsengv6gAu427CfcEL4n7VvpNi2c+BngFv9BMB824AfkxjH6uBlgH/l8H9MsjDv0mifMD8xcD1aX1AUtn+NOBu7/lbBJz0cV/q5F/VgvsFf17A/MZpHSjv9d6dyvTLcIkoV8C094Eh3vM4YGzAvHbAmoD/U0sSRznxF+cJH0DvON2RYpu/pfMlzEyS+A1oFzCvNa5YKDmOw0CegPnb8b4oKbZ5Nu4XY9GAac/w71XBSXGmWP+E15zK/OLe6yqW8nWl8X4Fflm/DJhXHTjsPb8cdyKWgPlfpXy/0ompMwGfe2+/PQL+fw54LeCz+d+AeVVSfhZSbHt+iuWre5+T3EG8N38AtwOnpVjuCdzJ+aR9huo9S3nccUnnKFA9YNrtwPw01h9C6knikYD/+wOfec+DOXcFJok/MjjGC4GhBFyppPV5TeU9/CJgXkfcuTa3939R75gVT2//kVKO31lVi6vqOaraX1UP434xdxORPckP3I3HMgHr/Rnw/GzcySY15wBTA7azGncyKR2wTGBtlkO4jJ0qEWkrIt+JyD/e9trhLqPB/YILjCvweSnc1cWygFg+86anJq3XVBb4U1WTAqZtwv2CyfTr8exQ1fgMlgl8LZu8OLJDWW97aW17l6oeC/g/rddTFvhHVfen2Fa5VJbNkIjkFpH/ishvIrIP9wWEf491ZqQ8HgW88ueywGb1vrWeP0mDiJQWkYkistmL6d1U4knr2Kf8bAa+52lJuXxeoGQQ7801uO/FJhFZICKNvenP466CZ4vI7yLyYDr7zpb3LBUlvdeR8jOX2c9JWu9zMOeuQBnFfisuoa8RkSUi0iETMW4LeH4Y2KmqiQH/QwbnhkhJEqn5E5eNiwc8CqvqfwOWSfkhOTedbbVNsa0Cqro5iDgC94GI5Mdddr8AlFbV4sCnuKsEcJfZ5QNWOTvg+U7cgakREEcxdTft04r7vFSmbwHOTnGzvgLu11VWacaLnPBaKnhxgLs6KpQ8Q0TOyuS2t+C+WKltOzO2ACVEpGiKbWX1fbkR6IS7X1EMd9UJ/x7r7LAVKCcigds8O62Fgadx72ctVT0N6JGJeLZy8jHMSMrlE3Cf43TfG1VdoqqdcEWI03D3F1DV/ap6r6qeC1wF3CMiLYOMP/B1ZOY9S/n52+m9jpSfubQ+J8F8NwIFc+4Kevuqul5Vb8C9l88Ck0WkMCd/73KT9g/OLIvkJPEu0FFEWnu/Wgp4ddHLp7H8J0AZERkkIvlFpKiIXOTNew14SkTOARCRUiLSKcg4tgEVA07I+XBlsDuAYyLSFrgyYPlJQG8RqSYihYBHk2d4v/zfAIaLyJleLOVEpHUa+x4L3Cci9b0aXJW91/A97pfLYBHJ69Ut7whMzMRrSiuhpudOESkvIiVw5ZofeNN/AmqISF0RKYC7zM3M/t4HHvGOS0ngMdzxzxRV/RN3P+MZ7/NSG/crLNPb8hTF3Z/ahfsyPp3F7aTnW9xV7V0iksf7XDbKIKYDwF4RKYe7ER2sSUAvEanufTYfD2KdHgHLPwFM9n6JpvneiEg+EekuIsVUNQF3wzXJm9fB+xwL7oZ3YvK8TMjse7YNKC8i+QC8+CfhzglFve/UPaT9OUl5DshIZs9d6RKRHiJSyjt/7PEmJ+HuoxQQkfYikhd38z1/VvaRnohNEt4XvhPu5uwOXHa+nzRi9ooYWuFOln8D64Hm3uyXcTeLZ4vIftxN0otS204qPvT+7hKRH7z9DMR9yHbjflFND4hjFjASmIe7rP7Om3XE+/tA8nTvMv1L0miPoKof4mpwTcDdmJ6Gq11y1HudbXG/il4FblbVNUG+piHAeO9S+Nog18GLYzauRtdvwJNenOtwJ5Avce/7VynWexOo7u1vWirbfRJXe+NnXA2MH5K3nQU34H7VbgGmAo+r6pdZ3NbbuGKIzbiaOt+lv3jmeceyCy6Z7cFdGXzCv5+XlIbiavbsxdVe+ygT+5qFu8E8F/cZnBvEau/g7r38jasMMNCbntF7cxOw0fuM3wF096afj/ucHMCd7F9V1XnBvgbvdWT2PZuLqxDzt4js9KYNwP0S/x33eZ2Au2eTmhPOAUHEl6lzVxDaAKtE5ADuXHa9qh5W1b24eyFjccfhIK4mYLZKrlVgQkREquFqBeVPUa5uTKpE5HvczeZxPscxH3fDdqyfcQQjUt6zaBSxVxI5mYhc7RV5nY4rQ5xhCcKkRUSaishZXtFJT6A2rkKDSYO9Z+FjSSI0bsdV0/wNV3baz99wTISriruvswfXzqerqm71NaLIZ+9ZmFhxkzHGmDTZlYQxxpg0WZIwxhiTpsjrcTAVJUuW1IoVK/odhjHG5CjLli3bqaqn1MAuRySJihUrsnTpUr/DMMaYHEVEgul6JV1W3GSMMSZNIU0S4oa8XCEiy0VkacD0ASKyRtxwhc+FMgZjjDFZF47ipuaqmtwUHhFpjmuyXkdVjyT3YWSMMSby+HFPoh+uj/ojAJrFoSITEhL466+/iI/PqHdrE20KFChA+fLlyZs3r9+hGBP1Qp0kFNepngJjVPV1XL/ol4nIU7hRk+5T1SWZ3fBff/1F0aJFqVixIif2GGyimaqya9cu/vrrLypVquR3OMZEvVAniSaqutkrUvpCRNZ4+yyBGwO2ITBJRM5NMYAIItIXNz4yFSqc3O19fHy8JYgYJCKcccYZ7Nixw+9QjIkJIb1xnTyoj1ekNBXX5/tfwEfqLMb1i37SSF+q+rqqNlDVBqVKpV7N1xJEbLLjbkz4hCxJiEjh5BHCvFGUrsR1mT0Nb5wHEamCG8RnZxqbMUEYMWIEhw4dytQ6ixYtokaNGtStW5fDhw+fMG/kyJFUq1aN7t27p7E2LF26lIED3dACcXFx3HXXXZkP3EQEVWXk9yMZOn+o36GYCBTK4qbSuHGlk/czQVU/80aHektEVuIGI++ZsqgpFhw7dow8ebLn7R8xYgQ9evSgUKFCGS/see+993jooYfo0aPHSfNeffVVvvzyS8qXT3sgrQYNGtCgQYMsxZudr92cGlXlkbmP8PRXbmC5mmfW5Jrq1/gclYkkIbuSUNXfVbWO96ihqk9504+qag9VramqF6pqMKNjRZyNGzdywQUX0L17d6pVq0bXrl2P/5pftmwZTZs2pX79+rRu3ZqtW10Pxs2aNWPQoEE0aNCAl19+mSVLlnDJJZdQp04dGjVqxP79+0lMTOT++++nYcOG1K5dmzFjxgAwf/58mjVrRteuXY/vV1UZOXIkW7ZsoXnz5jRv3vykOOfMmUO9evWoVasWt9xyC0eOHGHs2LFMmjSJRx999KSrhTvuuIPff/+dtm3bMnz4cBYvXkzjxo2pV68el1xyCWvXrj0eT4cOJ4/H3qtXLyZPnnz8/yJFihxf/rLLLuOqq66ievXqab5OEz6qyv1f3M/TXz3NbfVu48IyF9JvZj92HLT7PSaAqkb8o379+prSL7/8ctK0cNqwYYMC+tVXX6mqau/evfX555/Xo0ePauPGjXX79u2qqjpx4kTt3bu3qqo2bdpU+/Xrp6qqR44c0UqVKunixYtVVXXv3r2akJCgY8aM0WHDhqmqanx8vNavX19///13nTdvnp522mn6559/amJiol588cW6aNEiVVU955xzdMeOHSfFePjwYS1fvryuXbtWVVVvuukmHT58uKqq9uzZUz/88MNUX1vg9pLjUlX94osvtEuXLqqqOm/ePG3fvr2qqo4bN07vvPPOVLdbuHDh48sXKlRIf//9d1XVNF9nsPw+/jldUlKSDvh0gDIEvXPmnZqYlKgrtq3QvE/k1W6TuvkdnskmwFI9xfNvdFzzDxoEy5dn7zbr1oURI9Jd5Oyzz+bSSy8FoEePHowcOZI2bdqwcuVKWrVqBUBiYiJlypQ5vs51110HwNq1aylTpgwNGzYE4LTTTgNg9uzZ/Pzzz8d/je/du5f169eTL18+GjVqdLwIqG7dumzcuJEmTZqkGd/atWupVKkSVapUAaBnz56MGjWKQYMGBf027N27l549e7J+/XpEhISEhKDXTalRo0bHq62m9TqtWmvoJWkS/Wf2Z8yyMdxz8T28cOULiAg1z6zJ0GZDeXjuw0xaNYlra2Rm+HMTraIjSfgkZS0bEUFVqVGjBt9++22q6xQuXDjdbaoqr7zyCq1btz5h+vz588mfP//x/3Pnzs2xY6EfEfXRRx+lefPmTJ06lY0bN9KsWbN0l8+TJw9JSUkAJCUlcfTo0ePzAl97Wq/ThFZiUiJ9ZvRh3PJxPNTkIZ5q8dQJn+P7L72fqWum0n9mf5qe05TSRUr7GK2JBNGRJDL4xR8qf/zxB99++y2NGzdmwoQJNGnShKpVq7Jjx47j0xMSEli3bh01atQ4Yd2qVauydetWlixZQsOGDdm/fz8FCxakdevWjB49mhYtWpA3b17WrVtHuXLl0o2jaNGi7N+/n5IlT6xJXLVqVTZu3Mivv/5K5cqVeeedd2jatGmmXuPevXuP7z8uLi7D5StWrMiyZcu49tprmT59eppXHmm9zoySqMm6Y0nH6DWtF++teI/Hmz7O400fP+mHTp5ceYjrHMeFY9z9iSnXTrEqxzHOeoE9BVWrVmXUqFFUq1aN3bt3069fP/Lly8fkyZN54IEHqFOnDnXr1uWbb745ad18+fLxwQcfMGDAAOrUqUOrVq2Ij4/ntttuo3r16lx44YXUrFmT22+/PcMrhr59+9KmTZuTblwXKFCAcePG0a1bN2rVqkWuXLm44447MvUaBw8ezEMPPUS9evWCunLp06cPCxYsoE6dOnz77bdpnvSz8jpN1iUkJnDjlBt5b8V7PNXiKYY0G5Lmyb96qeoMaz6MqWumMnHlxDBHaiJNjhjjukGDBppyPInVq1dTrVo1nyJytZs6dOjAypUrfYshlvl9/HOSI8eOcP2U65m2ZhovtHqBey+5N8N1EpMSaTKuCWt3rmVV/1WUKVomw3VM5BGRZaqatbrqHruSMCaKxR+L55pJ1zBtzTRGthkZVIIAyJ0rN3Gd4jh87DC3f3I7OeHHpAkNSxJZVLFiRbuKMBHtUMIhOk3sxMz1MxnTYQwDLhqQqfWrlqzKUy2eYsa6Gbz787shitJEOksSxkShg0cP0mFCB7747Qveuuot+tbvm6Xt3H3R3Vx69qUM/Gwgm/dtzuYoTU5gScKYKLPvyD7avNeGBZsW8PbVb9O7Xu8sbyt3rtyM6zSOI8eO0PeTvlbsFIMsSRgTRfbE7+HKd67k2z+/5f1r3qdH7ZP75sqs8884n/9e8V8+Xf8pccvjTj1Ik6NYkjAmSvxz+B+uePsKftj6A5OvnZytLabvanQXl59zOYM+H8Sfe//Mtu2ayGdJIgpkd1fhobJlyxa6du0aln3Fmh0Hd9BifAtWbF/B1Oum0vmCztm6/VySi3GdxpGYlMhtM26zYqcYYknCJ9nZcCwrSSK5q/Dly5dTsGDBbIslPWXLlj2hh1iTPf4+8DfNxzdn7a61zLhhBu2rtA/Jfs49/Vyea/Ucs3+bzdgfxoZkHybyWJLIomjtKjy91/XEE0/QsGFDatasSd++/97EHDlyJNWrV6d27dpcf/31ACxYsIC6detSt25d6tWrx/79+9m4cSM1a9YEXBcfXbp0oU2bNpx//vkMHjz4eAxvvvkmVapUoVGjRvTp08cGNErH5n2baRbXjA17NjDzxplced6VId3fHQ3uoEWlFtw7+1427dkU0n2ZCHGq3ciG42FdhYevq/C0Xpeq6q5du44v16NHD50+fbqqqpYpU0bj4+NVVXX37t2qqtqhQ4fj29i/f78mJCTohg0btEaNGqrquhevVKmS7tmzRw8fPqwVKlTQP/74Qzdv3qznnHOO7tq1S48ePapNmjQ53g15IL+PfyTYtGeTnvfyeVrk6SK6cOPCsO13w+4NWuTpItpyfEtNSkoK235N5mFdhTuDPhvE8r+XZ+s2655VlxFtRqS7TLR2FZ7a67rvvvuYN28ezz33HIcOHeKff/6hRo0adOzYkdq1a9O9e3c6d+5M586dAbj00ku555576N69O126dEl1lLuWLVtSrFgxAKpXr86mTZvYuXMnTZs2pUSJEgB069aNdevWpRtvLNqwewMt3m7B7sO7+eKmL7i4/MVh23fF4hV58coXuf2T2xmzbAx3NMhcf2AmZ7HiplOQXlfhy5cvZ/ny5axYsYLZs2cfXybYrsKT19+wYQNXXumKEMLVVXhqrys+Pp7+/fszefJkVqxYQZ8+fYiPjwdg5syZ3Hnnnfzwww80bNiQY8eO8eCDDzJ27FgOHz7MpZdeypo1a07ajx9dn0eDX//5laZxTdkbv5cvb/4yrAkiWZ8L+9Dq3FbcN/s+NuzeEPb9m/CJiiuJjH7xh0q0dhWe2utKTgglS5bkwIEDTJ48ma5du5KUlMSff/5J8+bNadKkCRMnTuTAgQPs2rWLWrVqUatWLZYsWcKaNWuoW7duhvtu2LAhgwYNYvfu3RQtWpQpU6ZQq1atDNeLFWt2rqHF+BYkJCUwt+dc6p5V15c4RISxV42l5qs1uWX6Lcy5eQ65xH5zRqMMj6qIlEjlkTccwUW6aO0qPLXXVbx4cfr06UPNmjVp3br18WKyxMREevToQa1atahXrx4DBw6kePHijBgxgpo1a1K7dm3y5s1L27Ztg3pPy5Urx8MPP0yjRo249NJLqVix4vEiqVi3cvtKmsY1JUmTmNdznm8JIlmFYhUY3no48zfO59Ulr/oaiwmhjG5aABuBRGAnsMt7vhn4Aah/qjdFgnlE6o3r5Juw0SQSXtf+/ftVVTUhIUE7dOigH3300UnL+H38w+3HrT/qGc+eoWVeKKOrd6z2O5zjkpKStM27bbTQU4V0/a71fodjUiAbblwHc334BdBOVUuq6hlAW+AToD9gPx9MthsyZAh169alZs2aVKpU6fjN8Fi1dMtSWoxvQaG8hVjYeyEXlLzA75COExHe6PgGeXPlpffHvUnSJL9DMtksw0GHRGSFqtZKMe1nVa0tIstVtW4oA4TIHHTI+CtWjv93f31H63dbU6JgCebePJdKp1fyO6RUjV8+nl4f92J46+EMuniQ3+EYT7gGHdoqIg+IyDneYzCwTURyA/azwZgQWbRpEa3eaUWpQqVY0GtBxCYIgJvr3EyHKh14aM5DrNtlVZajSTBJ4kagPDDNe1TwpuUGsq8HsSzI6CrIRKdYOO5zN8ylzXttKFe0HAt7L6RCsQp+h5QuEWFMhzEUzFOQXtN6kZiU6HdIJptkmCRUdaeqDlDVet7jLlXdoapHVfXX9NYVkY0iskJElovI0hTz7hURFZGSaa2fngIFCrBr166YOGGYf6kqu3btokCBAn6HEjKzf5tN+wntqVS8Egt6LaBs0bJ+hxSUskXL8krbV/j2r28Z/t1wv8Mx2STDdhIiUgW4D6gYuLyqtghyH81VdWeKbZ4NXAn8EXSkKZQvX56//vqLHTt2ZHUTJocqUKBAqi24o8HMdTPpMqkL1UpW44ubvqBU4VJ+h5QpN9a6kcmrJ/PI3Edof357qpWK/vtG0S6YxnQfAq8BY3HVX7PDcGAw8HFWN5A3b14qVYrcMlpjMmvq6qlcN/k6apeuzeybZlOiYAm/Q8o0EeG19q9R49Ua9Pq4F1/f8jV5ckVFm92YFcw9iWOqOlpVF6vqsuRHkNtXYLaILBORvgAi0gnYrKo/ZTVoY6LNpFWT6PZhN+qXrc+XN3+ZIxNEstJFSjOq3SgWb17Mi9+86Hc45hQFkyRmiEh/ESkT2Oo6yO03UdULcW0r7hSRy4GHgccyWlFE+orIUhFZakVKJpq9+/O73DDlBhqf3ZjZPWZTvEBxv0M6ZdfWuJau1bvy2PzHWLV9ld/hmFMQTDuJ1HrvUlU9N1M7EhmCK64aACSPkFMe2AI0UtW/01o3tXYSxkSDcT+O49bpt9KsYjNm3DCDwvnS7wAyJ9lxcAc1Xq1BhWIV+PbWb8mb23rzCbewtJNQ1UqpPDJMECJSWESKJj/H3aheoqpnqmpFVa0I/AVcmF6CMCZajVk6hlum30Kr81rxyY2fRFWCAChVuBSvtn+VZVuX8dzXz/kdjsmiNO8oiUgLVZ0rIl1Sm6+qH2Ww7dLAVK/b6TzABFX9LMuRGhNFXvn+FQZ+NpD257dn8rWTKZAnOqv0dq3eletqXMfQBUPpWLUjtUvX9jskk0npVTtoCswFOqYyT4F0k4Sq/g7UyWCZihnEZ0zUeeGbF7j/i/vpfEFnPuj6Afly5/M7pJD6X7v/MW/jPHpO68ni2xZbsVMOk2aSUNXHvb+9wxeOMdHtqYVP8ci8R7i2xrW8e/W7MXHCLFmoJK+1f40uk7rw9KKnebzZ436HZDIhveKme9JbUVVfyv5wjIlOqsqQ+UN4YuET9Kjdg3GdxsVU+4Grq11N91rdeXLRk1xV9Srqlannd0gmSOnduC6awcMYEwRV5eE5D/PEwifoXbc3cZ3iYipBJBvZdiQlC5Wk57SeHE086nc4JkjpFTcNDWcgxkQjVeXe2fcy/Lvh3F7/dl5t/2rMDvNZomAJXu/wOldNvIphC4YxrMUwv0MyQUivuGmwqj4nIq/gblSfQFUHhjQyY3K4JE1i4KyBjFoyigGNBvBym5fxavvFrI5VO9KzTk+e+eoZOl3QiQZlT6kKvwmD9H7SrPb+LgWWpfIwxqQhSZO4fcbtjFoyivsa32cJIsCINiMoXaQ0vab14sixI36HYzKQXnHTDO/v+PCFY0zOl5iUyK3Tb2X8T+P5v8v+j2HNh1mCCFC8QHHGdhxLuwntGLpgKE+3fNrvkEw6MiwcFZFSIvKCiHwqInOTH+EIzpic5ljSMW6edjPjfxrP0GZDebLFk5YgUtH2/LbcWu9Wnv36WRZvXux3OCYdwdxBew9X9FQJGApsBJaEMCZjcqSExARumHIDE1ZM4JmWz/BY0wz7sYxpL175IuWKlqPntJ7EH4v3OxyThmCSxBmq+iaQoKoLVPUWINgBh4yJCUeOHaHrh12Z/MtkXrryJR5s8qDfIUW8YgWK8eZVb7Jm5xoem2cJNVXff+93BEEliQTv71YRaS8i9YCc29m9Mdks/lg8V39wNdPXTud/bf/Hfxr/x++QcoxW57Wi74V9eeGbF/jmz2/8DieyTJsGF18Mkyb5GkYwXYV3ABYBZwOvAKcBQ1V1eujDc6yrcBOpDiUcotPETsz5fQ5jOoyhT/0+foeU4+w/sp9ao2uRL3c+lt+xnEJ5C/kdkv927oQaNaBsWXc1kS9r/XuFtKtwEXnWe1pQVfeq6kpVba6q9cOZIIyJVAeOHqD9hPbM+X0O4zqNswSRRUXzF+XNq95k/T/reWTuI36HExkGDIDduyEuLssJIrukV9zUTly1jIfCFYwxOcW+I/to824bFm1axLtd3qVn3Z5+h5SjtTy3Jf0b9GfEdyNYtGmR3+H4a/JkmDgRHnsM6qTbkXZYpFncJCLPA32AIvw7khyA4EamOy304TlW3GQiye7Du2nzXht+2PoD71/zPl2rd/U7pKhw4OgBao+uTS7JxU93/BR1gzAFZft2V8x0zjnw7beQ99R6CQ5pcZOq3q+qxYGZqnpawKNoOBOEMZFk16FdXPHOFfy49Ucmd5tsCSIbFclXhHGdxvHb7t94aE4MFmCoQv/+sG+fK2Y6xQSRXYIZvrRTOAIxJtJtP7idFm+3YNX2VXx8/cd0usC+GtmtacWmDGw0kFcWv8L8jfP9Die8Jk2CKVNg6FCoWdPvaI7LsHZTJLDiJuO3rfu3csU7V7Bh9wam3zCdK869wu+QotbBowepO6Yux5KOsaLfCorkK+J3SKG3bZsrZjrvPPj6a8iTPV3Jh7S4yRjjbN63mWbjm7FpzyY+7f6pJYgQK5yvMOM6jWPTnk0M/mKw3+GEnir06wcHDrhipmxKENkl3SQhIrlF5L1wBWNMpNm0ZxOXx13O1v1b+bzH5zSr2MzvkGJCkwpN+M/F/2H00tHM+X2O3+GE1vvvw9Sp8OSTUK2a39GcJJjGdF8BLVTVt6GkrLjJ+OH33b/TYnwL9sTv4fMen3NR+Yv8DimmHE44TN0xdYk/Fs+Kfis4LX8U1pfZutUVM11wASxaBLlzZ+vmw1Xc9DvwtYg8KiL3JD9OZafGRLr1u9bTNK4p+4/uZ27PuZYgfFAwb0HGdx7PX/v+4v7Z9/sdTvZThdtvh8OHXTFTNieI7BJMkvgN+MRb1sa4NlFv9Y7VXB53OfHH4pnXcx4XlrnQ75Bi1sXlL+a+xvfx+g+vM/u32X6Hk73eeQdmzICnn4YqVfyOJk1B124SkSIAqnogpBGlwoqbTLis2LaClm+3JJfkYs7Nc6hxZg2/Q4p58cfiuXDMhew/up+V/VZSrEAxv0M6dZs3u2KmWrVg/vyQXUWEpbhJRGqKyI/AKmCViCwTEfvmmKjz49YfaT6+OXlz52VBrwWWICJEgTwFiOscx5b9W7jn8ygo6VaFPn3g6FEYNy5ii5mSBVPc9Dpwj6qeo6rnAPcCbwSzcRHZKCIrRGS5iCz1pj0vImtE5GcRmSoixbMcvTHZZMnmJbR4uwWF8xVmYa+FVC1Z1e+QTIBG5RrxwKUP8Nbyt/h0/ad+h3Nqxo2DWbPg2WehcmW/o8lQMLWbflLVOhlNS2PdjUADVd0ZMO1KYK6qHkvuaVZVH0hvO1bcZELpmz+/oe17bTmj4BnM6zmPc4qf43dIJhVHjh2h/uv12R2/m5X9VnJ6wdP9Dinz/vjDFTHVqwdz50Ku0DZVC1vtJq9mU0Xv8QiuxlOWqOpsVT3m/fsdUD6r2zLmVC3ctJAr37mS0oVLs7D3QksQESx/nvyM7zyebQe2MejzQX6Hk3mqcNttkJgIb70V8gSRXYKJ8hagFPARMAUo6U0LhgKzvfsYfdPY9qwgt2VMtprz+xzavNuGs4udzYJeCyh/mv1eiXT1y9bn4cse5u2f3mb62hw2rM0bb8AXX8Dzz8O55/odTdBC2neTiJRT1c0icibwBTBAVRd68/4PaAB00VSC8JJKX4AKFSrU37RpU8jiNLHns18/4+oPrqZyicp8edOXlC5S2u+QTJCOJh6l4RsN2X5wOyv7reSMQmf4HVLGNm50xUwXXQSzZ4ftKiLi+25S1c3e3+3AVKARgIj0AjoA3VNLEN46r6tqA1VtUKpUqVCGaWLMjLUz6DSxExeUvIB5PedZgshh8uXOx/jO49l5aCcDPxvodzgZS0qCW291z998M8cUMyULWbQiUlhEiiY/B64EVopIG2AwcJWqHkpvG8Zkt49Wf0SXSV2oU7oOc2+eS8lCJf0OyWRB3bPq8ujljzJhxQQ+Wv2R3+Gkb8wYd5P6pZfcYEI5TMiKm0TkXNzVA0AeYIKqPiUivwL5gV3evO9U9Y70tmW1m0x2mLhyIj0+6kGjco2Y1X1WdDTKimEJiQlcNPYiNu/fzKr+qyIz4f/+O9SuDZdeCp99BiJh3X12FDdl2CetiIxMZfJeYKmqfpzWeqr6O3BSNVlVjfyKwSbqvP3T2/T+uDdNKjThkxs+oWh+61kmp8ubOy/jO4+n/uv1uevTu5jYdaLfIZ0oKQluucU1lhs7NuwJIrsEU9xUAKgLrPcetXHVVm8VkREhi8yYbPLmD2/Sa1ovmlVsxqc3fmoJIorUKl2LIc2G8MGqD/hw1Yd+h3OiUaNgwQIYPhzOPtvvaLIsmMZ03wGXqmqi938eYBHQBFihqtVDHaQVN5msGr1kNP0/7U+bym346NqPKJi3oN8hmWx2LOkYjd9szMY9G1nVfxVnFj7T75Dg119dMVOzZjBzpm9XEeGq3XQ6EDh+YGGghJc0jpzKzo0JpZe/e5n+n/anY5WOTLtumiWIKJUnVx7Gdx7PviP76D+zP74PyZyYCL16Qb58rm1EDi1mShZMkngOWC4i40QkDvgReN6rsfRlKIMzJque+/o5Bn0+iC7VujD52snkz5Pf75BMCFUvVZ0nmj3BlNVT+GDVB/4GM3KkG6d65EgoV87fWLJBULWbRKQMXhsHYImqbglpVClYcZPJjGELhvHY/Me4vub1vN35bfLmzut3SCYMjiUdo8lbTVj/z3pW9V/FWUXOCn8Qa9dC3brQqhV8/LHvVxHhbEyXC9gB7AYqi8jlp7JTY0JBVXl07qM8Nv8xbqp9E+9e/a4liBiSJ1ce4jrHcfDoQe745I7wFzslFzMVLOjaRuTwYqZkwVSBfRa4DjeeRJI3WYGFIYzLmExRVR788kGe++Y5bq13K2M6jCF3rsjup99kvwtKXsBTLZ7ivi/u470V79Gjdo/w7fyll+C77+C996BMmfDtN8SCqd20Fqitqr7dpLbiJpMeVeU/n/+Hl79/mX4N+vG/dv8jl+Ssrg9M9klMSuTyuMv5ZccvrOq/irJFy4Z+p7/8AhdeCO3awZQpEXMVEbauwgG7ZjcRKUmTuPPTO3n5+5e5+6K7GdVulCWIGJc7V27GdRrHkWNH6Dujb+iLnY4dc8VMRYrA6NERkyCySzDfpkO42k1jRGRk8iPUgRmTkcSkRPrO6MvopaMZfMlghrcejkTZF9RkTZUzqvBMy2eYuX4m438aH9qdPf88LFkCr74KpaOvs8hgipt6pjZdVUP8zv/LiptMSolJifT+uDfv/PwOj17+KEObDbUEYU6QpEk0i2vGT9t+YlX/VaEZL2TlSqhfHzp1gkmTsn/7pyg7iptCOp5EdrEkYQIlJCZw87SbmbhyIsOaD+ORyx/xOyQToX775zdqv1abyypcxqzus7L3h0RCAjRu7IYkXbUKInBIg5DekxCRSd7fFSLyc8BjhYj8fCo7NSarjiYe5fop1zNx5USeveJZSxAmXeeVOI/nrniOz3/7nLd+fCt7N/7ss7BsmbsPEYEJIrukeSUhImVUdauIpNoBuqqGbag4u5IwAEeOHaHbh92YsW4Gw1sPZ9DFg/wOyeQASZrEFW9fwdItS1nZfyUVilU49Y3+9BM0bAjXXAPvv3/q2wuRkF5JqOpW7+lO4E8vKeTHdf8d1hbXxhxOOEyniZ2YsW4Gr7Z71RKECVouycVbnd5CUW6dfuup13Y6etTVZipRAv73v2yJMZIFU7tpIVBARMoBs4GbgLhQBmVMoINHD9Lh/Q7M/m02YzuOpV/Dfn6HZHKYisUr8nyr5/ny9y95fdnrp7axp5+G5ctdq+ozcsD42qcomCQh3jCjXYBXVbUbUCO0YRnj7D+yn3YT2jF/43zGdx7PrRfe6ndIJoe6vf7tXHHuFdw7+1427N6QtY388AM89RT06OFqNMWAoJKEiDQGugMzvWnW34EJub3xe2n9bmu+/uNr3uvyHjfVucnvkEwOJiKM7TiWXJKLW6ffSpImZbxSoCNHXDFTqVLw8sshiTESBZMkBgEPAVNVdZU3dvW8kEZlYt7uw7tp9U4rlmxZwgddP+D6mtf7HZKJAucUP4eXWr/EvI3zGL1kdOZWHjYMVqyA11939yNiRKbaSYhILqCIqu4LXUgns9pNsWXnoZ20eqcVv+z4hcndJtOxake/QzJRRFVp+15bFv2xiJ/v+JnzSpyX8UpLlrg2ETfdBOPGhT7IbBKWvptEZIKInOYNMrQS+EVE7j+VnRqTlu0Ht9N8fHPW7FzDx9d/bAnCZDsRYexVY8mbKy+9P+6dcbFTfLwrZjrrLDdedYwJpripunfl0BmYBVTC1XAyJltt3b+VZnHN+O2f3/jkhk9oU7mN3yGZKFX+tPKMaDOCRX8s4pXvX0l/4SFDXC+vY8dC8eLhCC+iBJMk8opIXlySmK6qCbjxJIzJNn/t+4umcU35Y+8fzOo+i5bntvQ7JBPletbpSfvz2/PQnIdYt2td6gt9953rwO+226BNbP5oCSZJjAE2AoWBhV4L7LDekzDRbeOejVw+7nK2HdzG7Jtm07RiU79DMjFARHi94+vkz5Of3h/3JjEp8cQFDh+G3r3dONUvvuhPkBEgwyShqiNVtZyqtlNnE9A8DLGZGPDbP7/RNK4pu+N38+VNX3LJ2Zf4HZKJIWWLluWVtq/wzZ/fMOK7ESfOfOwxWLMG3noLTjvNl/giQYbDlwKISHtcA7oCAZOfCGK9jcB+IBE4pqoNRKQE8AFQEXeFcq2q7s5U1CYqrN25lhZvt+DIsSPMvXku9crU8zskE4O61+rO5F8m88i8R2hfpT0XlLwAvvnGXT3ccQdccYXfIfoqmNpNr+HGuB4ACNANSLXTvzQ0V9W6AdWwHgTmqOr5wBzvfxNjftnxC03jmpKQmMC8nvMsQRjfiAivdXiNQnkL0WtaLxIP7He1mSpUgOee8zs83wVzT+ISVb0Z2K2qQ4HGQJVT2GcnIHnAovG4G+Imhvy87WeaxTVDRJjfaz61StfyOyQT484qchaj2o3i+83f8+KT7WD9elfMVLSo36H5LpjipsPe30MiUhbYBZQJcvsKzBYRBcao6utA6YAeZv8GQjbe3+D/a8RbidYIL9Lsz6eUync6c/t9RZUzTuX3hjHZ57oa1/HhwtE8unUhHQbeQPUWLfwOKSIEkyQ+EZHiwPPAD7gT/xtBbr+Jqm4WkTOBL0RkTeBMVVUvgZxERPoCfQEqVMha/+/1Kzbm0G/xWVrXhE7+P3Zy1/StVDprIdxmScJEBjl0iNGjNrHwqlz0rLaWb5OOkSdXULdto1pmu+XIDxRQ1b2Z3pHIEOAA0Ado5g1oVAaYr6pV01vXuuWIMvHx0KULzJrl+uO/806/IzIGBgyA//2PDz8cwrWrhvBUi6d4+LKH/Y7qlISrW44CInKPiHwETABuEZECQaxXWESKJj8HrsR16zEd6Okt1hP4OKvBmxyqQAGYOtV1tXzXXTHZ1YGJMPPmuR8sd99Nt66Pc22Naxkyfwgrtq3wOzLfZXgl4Y11vR9415t0I1DcG1civfXOBaZ6/+YBJqjqUyJyBjAJqABswlWB/Se9bdmVRJRKSIAbb4TJk+G//4UHHvA7IhOL9u+H2rUhTx43LGmhQuw8tJMar9agXNFyfH/b9+TNndfvKLMkO64kgilwq6mq1QP+nyciv2S0kqr+jhvqNOX0XYD1uWAgb143PnC+fPDgg25YyEcf9TsqE2sGD4ZNm2DRIihUCICShUryWvvX6DKpC8989QyPNX3M5yD9E0wV2B9E5OLkf0TkIsB+1pvskScPvP029OzpWrg+8gic6hjExgTriy/gtdfgnnvg0ktPmHV1tau5sdaNDFs4jOV/L/cnvggQTHHTaqAq8Ic3qQKwFjiGq6BUO6QRYsVNMSEpybVufeMNuO8+14hJxO+oTDTbtw9q1nRXDz/+CAULnrTIrkO7qDm6JmcWPpMlfZaQL3c+HwLNunAVN8Vm14cmvHLlcr/o8uWDF15wRU8jRliiMKFz332weTN8/XWqCQLgjEJnMKbDGDpN7MSTC5/kieYZ9kYUdTJMEl6HfsaEXq5c8MorkD8/vPSSSxSjRrnpxmSnzz93V60PPAAXX5zuoldVvYqb69zM04ueplPVTtQvWz9MQUaGTLWT8IsVN8UYVXj4YVfj6ZZb3JjCuXP7HZWJFnv2uGKmYsVg2TJXJTsDuw/vpubompQoWIKlfZaSP0/+0MeZDULaTsJrOGdM+InA00/D44+7/nN69YJjx/yOykSLe+6Bv/+GuLigEgTA6QVP542Ob7By+0qeWBBbRU7pXcd/CyAi74QpFmP+JeKGjXzqKXj3Xeje3bWrMOZUzJwJ48a5YqaGDTO1arvz23FL3Vv479f/ZcnmJSEKMPKkWdwkIiuBp4FhwP0p56vqR6EN7V9W3BTjXnzR3WS8+mqYONHd3DYms3bvhho14IwzYOlSd+8rk/bG76Xm6JoUzVeUH27/gQJ5grsS8Uuou+W4A7gMKA50TPHocCo7NSZT7r0XRo50XXl06eL6fjIms+6+G7Zvh/Hjs5QgAIoVKMbYjmNZvXM1j897PJsDjExp1m5S1a+Ar0Rkqaq+GcaYjDnZgAHuCuKOO1yfT9OmpVlt0ZiTfPwxvPOOa7B54YWntKnWlVvT58I+vPDtC3S+oDONz26cTUFGpmAa0+XDXVVc7k1aALymqmErILbiJnPcuHFw663QrBnMmAGFC/sdkYl0u3a5YqazzoLFi7OluHLfkX3UGl2LAnkKsPz25RTMG5k/WMLSCyzwKlDf+/sqcCEw+lR2akyW9e7tuvFYsADatnWdsxmTngEDXKIYPz7b7medlv803rzqTdbtWscjcx/Jlm1GqmCSRENV7amqc71HbyBz1QKMyU49eriOAb/5Bq680tV7NyY1U6a4z8pjj0Gdk/obPSVXnHsF/Rr0Y/h3w/nqj6+ydduRJJgkkSgi5yX/43UBnhi6kIwJwrXXwocfusZQrVrBP+n2Nm9i0Y4d0K+fuwfx4IMh2cVzrZ7jnOLn0Pvj3hw8ejAk+/BbMEniflz34PNFZAEwF7g3tGEZE4Srr4aPPoKff4aWLWHnTr8jMpHkzjvdVeb48a5b+hAokq8I4zqN49d/fuXhOTl7FLu0ZJgkVHUOcD4wEBgAVFXVeaEOzJigdOjgbmCvWeNuZm/b5ndEJhJMmuSuNIcOdV1whFCzis0Y0GgAIxePZMHGBSHdlx+s7yYTHebOhY4doUIFmDMHypb1OyLjl23bXG2mc891963yBNPZ9ak5ePQgdV6rQ5Im8XO/nymSr0jI9xmMcNVuMibytWgBn30Gf/0FTZvCn3/6HZHxg6q7D3HggOubKQwJAqBwvsKM6zSOjXs28uCXobn/4RdLEiZ6XHaZG2ls+3a4/HLYuNHviEy4TZzoWuY/8QRUr57x8tnosnMuY9DFgxi1ZBRzN8wN675DKZjGdAJ0B85V1SdEpAJwlqouDkeAYMVNJpOWLnVVY4sUccVQlSv7HZEJh61bXTFT1arw1Ve+dC9/KOEQ9cbU48ixI6zot4Ki+YuGPYZA4WxM1xi4wft/PzDqVHZqTEg1aOCSw+HDruhpzRq/IzKhpgq33+6OeVycb+OPFMpbiHGdxvHH3j+4/4uT+kXNkYJJEhep6p1APICq7gasG04T2erWhXnzIDHR1XpaudLviEwovfuuq+X21FPuSsJHl5x9Cfc2vpcxy8Yw+7fZvsaSHYJJEgkikhtQABEpBSSFNCpjskPNmjB/vhv+tHlz+OknvyMyobB5MwwcCJde6np6jQBPNH+CC0pewG3Tb2Nv/F6/wzklwSSJkcBU4EwReQr4CjfOhDGR74ILYOFC12Ns8+auhbaJHqrQty8cOeI6f4yQYW4L5i1IXKc4Nu/fzL2zc3bb42Aa070HDAaeAbYCnVX1w1AHZky2qVzZdQhYrJhrmf3dd35HZLJLXBx8+qkbD/388/2O5gQXlb+IwZcM5s0f32TW+ll+h5NlwdRuKpHK5P3BdhXuFVUtBTaragcRaQk8j0tQB4Beqvpretuw2k0mW/zxh2tPsW0bzJoFTZr4HZE5FX/+6YoUk+8/5Yq8Gv1Hjh2h/uv12R2/m5X9VnJ6wdPDuv9w1W76AdgBrAPWe883isgPIlI/iPXvBlYH/D8a6K6qdYEJQHT3s2siR4UKruipXDlo3dqdWEzOpAq33eYqJowbF5EJAiB/nvzEdY5j24Ft/Ofz//gdTpYE885+AbRT1ZKqegbQFvgE6I+rHpsmESkPtAfGBkxW4DTveTFgS2aDNibLypZ1RU+VKkG7djA759c+iUljx7pj99xzrvuNCNagbAMeavIQ438az4y1M/wOJ9OCKW5aoaq1Ukz7WVVri8hy74ogrXUn4+5lFAXu84qbLgOmAYeBfcDFqrovvRisuMlkux07XBfja9a4nmTbtfM7IhOsTZugVi1o2NC1sI/Qq4hARxOP0vCNhmw/uJ1V/VdRomBqpfjZL1zFTVtF5AEROcd7DAa2efca0qwKKyIdgO2qmrI6yX9wVyblgXHAS2ms31dElorI0h07dgT3aowJVqlSrsFdzZrQubMbM9tEPlU3fK0qvPlmjkgQAPly5yOuUxw7D+1k4KyBfoeTKcG8wzcC5XG//qcBFbxpuYFr01nvUuAqEdkITARaiMhMoI6qfu8t8wFwSWorq+rrqtpAVRuUKlUqiDCNyaQSJeDLL6F+fejWzXUtbSLbmDGul98XX4SKFf2OJlPqlanHI5c9wnsr3mPamml+hxO0sHQVLiLNgPuAzsDfwCWquk5EbsVdVVyT3vpW3GRCav9+V9z0zTdu/Ozu3f2OyKRmwwZXzHTJJfD55yDid0SZlpCYQKOxjdiyfwur+q+iZKGSId1fWIqbRKSUiDwvIp+KyNzkR1Z2pqrHgD7AFBH5CbgJN/KdMf4pWtR1M960Kdx0k6t7byJLUhLccosrXho7NkcmCIC8ufMyvvN4dh/ezYBZA/wOJyjBFDe9B6wBKgFDgY3AkszsRFXnq2oH7/lUVa2lqnVUtZmq/p7JmI3JfoULwyefwBVXQO/e8PrrfkdkAr36qutiZfhwV5U5B6tdujaPNX2MiSsnMvmXyX6Hk6FgajctU9X6yTWavGlLVLVhWCLEiptMGMXHQ9euMHMmvPIK3HWX3xGZX3+FOnXcGCGffppjryICJSQm0PjNxmzau4lV/VdxZuEzQ7KfcNVuSm5ZvVVE2otIPSA89beMCbcCBVyV2M6dYcAAd4PU+CcpyV3Z5c0Lb7wRFQkCXLFTXOc49h3ZR/+Z/YnkYaSDSRJPikgx4F7czeexwKBQBmWMr/Llg0mTXI2n++6Dp60/S9+MHOkGEHr5ZShf3u9oslXNM2sytNlQpqyewqRVk/wOJ03BJIndqrpXVVeqanNVrQ/8E+rAjPFV3rwwYYKr6fR//wdDhri6+SZ81q2Dhx6CDh3g5pv9jiYk7rvkPhqVa0T/T/vz94G//Q4nVcEkiVeCnGZMdMmTB8aPh169YOhQlywsUYRHYqJ73wsWdG0joqSYKaU8ufIQ1ymOg0cPcscnd0RksVOetGaISGNcQ7dSInJPwKzTcA3pjIl+uXO7lr3588Mzz7hxC154IWpPWhFj+HD49ls34lzZsn5HE1LVSlXjyRZPcv8X9zNhxQS6146sdjrpXUnkA4rgEknRgMc+oGvoQzMmQuTKBaNHuxvZL73kRkFLssEZQ2b1anjkEVd54MYb/Y4mLP5z8X9oXL4xA2YNYMv+yOrzNM0rCVVdACwQkThV3RTGmIyJPCLu5mm+fK7G05Ej8NprOabvoBzj2DFXzFSkiHt/Y+SKLXeu3MR1jqPOa3W4/ZPbmX79dCRCXnuaSSJAfhF5HagYuLyqtghVUMZEJBF4/nlX9PT005CQ4Fr/RsiQmVHhxRdh8WKYOBFKl/Y7mrCqckYVnmn5DP/5/D+8/dPb9Kzb0++QgOAa0/0EvAYsAxKTp6fSu2vIWGM6E1FUYdgwePxxVxwyfry7yW1OzapVcOGFcNVVrgpyhPySDqckTaJZXDN+3vYzq/qvotxp5U5pe+FqTHdMVUer6mJVXZb8OJWdGpOjicBjj7kb2RMmuESRENRoviYtCQnQsyecdhqMGhWTCQIgl+TirU5vkZCUQJ8ZfSKitlMwSWKGiPQXkTIiUiL5EfLIjIl0Dz7obmR/+KFreHfkiN8R5VzPPQfLlrk+ms4MTRcVOUXlEpV59opnmfXrLMYtH+d3OEEVN21IZbKqatjGDLTiJhPRRo1yfTy1awdTpriuPUzwfv4ZGjSALl3cvQhDkibR8u2W/LD1B1b0W0GFYlnr1DAsxU2qWimVR2QPKmtMON15p2vwNWuWK08/dMjviHKO5GKm00+H//3P72giRi7JxZtXvUnJQiXZuGejr7FkeLdNRAoB9wAVVLWviJwPVFXVT0IenTE5Rd++rnrsLbdA+/YwY4arxmnS9/TTsHy561SxZGgH4Mlpzj39XNbetZY8ufytFBHMPYlxwFH+HWZ0M/BkyCIyJqfq1cu1EF60CNq0gX37/I4osv34Izz5pOsf6+qr/Y4mIvmdICC4JHGeqj6H12W4qh4CYrPqgTEZufFGeP99+P57uPJK2LPH74gi09GjrpipZEnX06uJWMEkiaMiUhBQABE5D7BqHMakpVs3mDwZfvgBWraEf6zT5JMMGwYrVrgRAEtYZclIFkySeBz4DDhbRN4D5gCDQxqVMTldp04wbZprINa8OezY4XdEkWPpUtfGpGdP6NjR72hMBjKsAgsgImcAF+OKmb5T1Z2hDiyQVYE1OdYXX7iEUakSzJkDZ53ld0T+OnIE6teH3btdAi1e3O+IolpYqsCKyNW4VtczvRpNx0Sk86ns1JiY0aqVG5d50yZo2hQ2b/Y7In8NHeqSw9ixliByiKCKm1R1b/I/qroHVwRljAlGs2bw+eewdatLFH/84XdE/li8GJ59Fm69Fdq29TsaE6RgkkRqy/hfL8uYnOTSS13R086dcPnlsCG1jgyiWHy8uwdRrpzr6dXkGMEkiaUi8pKInOc9XsL1CGuMyYyLLnL3Jfbvd4li/Xq/Iwqfxx6DNWtcMVOxYn5HYzIhmCQxANeY7gNgIhAP3BnKoIyJWvXrw9y57pd106ZuFLZo9803bsjXvn1d2xGTo6Rbu0lEcgNfqmrzLO/AbWMpsFlVO4gbbulJoBtufIrRqppuaxqr3WSizqpVrg2Fqru6qFnT74hC49AhqFvXNZ5bsQKKFvU7opgS8tpNqpoIJInIqVwf3g0E/lzqBZwNXKCq1XBXJ8bElho1YMECN1hRs2aui4po9MgjrljtzTctQeRQwRQ3HQBWiMibIjIy+RHMxkWkPNAeGBswuR/whKomAajq9swGbUxUqFrVJYpChaBFC1iyxO+IsteiRTBiBPTv766aTI4UTJL4CHgUWIi7YZ38CMYIXOvspIBp5wHXichSEZnl9SprTGyqXBkWLnRdZV9xBXz7rd8RZY+DB6F3b6hY0VV7NTlWhlVZVXW813dTBVVdG+yGRaQDsF1Vl4lIs4BZ+YF4VW0gIl2At4DLUlm/L9AXoEKFrA24YUyOULGiu6Jo2dLd2J0509V+yskeegh++w3mz7cu03O4YFpcdwSW4/pvQkTqisj0ILZ9KXCViGzE3XdoISLvAn/hrk4ApgK1U1tZVV9X1Qaq2qBUqVJB7M6YHOzss90JtXx519Bszhy/I8q6+fPhlVdg4EBXg8vkaMEUNw0BGgF7AFR1OZDhyHSq+pCqllfVisD1wFxV7QFMA5JrSzUF1mUyZmOiU9my7gR77rnQoYNrpZ3THDjgipkqV3YDCpkcL5gkkRDYLYcnKdUlg/Nf4BoRWQE8A9x2CtsyJrqULg3z5sEFF7ihUD/JYQNADh7s+qkaNw4KF/Y7GpMNgkkSq0TkRiC3iJwvIq8A32RmJ6o6X1U7eM/3qGp7Va2lqo1V9acsxG1M9CpZ0hU31a4NXbrA1Kl+RxScOXNg9Gj4z3+gSRO/ozHZJNgW1zVwAw1NAPYCg0IYkzGmRAn48kto0MANYvTBB35HlL59+9z43lWquCFJTdRIs3aTiBQA7gAqAyuAxqp6LFyBGRPzihVz9yXat3fDoh49Cjfd5HdUqbv/fvjrL/j6ayhY0O9oTDZK70piPNAAlyDaAi+EJSJjzL+KFoVZs1yr7J494a23/I7oZLNnu2FI770XLr7Y72hMNkuvnUR1Va0FICJvAovDE5Ix5gSFC7sb2Fdf7cZiOHoU7rjD76icvXtdTBdcAE884Xc0JgTSSxIJyU9U9Zjrl88Y44uCBd2Y2d26Qb9+LlEMHOh3VHDPPbBli2spXqCA39GYEEgvSdQRkX3ecwEKev8LoKp6WsijM8b8q0ABmDIFrr8e7r7bjRd9//3+xfPpp67466GHoFEj/+IwIZVmklDV3OEMxBgThHz5XE2nm25ybRKOHHE9rYbb7t3Qp4/rzfZxG804mtkwpMbkNHnzwrvvuoTx6KOu6GnoUAhnkfCgQbBtG0yfDvnzh2+/JuwsSRiTE+XJ41o1580Lw4a5RPHMM+FJFNOnw9tvuwRVv37o92d8ZUnCmJwqd2544w33S/7ZZ13R00svhTZR7NoFt9/uWoP7Ucxlws6ShDE5Wa5cMGqUK3oaMcJdUbzyipseCgMHws6dru1Gvnyh2YeJKJYkjMnpRGD4cHfSfv55lyjGjMn+RDF1KkyY4O5/1K2bvds2EcuShDHRQMQVOeXP7/pOOnrUVU/NnU2VFHfudA346tVzVV5NzLAkYUy0EHE3sfPlg8ceg4QEd4M5TzZ8ze+6y1V7/fJLd7PcxAxLEsZEm0cfdVcUDzzgrigmTDi1+wcffujaZjz1FNSqlX1xmhwhRHe3jDG+GjzY3aeYMgW6dnU1n7Ji+3bo3991WT54cPbGaHIESxLGRKtBg1zNpxkzoHNnOHw4c+urugSxbx/ExWVPsZXJcSxJGBPN+vd3bSk+/xw6doRDh4Jf94MP3JXIE0+47jdMTLIkYUy0u+02dyUwbx60awcHDmS8zt9/w513wkUXuXEiTMyyJGFMLLj5Ztff01dfQevWbhyItKi66q4HD1oxk7EkYUzMuOEGV4S0eDG0auWqtKbmvffg449dbaYLLghvjCbiWJIwJpZcc427z/DTT9CypWskF2jLFhgwAC65xN34NjHPkoQxseaqq9yVwi+/QIsWrporuGKmvn1dddlx47KvtbbJ0SxJGBOL2rSBmTPh11+hWTPYuhXGj3fTnnkGqlTxO0ITIeyOlDGxqmVL15tr+/bQtKm7orjsMlfcZIwn5FcSIpJbRH4UkU9STB8pIkHUxTPGhEzTpq4Nxd9/u76exo0LXTfjJkcKx5XE3cBq4LTkCSLSADg9DPs2xmTk0kth6VLYvx/OO8/vaEyECelPBhEpD7QHxgZMyw08D1hHMMZEiipVbChSk6pQX1eOwCWDpIBpdwHTVXVriPdtjDHmFIUsSYhIB2C7qi4LmFYW6Aa8EsT6fUVkqYgs3bFjR6jCNMYYk45Q3pO4FLhKRNoBBXD3JFYBR4BfxQ3WXkhEflXVyilXVtXXgdcBGjRooCGM0xhjTBpCdiWhqg+panlVrQhcD8xV1dNV9SxVrehNP5RagjDGGBMZrK6bMcaYNIWlMZ2qzgfmpzK9SDj2b4wxJmvsSsIYY0yaLEkYY4xJk6hGfsUhEdkBbMri6iWBnRkuZcLNjkvksWMSmU7luJyjqqVOZec5IkmcChFZqqoN/I7DnMiOS+SxYxKZ/D4uVtxkjDEmTZYkjDHGpCkWksTrfgdgUmXHJfLYMYlMvh6XqL8nYYwxJuti4UrCGGNMFlmSMMYYk6aoGuNaREoEsViSqu4JdSzmXyJyTxCLHVTVMSEPxgAgIl2CWCxeVT8NeTAGiNzzV1TdkxCReGALIOkslltVK4QpJAOIyFZgNOkfl+6qWiVMIcU8EdkFfEz6x+RyVbXxTMMkUs9fUXUlAaxW1XrpLSAiP4YrGHPcO6r6RHoLiEjhcAVjAJilqrekt4CIvBuuYAwQoeevaLuSKKCq8ae6jDHGhJuIVFPV1RksE/bzV1QlCQBxQ941Asp5kzYDizXaXmgOIyKtgc6ceFw+VtXPfAsqxonIBUAnTjwm0zM6UZnQEJFlqlpfROaoaku/40kWVUlCRK4EXgXW4z7wAOWBykB/VZ3tV2yxTERGAFWAt4G/vMnlgZuB9ap6t0+hxSwReQC4AZjIicfkemCiqv7Xr9hilVeU9CHQDxiecr6qvhT2oIi+JLEaaKuqG1NMrwR8qqrVfAksxonIutRuSntXfetU9XwfwoppIrIOqKGqCSmm5wNW2TEJPxGpirvaHgS8lnK+qg4Nc0hA9N24zsO/v4oCbQbyhjkW8694EWmoqktSTG8I2P0hfyQBZTm5C/4y3jwTZqq6FnhWRH5W1Vl+x5Ms2pLEW8ASEZkI/OlNOxt3Cf2mb1GZXsBoESnKv0n8bGCvN8+E3yBgjois59/vSgVc0exdfgVlAJgrIjcCFQk4R2dUQzBUoqq4CVwNAVK/GfeLf1EZABE5i4Djoqp/+xlPrBORXJxcyWOJqib6F5URkc9wP6CWAcePhaq+6Es80ZYkjDEmJxORlapa0+84ksVM300iMsTvGMzJROQHv2MwJxKRT/yOIcZ9IyK1/A4iWcxcSYhIR1Wd4XccxkQ6ESmjqlv9jiNWicgvuHtDG4AjuG46VFVr+xJPrCQJ4z8RKc2J9yS2+RmPcZI7llPVf/yOxYCInJPadFVNWRMtLKKqdpOI5AFuBa7GVe8Dr2Uv8GbKOuEmPESkLq7edzECGjmKyB5cI0crcgozEakAPAe0BPa4SXIaMBd4MGVbIxN6InKaqu4D9vsdS6CoupIQkfdxH/jxnNiKtCdQQlWv8ym0mCYiy4HbVfX7FNMvBsaoah1fAothIvItMAKYnFybSURyA92AQap6sY/hxSQR+URVO4jIBkA5sTdYVdVzfYkrypJEqi17M5pnQktE1qfVgldEflXVyuGOKdZlcEzSnGdiT1QVNwH/iEg3YIqqJsHxuuDdgN2+RhbbZonITFzfTYGNHG8GrIM/fywTkVdxV92Bx6QnYN3pm+Oi7UqiIvAs0IJ/k0JxYB6unHWDP5EZEWlL6o0cbeQzH3h9NN1KKscEd//uiF+xmcgSVUkikIicAaCqu/yOxRhjcqqobUynqrsCE4SItPIznlgmIrlF5HYRGSYil6SY94hfccUyESkkIoNF5H4RKSAiPUVkuog8JyJF/I7PRI6oTRKpsA7+/DMGaArsAl4RkcB+8bv4E1LMiwNKA5WAmbgeeZ/H1agZ7V9YJiURWe09fOl4MaqKm0RkelqzgBaqauMo+8Dr+ri29zwPbmCokrhBb77LaFxfk/1EZLmq1vXG9NgKlFFV9f7/ya/WvSZ1XvH5xao6M9z7jrbaTZcBPYADKaYnD2lq/JEv+YmqHgP6ishjuIZbVrThIy8xfJo8vK/3f/T8csyBUuuZwCs6D3uCgOhLEt8Bh1R1QcoZIrLWh3iMs1RE2gSOZ62qT4jIFqxowy9LRaSIqh5Q1VuSJ4rIeURYi99YEak9E0RVcZMx5tSJiKidGMIuUnsmiKUb18aYIFiC8E3hlAkCQFW/A3y7nxptxU3GGJNTRWTPBFbcZIwxESISeyawJGF8IyJlgH+sC4jIYcfEpBQT9yREZLyIjBaRiBk31gDwDrBGRF7wOxBznB2TCCQiff3ad6zck/gfUAG4CXjA51iMR1Wv8BpvVfc7FuPYMYlYkvEiIdqxFTeZcPBOPI04sax1sdWk8Y8dExOMqEoSIlIMeAjoDJyJG91pO2740v+q6h7fgothInIlriuO9QQ0EsIN9t5fVWf7FVussmMSmUSkNe78FZi4Pw5siBr2mKIsSXyO6+phvKr+7U07CzeQSktVvdLP+GKViKwG2qYcN1lEKgGfqmo1XwKLYXZMIo+IjACq4KrABg6/fDOwXlXv9iWuKEsSa1W1ambnmdASkfVANa/fpsDp+YBfbPjS8LNjEnnSGmLZKxZc59eQstF243qTiAzGXUlsg+OdZfXi38YpJvzeApaIyERObCR0PdaFu1/smESeeBFpqKpLUkxvCMT7ERBE35XE6cCDuMYoZ3qTt+GGZHxWVf/xK7ZYJyLVSL2R0C/+RRXb7JhEFhG5ENfhZVH+LW46G9gL3Kmqy3yJK5qShDHG5HTefdTArsL/9jOemGhMB8eztIkwIjLE7xjMieyY+MdLEHhXDX8Al4iIr21WYiZJAP38DsCkypdLaJMuOyY+EJHbgW+B70SkH/AJ0B6YKiK3+haXFTcZY4z/RGQFcBFQENgEVFbVv717rfNUta4fcUVb7abkBnVtOPFm3OfWkM4/3rjWtwJXA2W9yZtxjRzfVNUEv2KLVXZMIlKCqh4CDonIb8n3IlR1t59DykbVlYSI3Aw8DszmxFakrYChqvq2X7HFMhF5H9gDjOfERkI9gRKqep1PocUsOyaRR0SWAReraoKIlFfVv7zpBYDv/RqZLtqSxFrgopRXDd7l2vepNVQxoZdWI6GM5pnQsWMSeUSkArAllQaO5XANH7/0I65ou3EtuP6aUkrCx14UDf+ISDcROf55E5FcInIdsNvHuGKZHZPI82fKBAGgqpuTE4TX+jqsou2exFPADyIym39bkVbAFTcN8y0qcz3wLPCqiCSfgIoD87x5JvzsmESeeSIyBdeh3x/JE72uUprgigLnAXHhDCqqipvgeNFSa06+cW2/jiKAiJwBoKq7/I7FOHZMIoN37+EWoDtQCXfPqACQG3ef9VVV/THscUVTkhARyagv/GCWMeEjIq1U9Qu/44hFInIaUEpVf0sxvbaq/uxTWAYQkbxASeCw3zUzo+2exDwRGeDdADpORPKJSAsRGY+7ZDORwzqT84GIXAusAaaIyCoRaRgwO86fqEwyVU1Q1a1+JwiIvnsSbXCXa+97/eLvwTVMyYW7XBvhx+VarBOR6WnNAs4IZyzmuIeB+qq6VUQaAe+IyEOqOhWr5GECRFVxU6BIulyLdd6N0R7AgZSzgA9UtXT4o4ptIrJCVWsF/F8G1w3EeKCXqlpfZwaIviuJ47wWo1v9jsMA8B1wSFUXpJzhtW0x4bdfRM5Lvh/hXVE0A6YBNXyMy0SYqL2SMMakTUTq4BL3+hTT8wLXqup7/kRmIo0lCRNyVuss8tgxMcGKttpNJjJZrbPIY8fEBMWuJEzIRWojoVhmx8QEy5KECSurdRZ57JiY9FiSMMYYkya7J2GMMSZNliSMMcakyZKECSsRSRSR5SKyUkRmiEjxEOyjmYh8ko3bGyQihQL+/zQ74haROBHpmg3bGSIi92Vi+YdPdZ8mdliSMOF2WFXrqmpN4B/gTr8DEie978Ig4HiSUNV2OfwGryUJEzRLEsZP3+KN+yEi80Wkgfe8pIhs9J73EpGPROQzEVkvIs+ltiERaSMia0TkB6BLwPQTfmV7VzAVvcdaEXkbWAmcLSKjRWSp1yvqUG/5gUBZXLuCed60jSJS0nt+j7fNlSIyyJtWUURWi8gb3rZmi0jBNN6DK7x9rhORDgGv+X8BMX/idZmR/Dp/EJGfRGROKu9DHxGZJSIFRaSHiCz2rtzGiEhuEfkvUNCb9p6IFBaRmd72Voobmc6Y46K27yYT2UQkN9CS4LoKrwvUA44Aa0XkFVVNHnkwuc7/G0AL4FfggyDDOB/oqarfedv5P1X9x4ttjrhxFUaKyD1Ac1XdmeI11Ad6AxfhOiv8XkQW4Ib/PB+4QVX7iMgk4Brg3VRiqAg0As7DJaLKaQUrIqW813m5qm4QkRIp5t+FG4WxM3AucB1wqaomiMirQHdVfVBE7lLVut461+DGVW7v/V8suLfOxAq7kjDhVlBElgN/A6WBYAYcmqOqe1U1HvgFOCfF/AuADaq63utGIrWTcWo2JScIz7XelciPuE7uqmewfhNgqqoeVNUDwEfAZd68Daq63Hu+DJcMUjNJVZO8PpR+915LWi4GFqrqBgBV/Sdg3s1AW6Crqh7BJeD6wBLv/W6JSxwprQBaicizInKZqu5N7wWb2GNJwoTbYe9X7Dm4X9/J9ySO8e/nsUCKdY4EPE8kc1fAgdtNue2DyU/EjT9yH9BSVWsDM1OJIzOCjTllQyUl/ZjTsgKXiMp7/wsw3rv/U1dVq6rqkJN2rroOuNBb/0kReSyIfZkYYknC+EJVDwEDgXtFJA+wEffLFyCzNX7WABVF5Dzv/xsC5m3EnQQRkQtxXVCk5jRc0tgrIqVxv8qT7QeKprLOIqCziBQSkcLA1d60zOgmIrm82M8F1nox1/Wmn40rjgLX5frlXkIjRXHTj8DtwHQRKQvMAbqKyJnJy4pI8hVYgrhW1njLHlLVd4Hn8d4rY5LZPQnjG1X9UUR+xp3UXwAmiUhf3K/4zGwnPnk9ETmEO1Enn9SnADeLyCrge2BdGtv4SUR+xCWcP4GvA2a/DnwmIltUtXnAOj+ISByw2Js01ntNFTMR/h/e+qcBd3iv5WtgA65obTXwg7e/Hd7r/MirjbUddw8iOZ6vvJv0M73pjwCzvWUTcFdtm7zX87NXtPY28LyIJHnL9MtE7CYGWLccxhhj0mTFTcYYY9JkScIYY0yaLEkYY4xJkyUJY4wxabIkYYwxJk2WJIwxxqTJkoQxxpg0WZIwxhiTpv8HAPCws5UDC2gAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot the two series on the same graph\n",
+    "plt.plot(joined.index.astype(str), joined['f_pct'], color='red', label='percent of failure')\n",
+    "plt.plot(joined.index.astype(str), joined['p_pct'], color='green', label='percent of passing')\n",
+    "\n",
+    "# set x and y axis labels\n",
+    "plt.xlabel('Run duration buckets')\n",
+    "plt.ylabel('Percentage of passing or failing')\n",
+    "plt.xticks(rotation=90) \n",
+    "\n",
+    "# set title and legend\n",
+    "plt.title('Percentage contribution of failing and passing to their sum')\n",
+    "plt.legend()\n",
+    "\n",
+    "# show the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2716cdab-411c-4634-8581-97b12794f07d",
+   "metadata": {},
+   "source": [
+    "This above plot indicates that at a time duration 25, a test is more likely to fail than pass."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36efb68b-889d-4e59-b3a8-02d2f3cc6638",
+   "metadata": {},
+   "source": [
+    "### Test 4: Lets do this for a much larger test dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "2c67b65f-88df-4c82-b0aa-71cc37524f5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# From the repo https://github.com/github/codeql\n",
+    "test_id = \"39411153\" #\"Compile all queries using the latest stable CodeQL CLI\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "d30e1017-9d4f-4073-b653-7186501c8a1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_train = pd.read_csv(\"../data/processed/{}passing_train.csv\".format(test_id))\n",
+    "failing_train = pd.read_csv(\"../data/processed/{}failing_train.csv\".format(test_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "98c441ca-5da2-4ac6-b6bd-2a549c905631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# bucketing into 30 second intervals\n",
+    "\n",
+    "ranges = np.arange(0, max(passing_train['run_duration'])+1, 30).tolist()\n",
+    "ranges.append(np.inf)\n",
+    "passing_train['run_duration_ranges'] = pd.cut(passing_train['run_duration'], bins=ranges)\n",
+    "failing_train['run_duration_ranges'] = pd.cut(failing_train['run_duration'], bins=ranges)\n",
+    "p_vc = pd.DataFrame(passing_train['run_duration_ranges'].value_counts().sort_index())\n",
+    "f_vc = pd.DataFrame(failing_train['run_duration_ranges'].value_counts().sort_index())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "031f565b-4531-4e3a-8bee-31cb7567f6c6",
+   "metadata": {},
+   "source": [
+    "---------------------"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "435906d3-62a3-4092-bf11-a63900681298",
+   "metadata": {},
+   "source": [
+    "### IQR method to remove outliers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "473eaad4-7913-430b-b714-06558f922b39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Mostly thinking of removing this part, just kept it for now if we need to test out the methods after removing outliers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "88725452-d8dd-4850-8418-194dcb3de139",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# q1 = passing_train['run_duration'].describe()['25%']\n",
+    "# q3 = passing_train['run_duration'].describe()['75%']\n",
+    "# iqr = q3 - q1\n",
+    "# outlier_threshold = q3 + 6.0 * iqr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "c706ef0c-370c-4a98-88de-92e806ef49a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ranges = np.arange(0, int(outlier_threshold)+1, 30).tolist()\n",
+    "# ranges.append(np.inf)\n",
+    "# passing_train['run_duration_ranges'] = pd.cut(passing_train['run_duration'], bins=ranges)\n",
+    "# failing_train['run_duration_ranges'] = pd.cut(failing_train['run_duration'], bins=ranges)\n",
+    "# p_vc = pd.DataFrame(passing_train['run_duration_ranges'].value_counts().sort_index())\n",
+    "# f_vc = pd.DataFrame(failing_train['run_duration_ranges'].value_counts().sort_index())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a57c1062-92e3-4711-bd5e-4ff68d906ce5",
+   "metadata": {},
+   "source": [
+    "------------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "41d58961-2322-4fc1-92cb-36a0e0d8ba4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_vc['prefix_sum'] = p_vc['run_duration_ranges'][::-1].cumsum()[::-1]\n",
+    "f_vc['prefix_sum'] = f_vc['run_duration_ranges'][::-1].cumsum()[::-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "b9fea6ac-1c82-4e9c-9c87-13594e8bc858",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 30.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>4528</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 60.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>4528</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(60.0, 90.0]</th>\n",
+       "      <td>8</td>\n",
+       "      <td>4528</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(90.0, 120.0]</th>\n",
+       "      <td>99</td>\n",
+       "      <td>4520</td>\n",
+       "      <td>99.823322</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(120.0, 150.0]</th>\n",
+       "      <td>593</td>\n",
+       "      <td>4421</td>\n",
+       "      <td>97.636926</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341820.0, 341850.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.022085</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341850.0, 341880.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.022085</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341880.0, 341910.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.022085</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341910.0, 341940.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.022085</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341940.0, inf]</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.022085</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>11399 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 30.0]                             0        4528             100.000000\n",
+       "(30.0, 60.0]                            0        4528             100.000000\n",
+       "(60.0, 90.0]                            8        4528             100.000000\n",
+       "(90.0, 120.0]                          99        4520              99.823322\n",
+       "(120.0, 150.0]                        593        4421              97.636926\n",
+       "...                                   ...         ...                    ...\n",
+       "(341820.0, 341850.0]                    0           1               0.022085\n",
+       "(341850.0, 341880.0]                    0           1               0.022085\n",
+       "(341880.0, 341910.0]                    0           1               0.022085\n",
+       "(341910.0, 341940.0]                    0           1               0.022085\n",
+       "(341940.0, inf]                         1           1               0.022085\n",
+       "\n",
+       "[11399 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(p_vc['prefix_sum'])\n",
+    "p_vc['prefix_sum_percentage'] = p_vc['prefix_sum'] / max_duration * 100\n",
+    "p_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "d95c74d6-0871-4a36-9846-0af227d11bf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_duration_ranges</th>\n",
+       "      <th>prefix_sum</th>\n",
+       "      <th>prefix_sum_percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(0.0, 30.0]</th>\n",
+       "      <td>10</td>\n",
+       "      <td>368</td>\n",
+       "      <td>100.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(30.0, 60.0]</th>\n",
+       "      <td>31</td>\n",
+       "      <td>358</td>\n",
+       "      <td>97.282609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(60.0, 90.0]</th>\n",
+       "      <td>72</td>\n",
+       "      <td>327</td>\n",
+       "      <td>88.858696</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(90.0, 120.0]</th>\n",
+       "      <td>49</td>\n",
+       "      <td>255</td>\n",
+       "      <td>69.293478</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(120.0, 150.0]</th>\n",
+       "      <td>48</td>\n",
+       "      <td>206</td>\n",
+       "      <td>55.978261</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341820.0, 341850.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.543478</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341850.0, 341880.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.543478</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341880.0, 341910.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.543478</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341910.0, 341940.0]</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.543478</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(341940.0, inf]</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.543478</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>11399 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      run_duration_ranges  prefix_sum  prefix_sum_percentage\n",
+       "(0.0, 30.0]                            10         368             100.000000\n",
+       "(30.0, 60.0]                           31         358              97.282609\n",
+       "(60.0, 90.0]                           72         327              88.858696\n",
+       "(90.0, 120.0]                          49         255              69.293478\n",
+       "(120.0, 150.0]                         48         206              55.978261\n",
+       "...                                   ...         ...                    ...\n",
+       "(341820.0, 341850.0]                    0           2               0.543478\n",
+       "(341850.0, 341880.0]                    0           2               0.543478\n",
+       "(341880.0, 341910.0]                    0           2               0.543478\n",
+       "(341910.0, 341940.0]                    0           2               0.543478\n",
+       "(341940.0, inf]                         2           2               0.543478\n",
+       "\n",
+       "[11399 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_duration = max(f_vc['prefix_sum'])\n",
+    "f_vc['prefix_sum_percentage'] = f_vc['prefix_sum'] / max_duration * 100\n",
+    "f_vc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "3a78bff9-887e-4528-917e-75355329a5ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# join dataframes a and b on their index\n",
+    "joined = f_vc.join(p_vc, how='outer', lsuffix='_f', rsuffix='_p')\n",
+    "\n",
+    "total = joined[['prefix_sum_f', 'prefix_sum_p']].sum(axis=1)\n",
+    "joined['f_pct'] = joined['prefix_sum_f'] / total * 100\n",
+    "joined['p_pct'] = joined['prefix_sum_p'] / total * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "aab2a94d-05f6-4e77-891d-78b59201ff2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmQAAAHmCAYAAADdgZLyAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAACVmUlEQVR4nO2dd5hU1fnHP+8uVaqKCgoCNgQLiIAFE7CXGGOMLdEI0ViS2GJiTbHEGE21/CwxGks0iT32rtgLiCgioqioKCo2pJfd9/fHOcPeHaac2T0zc3f3/TzPfebOve+c8z1l7rxzqqgqhmEYhmEYRvWoqbYAwzAMwzCMto45ZIZhGIZhGFXGHDLDMAzDMIwqYw6ZYRiGYRhGlTGHzDAMwzAMo8qYQ2YYhmEYhlFlzCEzjDaEiHxDRGYk3s8SkV0ihj9NRMbGCi8wThGRa0TkSxF5MY/NuSLymYh8HBDeFSLyG38+VkRmJ+5VPH1NQURURDaqtg5oOXkGICITROTHTfzs/SIyLrYmo+3QrtoCjNaJiMwC1gHqgIXA/cCxqrqgmroyiMhZwEaqemi1tcRCRBTYWFVn5rNR1aeAQZHiuxaYraq/ToS/WYywS2QHYFegr6ouzL4pIusDvwD6q+qnxQJT1WMK3KtG+lo05cozERkP/FhVd2ji588i4jNAVfeMEY7RdrEWMqOcfFtVuwLDgRHAr4vYN8K3fFgdjYSItNY/YP2BWbmcMc/6wOchzphhlINW/N0zYqKqdtgR/QBmAbsk3v8JuMefbws8C3wFvAKMTdhNAH4PPAMsBjYCNgMeBr4APgHO8LY1wGnA28DnwM3AGv7eAECBccD7wGfAr/y9PYBlwHJgAfCKv/4jYDowH3gHODorTacAc4CPgB/78Dfy9zoCf/ZxfQJcAXQukD9HJuJ6HRjurw/2efAVMA3YJ/GZa4FLgXv9514ANvT3nvR6Fvo0HQSMBWYDpwIfA//KXMsqp9O9hi+Ba4BO/t544Oks3erL5Ciff8t8fHdnl7vPkwt9fn3kzzv6exltvwA+9fn6owL5tS5wl68DM4Ej/fUjgCW4ltgFwNlZn9sFV4/q/f1r/fVbfJ7M83m3WVY+n5vUmateA2fh6tz1vjymASMStsOBl/29W4CbMuHmSN+GwGO4evwZcCPQMyveXwKves03ZcrJ3z+Zhrp5OIm6mSOuCcAfgBeBr4E78d+bgLzZy9eV+cCHwC/99V7APbh6+wXwFFBTrjzDfU+S5f6Vv97Dhz0XeA/3J7Amx+fzPQMmAL/DPX/mAw8BvRKfK/bs+nHiu/MM8DdfprnSMAqY5MvgE+Cvuepcnjy8BbjBa5wKbIL7Hn8KfADsVq1nvx1NP6ouwI7WeWQ9QPr5B+/vgPX8A2ovnEO1q3+/lredgHNqNsN1qXfD/dD8Aujk32/jbU8Angf64n78/w78x98bgPtR+gfQGRgKLAUG+/tnATdkaf4W7odRgDHAIhocpT1wP1KbAav5h2HSIfsbzmFYw2u8G/hDnrw5APdjNtLHtRGulac9ztk4A+gA7OQfuIP85671eTXK582NwH8T4Tb6EfYP9hXABT5/Omc/7H05vebLaA3cj0jGGRlPHocsoefcAuV+ji+ftYG1cD9kv8vSdo5P914+v1fPk2dPApf5OjAM94O7Uz6dWZ9tlGZ/7XBfThmncUri3sp05cmv5A/jEq+9FufkPO/vdcA5BCf49O2HcwDyOWQb4b4LHX1ePQlcmBXvizjHdA2cM39Mom5+AmwOdAH+nV0XsuKagKt/GfvbSHwXiuTNHOAb/nx1Gr4ff8D9CWnvj28AUuY8W6Xccc7YnV7/AOBN4Ig8nz+LVZ8BE3B/8DbBfV8mAOf7eyHPrqRDtgI4DvddXeXPGfAc8EN/3hXYtkB9zZWHu/uwrwfeBX7l8+1I4N1yPdvtKN9RdQF2tM7DP0AW4P5Jvof7Me2Ma635V5btg8A4fz4BOCdx7/vAy3nimA7snHjfB/ePtx0NDlnfxP0XgYP9+SoP4xzh/w84wZ//k4SDhfsBzbQWCa5lasPE/e3yPRR9ek/Icf0bOKevJnHtP8BZ/vxa4KrEvb2ANxLvczlky2jcktLoYe/L6ZisMN/25+NpnkP2NrBX4t7uuK7FjI7FQLvE/U/xP0pZYfbDtYR0S1z7Aw2tXavozPp8ozTnuN/Tp6tHdrry5Ffyh/GRxL0hwGJ//k2c0yOJ+09n51cBTfuSqPc+3kMT7/8IXJGom+cn7m2SXReywp6QZT/E15PagLx5Hzga6J5ldw7OEVolznLlWXa54xy8ZcCQxLWjgQl5Pn8WuR2yXyfe/xR4wJ+HPLuSDtn7Rcr4SeBsEi1w+eprjjx8OHHv27hnba1/382XWc+QumZHeg4bn2OUk31Vtaeq9lfVn6rqYlxL0AEi8lXmwA3K7pP43AeJ8364H/Zc9AfuSIQzHffDvU7CJjmrbhHun2hORGRPEXleRL7w4e2F64oB1zKR1JU8XwvXavZSQssD/nou8qVpXeADVa1PXHsP98+85PR45qrqkiI2ybS853XEYF0fXr6wP1fVFYn3+dKzLvCFqs7PCmu9HLZFEZFaETlfRN4Wka9xP3bQUNalkF0enfx4oXWBD9X/Qno+IA8iso6I/FdEPvSabsihJ1/ZZ9fNZJ7nI9u+PdArIG++h/tevCciT4jIdv76n3Ctuw+JyDsiclqBuKPkWQ56+XRk17lS60m+fA55diUppv0InPP8hohMFJG9S9D4SeJ8MfCZqtYl3kPxZ4ORMswhMyrNB7h/mT0TRxdVPT9hk/1A3qBAWHtmhdVJVT8M0JGMAxHpiOu6+TOwjqr2BO7DtX6B66rpm/hIv8T5Z7iH4GYJHT3UTWjIp3vDHNc/AvplTWRYH9dq0FS0uEmjtKzvdYBr9Vstc0NEepcY9ke4H7FcYZfCR8AaItItK6ym5ssPgO/gxpf1wLWmQkNZx2AOsJ6IJMPsl88YOA+Xn1uoanfg0BL0zGHVMixGtv1yXD0umDeqOlFVv4Prhv4fbjwYqjpfVX+hqhsA+wAnicjOgfqT6Sglz7Lr32c+Hdl1Ll89CfluJAl5dgWHr6pvqer3cXl5AXCriHRh1e9dLfn/3BmtCHPIjEpzA/BtEdnd/xvv5Nd66pvH/h6gj4icKCIdRaSbiGzj710B/F5E+gOIyFoi8p1AHZ8AAxLOTwfcmJm5wAoR2RPYLWF/M/AjERksIqsBv8nc8C1a/wD+JiJrey3ricjueeK+CviliGztZ5Ju5NPwAu4f+Ski0t6v3fRt4L8lpCmf81qIn4lIXxFZAzcO5SZ//RVgMxEZJiKdcF0lpcT3H+DXvlx6Ab/FlX9JqOoHuPFnf/D1ZUtc60LJYXm64cYTfo774TuvieEU4jlca+2xItLO18tRRTQtAOaJyHq4Qfqh3AyMF5Ehvm6eGfCZQxP25wC3+haWvHkjIh1E5BAR6aGqy3GD0ev9vb19PRbcZIC6zL0SKDXPPgH6ikgHAK//ZtwzoZv/Tp1E/nqS/QwoRqnProKIyKEispZ/fnzlL9fjxr11EpFviUh73MSEjk2Jw2hZmENmVBT/4/od3MD1ubh/nSeTpy76bqpdcY7Jx8BbwI7+9kW4gfQPich83ADybXKFk4Nb/OvnIjLZx3M87oH+Ja6l4K6EjvuBi4HHcV0zz/tbS/3rqZnrvqvnEfKs96Wqt+Bmkv4bN2j/f7hZbst8OvfE/du/DDhMVd8ITNNZwHW+O+XAwM/gdTyEm1n6NnCu1/km7sf6EVy+P531uauBIT6+/+UI91zcLLJXcTPBJmfCbgLfx7XWfATcAZypqo80MazrcV1ZH+JmDD5f2Lx0fFnuh3Mcv8K1eN1DQ33J5mzcDMN5uFm0t5cQ1/24wfeP4ergYwEf+xdurNzHuIkSx/vrxfLmh8AsX8ePAQ7x1zfG1ZMFOMfqMlV9PDQNPh2l5tljuMlCH4vIZ/7acbgWpndw9fXfuDF2uWj0DAjQV9KzK4A9gGkisgD3LDtYVRer6jzc2LWrcOWwEDcj2WjlZGbBGIZRAiIyGDc7sWPWOCjDyImIvIAbiH9NlXVMwA1mv6qaOkJIS54ZRiWwFjLDCEREvuu7TVfHjfm425wxIx8iMkZEevvut3HAlrjJHkYeLM+Mtow5ZIYRztG4pRnexo11+Ul15RgpZxBuHN5XuHX09lfVOVVVlH4sz4w2i3VZGoZhGIZhVJmytZCJyD9F5FMReS1xbQ0ReVhE3vKvq/vrIiIXi8hMEXlVRIaXS5dhGIZhGEbaKGeX5bW4WSRJTgMeVdWNgUf9e3Czyjb2x1HA5WXUZRiGYRiGkSrK2mUpIgNwG0pv7t/PwG3GOkdE+uC2tBgkIn/35//JtisUfq9evXTAgAFl028YhmEYhhGLl1566TNVzbnQb7sKa1kn4WR9TMMWN+vReJuJ2f5aQYdswIABTJo0KbpIwzAMwzCM2IhI3q3NqjbL0u9XVnLznIgcJSKTRGTS3Llzy6DMMAzDMAyjslTaIfvEd1XiXz/11z+k8Z5lfcmz/5iqXqmqI1R1xFpr2fZehmEYhmG0fCrtkN0FjPPn44A7E9cP87MttwXm2dozhmEYhmG0Fco2hkxE/gOMBXqJyGzchrfnAzeLyBG4/dIy++3dB+yF24dtEfCjcukyDMMwjEqwfPlyZs+ezZIlS6otxagwnTp1om/fvrRv3z74M2VzyFT1+3lu7ZzDVoGflUuLYRiGYVSa2bNn061bNwYMGICIVFuOUSFUlc8//5zZs2czcODA4M/Z1kmGYRiGUQaWLFnCmmuuac5YG0NEWHPNNUtuGTWHzDAMwzDKhDljbZOmlLs5ZIZhGIZhlJULL7yQRYsWlfSZp556is0224xhw4axePHiRvcuvvhiBg8ezCGHHJL385MmTeL4448H4Nprr+XYY48tXXgFMYfMMAzDMIxVWLFiRbSwmuKQ3XjjjZx++ulMmTKFzp07N7p32WWX8fDDD3PjjTfm/fyIESO4+OKLm6Q3ZtpDMYfMMAzDMFohs2bNYtNNN+WQQw5h8ODB7L///iudopdeeokxY8aw9dZbs/vuuzNnjltpauzYsZx44omMGDGCiy66iIkTJ7L99tszdOhQRo0axfz586mrq+Pkk09m5MiRbLnllvz9738HYMKECYwdO5b9999/ZbyqysUXX8xHH33EjjvuyI477riKzkcffZStttqKLbbYgsMPP5ylS5dy1VVXcfPNN/Ob3/xmlVawY445hnfeeYc999yTv/3tb7z44otst912bLXVVmy//fbMmDFjpZ699957lfjGjx/PrbfeuvJ9165dV9p/4xvfYJ999mHIkCF501kuKr11kmEYhmG0PU48EaZMiRvmsGFw4YUFTWbMmMHVV1/N6NGjOfzww7nssss44YQTOO6447jzzjtZa621uOmmm/jVr37FP//5TwCWLVvGpEmTWLZsGZtuuik33XQTI0eO5Ouvv6Zz585cffXV9OjRg4kTJ7J06VJGjx7NbrvtBsDLL7/MtGnTWHfddRk9ejTPPPMMxx9/PH/96195/PHH6dWrVyN9S5YsYfz48Tz66KNssskmHHbYYVx++eWceOKJPP300+y9997sv//+jT5zxRVX8MADD6wM7+uvv+app56iXbt2PPLII5xxxhncdtttTcrSyZMn89prrzFw4ECuvPLKnOksZeZkKZhDZhiGYRitlH79+jF69GgADj30UC6++GL22GMPXnvtNXbddVcA6urq6NOnz8rPHHTQQYBz5vr06cPIkSMB6N69OwAPPfQQr7766spWpnnz5vHWW2/RoUMHRo0aRd++fQEYNmwYs2bNYocddsirb8aMGQwcOJBNNtkEgHHjxnHppZdy4oknBqdx3rx5jBs3jrfeegsRYfny5cGfzWbUqFErHa586TSHrArMWzKPnhf05J/7/JMfbWVr1RqGYRhNpEhLVrnInu0nIqgqm222Gc8991zOz3Tp0qVgmKrKJZdcwu67797o+oQJE+jYsePK97W1tRUZi/Wb3/yGHXfckTvuuINZs2YxduzYgvbt2rWjvr4egPr6epYtW7byXjLt+dJZLmwMWQHmLHB96uc/c36VlRiGYRhG6bz//vsrHa9///vf7LDDDgwaNIi5c+euvL58+XKmTZu2ymcHDRrEnDlzmDhxIgDz589nxYoV7L777lx++eUrW6LefPNNFi5cWFBHt27dmD9/fs44Zs2axcyZMwH417/+xZgxY0pK47x581hvvfUAN5uyGAMGDOCll14C4K677srbotaUdDYHc8gK0LHWefpLVyytshLDMAzDKJ1BgwZx6aWXMnjwYL788kt+8pOf0KFDB2699VZOPfVUhg4dyrBhw3j22WdX+WyHDh246aabOO644xg6dCi77rorS5Ys4cc//jFDhgxh+PDhbL755hx99NFFW8KOOuoo9thjj1UG9Xfq1IlrrrmGAw44gC222IKamhqOOeaYktJ4yimncPrpp7PVVlsFtcgdeeSRPPHEEwwdOpTnnnsub4tgU9LZHMTtWtQyGTFihE6aNKls4b/z5TtsePGGrNF5DT4/5fOyxWMYhmG0PqZPn87gwYOrFv+sWbPYe++9ee2116qmoS2Tq/xF5CVVHZHL3lrICrCi3nnCXyz+ospKDMMwDMNozZhDVoCMQwbWbWkYhmG0LAYMGGCtYy0Ic8gKkHTIXp/7ehWVGIZhGIbRmjGHrABJh2ziRxOrqMQwDMMwjNaMOWQFqKuvW3l+9D1HW7elYRiGYRhlwRyyAiyvb7w2yZSPp1RHiGEYhmEYrRpzyAqwZMWSRu/rtb5KSgzDMAyj5XLhhReu3Ng8lKeeeorNNtuMYcOGsXjx4jIpa8xHH320yt6ZlcIcsgIsXu4qQN/ubl+uOq0rZG4YhmEYrYaYi6A2xSG78cYbOf3005kyZQqdO3eOpqUQ66677sq9KyuNOWQFEBHW7rI2J29/MgAXvXBRlRUZhmEYRhizZs1i00035ZBDDmHw4MHsv//+K52il156iTFjxrD11luz++67M2eO2ypw7NixnHjiiYwYMYKLLrqIiRMnsv322zN06FBGjRrF/Pnzqaur4+STT2bkyJFsueWW/P3vfwfcXpZjx45l//33XxmvqnLxxRfz0UcfseOOO66yUj/Ao48+ylZbbcUWW2zB4YcfztKlS7nqqqu4+eab+c1vfsMhhxwSnK5zzjmHkSNHsvnmm3PUUUeRWfz+4osvZsiQIWy55ZYcfPDBADzxxBMMGzaMYcOGsdVWWzF//nxmzZrF5ptvDrhtmPbbbz/22GMPNt54Y0455ZSVGq6++mo22WQTRo0axZFHHsmxxx7b7PKyzcULsNfGe/HJLz/hmfefAeDW16vjNRuGYRgtmxMfODH6OORhvYdx4R4XFrSZMWMGV199NaNHj+bwww/nsssu44QTTuC4447jzjvvZK211uKmm27iV7/6Ff/85z8BWLZsGZMmTWLZsmVsuumm3HTTTYwcOZKvv/6azp07c/XVV9OjRw8mTpzI0qVLGT16NLvtthsAL7/8MtOmTWPddddl9OjRPPPMMxx//PH89a9/5fHHH6dXr16N9C1ZsoTx48fz6KOPsskmm3DYYYdx+eWXc+KJJ/L000+z99575+xCzJWuX/7ylxx77LH89re/BeCHP/wh99xzD9/+9rc5//zzeffdd+nYsSNfffUVAH/+85+59NJLGT16NAsWLKBTp06rxDNlyhRefvllOnbsyKBBgzjuuOOora3ld7/7HZMnT6Zbt27stNNODB06tNTiWwVrIQtg9Pqjqy3BMAzDMEqmX79+jB7tfsMOPfRQnn76aWbMmMFrr73GrrvuyrBhwzj33HOZPXv2ys8cdNBBgHN6+vTpw8iRIwHo3r077dq146GHHuL6669n2LBhbLPNNnz++ee89dZbAIwaNYq+fftSU1PDsGHDmDVrVkF9M2bMYODAgWyyySYAjBs3jieffLJJ6QJ4/PHH2Wabbdhiiy147LHHVm6avuWWW3LIIYdwww030K6da4saPXo0J510EhdffDFfffXVyutJdt55Z3r06EGnTp0YMmQI7733Hi+++CJjxoxhjTXWoH379hxwwAFF9YZgLWSGYRiGUWaKtWSVCxFZ5b2qstlmm/Hcc8/l/Ey+zbYzqCqXXHIJu+++e6PrEyZMoGPHjivf19bWlm0z7lzpWrJkCT/96U+ZNGkS/fr146yzzmLJEjc579577+XJJ5/k7rvv5ve//z1Tp07ltNNO41vf+hb33Xcfo0eP5sEHH1yllaxS6QFrITMMwzCMVsv777+/0vH697//zQ477MCgQYOYO3fuyuvLly9f2ZKUZNCgQcyZM4eJE93C6PPnz2fFihXsvvvuXH755Sxf7paGevPNN1m4cGFBHd26dWP+/Pk545g1axYzZ84E4F//+hdjxoxpUroyzlevXr1YsGDBysH59fX1fPDBB+y4445ccMEFzJs3jwULFvD222+zxRZbcOqppzJy5EjeeOONovECjBw5kieeeIIvv/ySFStWcNtttwV9rhjmkAUybug4gJUDBA3DMAwj7QwaNIhLL72UwYMH8+WXX/KTn/yEDh06cOutt3LqqacydOhQhg0bxrPPPrvKZzt06MBNN93Ecccdx9ChQ9l1111ZsmQJP/7xjxkyZAjDhw9n88035+ijjy7acnTUUUexxx57rDKov1OnTlxzzTUccMABbLHFFtTU1HDMMcc0KV09e/bkyCOPZPPNN2f33Xdf2dVaV1fHoYceyhZbbMFWW23F8ccfT8+ePbnwwgvZfPPN2XLLLWnfvj177rlnUJ6ut956nHHGGYwaNYrRo0czYMAAevToEfTZQkhLdjBGjBihkyZNqkhccrZrHj1jhzP4/c6/r0ichmEYRstl+vTpDB48uGrxz5o1i7333rvVbTCehnQtWLCArl27smLFCr773e9y+OGH893vfreRTa7yF5GXVHVErjCthaxEkvtbGoZhGIbR9jjrrLMYNmwYm2++OQMHDmTfffdtdpg2qD+QJ8Y/wZhrx7DhGhtWW4phGIZhFGXAgAGtrnUM0pGuP//5z9HDtBayQEas61oYv1z8ZZWVGIZhGIbR2jCHLJDO7TojCIuWl7b1g2EYhtF2acnjtI2m05RyN4csEBGhU7tOLF5RmQ1ODcMwjJZNp06d+Pzzz80pa2OoKp9//nnOlf8LYWPISqBTu04sWbGk2jIMwzCMFkDfvn2ZPXs2c+fOrbYUo8J06tSJvn37lvQZc8hKoFO7Tixebi1khmEYRnHat2/PwIEDqy3DaCFYl2UJdG7fmSV11kJmGIZhGEZczCErAeuyNAzDMAyjHJhDVgLWZWkYhmEYRjkwh6wEOrfrbC1khmEYhmFExxyyErBlLwzDMAzDKAfmkJVA5/bWQmYYhmEYRnzMISsBG9RvGIZhGEY5MIesBGxQv2EYhmEY5cAcshKwQf2GYRiGYZQDc8hKwAb1G4ZhGIZRDswhKwFrITMMwzAMoxyYQ1YCmUH9qlptKYZhGIZhtCLMISuBr5d+DcDjsx6vshLDMAzDMFoT5pCVwGtzXwNg5+t35reP/7bKagzDMAzDaC2YQ1YCfbr2WXn+uyd/V0UlhmEYhmG0JswhK4EasewyDMMwDCM+5mGUgIg0er+sblmVlBiGYRiG0Zowh6wExvYf2+j97K9nV0eIYRiGYRitCnPISuCwoYcx++ezue3A2wCYv3R+lRUZhmEYhtEaMIesBESE9bqvR9cOXQGYv8wcMsMwDMMwmo85ZE2gc7vOALZqv2EYhmEYUTCHrAl0atcJMIfMMAzDMIw4mEPWBDIO2dIVS6usxDAMwzCM1kBVHDIR+bmITBOR10TkPyLSSUQGisgLIjJTRG4SkQ7V0BaCtZAZhmEYhhGTijtkIrIecDwwQlU3B2qBg4ELgL+p6kbAl8ARldYWSsYh+3Thp1VWYhiGYRhGa6BaXZbtgM4i0g5YDZgD7ATc6u9fB+xbHWnF6dmpJwDXTLmmukIMwzAMw2gVVNwhU9UPgT8D7+McsXnAS8BXqrrCm80G1sv1eRE5SkQmicikuXPnVkLyKnTr2I0OtR2Y+ulU6rW+KhoMwzAMw2g9VKPLcnXgO8BAYF2gC7BH6OdV9UpVHaGqI9Zaa60yqSzOr7/xa8C2TzIMwzAMo/lUo8tyF+BdVZ2rqsuB24HRQE/fhQnQF/iwCtqC6d6xOwCLly+ushLDMAzDMFo61XDI3ge2FZHVxO3WvTPwOvA4sL+3GQfcWQVtwdhMS8MwDMMwYlGNMWQv4AbvTwameg1XAqcCJ4nITGBN4OpKaysFc8gMwzAMw4hFu+Im8VHVM4Ezsy6/A4yqgpwmkXHIFq+wLkvDMAzDMJpHVRyy1oC1kDWNzxZ9xhufvcGanddk8FqDqy3HMAzDMFKBOWRNpHN722C8KRxwywFMmDUBQZjzizms03WdaksyDMMwjKpje1k2kVqpBeC9r96rspKWxVdLvgJAUb5Y/EV1xRiGYRhGSjCHrIn07tobcI6FEU5dfd3Kc2tdNAzDMAyHdVk2kcz2SQuWLaiukBZGvdbTpX0XFi5fyNdLv2bpiqVBn2tX047amtoyqzMMwzCM6mAOWRPp2qErANPnTq+ykpZFndbRo1MPFi5fyNjrxgZ/bt1u6/LuCe/SobZD2bQZhmEYRrUwh6yJZByymV/OrLKSlkVdfR3b99ueMf3HMH/p/KDPPDf7Oe5+826+Xvo1vVbrVWaFhmEYhlF5zCFrIrU1tWzaa1NqxIbhlUK91tOxtiPHjjo2+DP/eOkf3P3m3cHdm4ZhGIbR0jBvohl079jdnIQSqdO6kp3Yju06ArC0zvLaMAzDaJ1YC1kz6Fjb0ZyEEqnX+pIH53esdQ7ZtE+nscHqG5RDlmEYlWDWLHj99WqraDlsvLE7jDaBOWTNoGO7jixavqjaMloUdfV11JTYMLt2l7UBGH/neD4/5fNyyDIMoxLstx+8/HK1VbQcBgyAd9+ttgqjQphD1gw61Hbgy8VfVltGi6IpLWRjB4xl7ICxvDzHHuSG0aJZsAB23RXOPbfaStLPH/8ITzxRbRVGBTGHrBlYl2Xp1Gndyl0OQhERhvcezsQPJ5ZJlWEYFaNXLxg1qtoq0k/v3qC28HhboqhDJiJr5Lg8X1WXl0FPi6Jju44sq1tWbRkthoXLFrKifkWTZqZ2qO1geW0YLR1VEKm2ipaBCNTXV1uFUUFCfhknA3OBN4G3/PksEZksIluXU1za6VDbwWZZBnL9K9fT9Q9d+WLxFytnTZZCx3YdWV6/HLV/jIbRcrHvbzgill9tjBCH7GFgL1XtpaprAnsC9wA/BS4rp7i007HWWshCeefLdwD4y25/4cRtTyz585mZlr3+1Iv9b94/pjTDMCqJtZCFUVNjDlkbI2QM2baqemTmjao+JCJ/VtWjRaT0po5WhI0hC6euvg5BOGm7k5r0+YM3P5hPFn7Co+8+yhPv2UBXw2iRWJdlONZl2eYIaSGbIyKnikh/f5wCfCIitUCbri3WZRlOndY1a3PwgasP5MI9LmTngTuzvK7ND180jJaJOWThWJdlmyPEIfsB0Bf4nz/W99dqgQPLJawlYIP6w6mrL312ZS5scL9htGDMwQjHHLI2R9EuS1X9DDguz+02vbN2x1o30Lxe621PyyI0t4UsgzlkhtHCsRayMGwMWZsjZNmLTYBfAgOS9qq6U/lktQw61HYAYFndMjq161RlNekmVgtZ+5r21GmdOcGG0RKxLstwbAxZmyNkUP8twBXAVUBdeeW0LDIO2fK65eaQFaEpm4rnIpPn+/53X/538P/MKTOMloS1+IRjXZZtjpBfsxWqermqvqiqL2WOsitrAax0yOptkHkxmrJlUi722ngvAO5+826+WvJVs8MzDKPCWAtZGOaQtTlCHLK7ReSnItJHRNbIHGVX1gJoX9sewMY0BRCry3Jo76FcutelADbb0jBaGtZlGY6NIWtzhHRZjvOvJyeuKbBBfDkti+QYMqMwsQb1gxtHBtYyaRgtDnMwwrExZG2OkFmWAyshpCWSHENmNGZ53XJen/s6insAz100N0oLGTS0TFq+G0YLw1rIwrEuyzZHXodMRHZS1cdEZL9c91X19vLJahlYC1l+zppwFuc9fV6ja4PWHBQl7EwL2Yr6FVHCMwyjgphDFoY5ZG2OQi1kY4DHgG/nuKdAm3fIMo5BS3LIlq5Yyvdu/h6fLvy0qG372vZcvMfFbL1u6XvIf7boM3p07MG1+1678trgXoNLDiefLrAuS8NocZiDEY6NIWtz5HXIVPVM//qjyslpWVR7luWDMx/kohcuWuX6sN7DOG/n83J8Aj74+gPufetetlxnS9brtl7esFfUr+Dhdx7mifeeaJJDVqd1dOnQhX033bfkzxajXY2rtkfdfRTdO3Yvaj+g5wAu3etSxP6ZG0Z1sS7LcDL5ZHnWZijUZVlwF2hV/Wt8OS2LjEP2/rz3GbHuiIrH/5/X/sMj7zzCsN7DVl6b/fVsHnnnkbwOWV29W0ru1NGn8oMtfpA37GV1y+h4bkeWrFjSJG11GmdWZS627rM1Y/qPYdHyRXy26LOCth8v+Jj7Z97PeTufR89OPcuixzCMEjDnIgxzyNochbosu1VMRQtlzdXWBCjqFGSYu3Aundt35pwnzmHBsgVs23dbDht6WJPjX1G/gn49+vHikS+uvHb2hLM564mz3DITOWY1ZsZdZVqZ8pHpjm2yQ5Yn/hj079mfCeMnBNle8sIlHP/A8TbezDDSgDkX4dT4Vams27LNUKjL8uxKCmmJ9O/RHwhzWq6afBVH3n0ku224Gw+9/RC1Ussdb9zRbIcs27Hq3L7zSk1dOnRZ5TN16lrIijlkIkKndp149ZNXuWXaLSVru/X1W1m98+olfy42mXSaQ2YYKcCci3CSLWRGm6BQl+UpqvpHEbkEWKVGqOrxZVXWAlit/WoALFq+qKjt+/PeB2D63OkAbNt3W1755JVmxb+ifsXKlqwMnds5h2z3G3ana4eu/N9e/8dGa2zU6DNAUHdin659uHPGndw5484m6Vs8f3GTPheTzAQAc8gMIwVYC1k4mXyytcjaDIWaSab710mVENISyexfuXh5bsdj9tezWbpiKQCfL/occIPqAVbvvDoLly3kx3f9uNFnaqWWn2/3czbttSnzl85n9D9Hc8EuF7DnxnuuEn6uFrKdBu7ELhvswvyl83nw7Qd56r2ncjpkxVrIAF466iU+mv9RUbtsFq9YzMh/jCz5c+XAWsgMI2WYQxaGtZC1OQp1Wd7tX6+rnJyWhYjQobYD5zx5DhuvuTGHbnnoynsPznyQPW7cI+9ndxywI69+8ioPzHyg0fUP53/IOl3X4Zwdz+H9ee8z9dOpnP7o6cEO2WZrb8bDP3yYTxZ8Qu+/9F6lOzUzqD/EIVu98+pN6nZM04Kt5pAZRoow5yIcG0PW5ii6l6WIrCUifxaR+0TkscxRCXEtgX98+x8AvDD7hUbXP5z/IQB/2/1vOZd++PYm3+a9E99j9kmzGx1d2ndh4bKFACtXuV+8IncLXC6HLEOm9S7bISulhayplDPsUjGHzDBShHVZhmNdlm2OkF/OG4GbgG8Bx+D2tpxbTlEticOGHsavH/s1D779YKPrmcViD978YJbVLeN/b/yv0f3MkhnZdOnQhedmP8fj7z6+cpmGNz9/kz8/+2eAlQu6rt1lbd7+8m3W6bJOznAyDtnD7zy8ciA/wNtfvA1QthmQQKrW+8o4ZFdNvoreXXuvcn9Y72HsssEulZZlGG2XFD0fUk0mny68EDrk/r0wIvPNb8KoUVWLPsQhW1NVrxaRE1T1CeAJEZlYbmEtiSUrlvDB1x+gqiudkczYsQ61Hdi016YAdO3QlQXLFtC5XeeVS2ZkM2StIUyYNYHD7zqcm/a/aeX1kx8+Oaf96H6jc17vUNuB/j36c//M+7l/5v2N7nWs7Ujf7n1LS2SJbLTGRtFW5m8O/Xv0p11NO/7y3F9y3l+327p8eNKHFVZlGG0U634LZ4MN3OuvflVdHW2JCy5IvUOWGRA0R0S+BXwErFE+SS2Pn2/7c8547AwWr1i8cuZlpoWsY21H9hm0D4vOWESH2g4sr19OrdSunP2XzSM/fISf3PsTbp9++8qxWLcdeBu7bbgbAN3+4JaHm3/6fAC6tF91aQtwrVQzj5+Zc0mO9jXt6diuYzNSXJw3fvZGKlrKRq43kvmnz8/ZZfmLB3/BbdNvq4Iqw2ijWJdlOPvvDwsXWpdlJalyS2SIQ3auiPQAfgFcAnQHfl5WVS2MHp16ALDV37dauZxEZrHYTNdkZn2wYl2FtTW19OjYg4XLF/LJwk8AWL3T6nTt0LWRXfb7XLSraRdkVw7K2SVaKpnu21zXbWyZYVQQc8hKY7XVqq3AqCCF1iG7QFVPBTqr6jxgHrBjxZS1IPbaeC8O2eKQVTYZH7TmoLwtYYXo2aknS1Ys4Xs3fw8g5wKvRvNpV9Ou0fg6wzAMw6gWhVrI9hKR04DTgdKXam9DDOg5gBv2uyFaeMeMOIZ1uq5DXX0d3Tt2Z+s+pW/ubRSnXU07ayEzjEpiLWSGkZdCDtkDwJdAVxH5OnFdAFXV7mVV1oZZc7U1+fHwHxc3NJpFbU3tynXZDMOoAOaQGUZe8q5Dpqonq2pP4F5V7Z44upkzZrQGrIXMMKqAOWSGkZOiC8Oq6ncqIcQwKk2t1KIo9WqzmAyjItiyF4aRl/QsqW4Eccmel+RcysIoncyisXX1ddTUFv1vYhhGc7EuS8PIizlkLYxjRx1bbQmthszSHPvdvB8/3/bn7DRwpyorMoxWjjlkhpGXgs0CIlIrIjdWSoxhVJIx/ccwct2RPDDzAf772n+rLccwDMNowxR0yFS1DugvIraRltHq2K7fdrx45Iv07trbZlsaRiWwFjLDyEtIl+U7wDMichewMHNRVf9aNlWGUUFqpdYWiDWMSmAOmWHkJcQhe9sfNUC38soxjMpTW2MOmWEYhlFdijpkqno2gIh09e8XlFuUYVSSWrEFYg2jIlgLmWHkpehcfxHZXEReBqYB00TkJRHZrPzSDKMyWAuZYVQIc8gMIy8hiy9dCZykqv1VtT/wC+Af5ZVlGJXDWsgMo0LYwrCGkZcQh6yLqj6eeaOqE4AuZVNkGBXGWsgMo4JYC5lh5CTEIXtHRH4jIgP88WvczMsmIyI9ReRWEXlDRKaLyHYisoaIPCwib/nX1ZsTh2GEUiM11kJmGJXAuiwNIy8hDtnhwFrA7cBtQC9/rTlcBDygqpsCQ4HpwGnAo6q6MfCof28YZceWvTCMCmEOmWHkJWSW5ZfA8bEiFJEewDeB8T78ZcAyEfkOMNabXQdMAE6NFa9h5KO2ptY2GDcMwzCqSjV2VB4IzAWuEZGXReQqEekCrKOqc7zNx8A6VdBmtEE61HbggZkP0P537fnHSzZfxTAA15q1+ebQrl28Y/lyqK2tdsoMI5VUY3PxdsBw4DhVfUFELiKre1JVVURyTscRkaOAowDWX3/9cms12gDn7nguD7/zMH9+9s9Mmzut2nIMIx3U1cG0afDNb8I3vhEnzJoa+NGP4oRlGK2Majhks4HZqvqCf38rziH7RET6qOocEekDfJrrw6p6JW4pDkaMGGFzqI1mM2bAGMYMGMPlky63wf2GkSGzRMUuu8BvflNdLYbRBijqkInIxTkuzwMmqeqdpUaoqh+LyAciMkhVZwA7A6/7Yxxwvn8tOWzDaA41UmNjyQwjQ8Yhs0H4hlERQlrIOgGbArf4998D3gWGisiOqnpiE+I9DrhRRDrgltD4EW48280icgTwHnBgE8I1jCZTIzU229IwMphDZhgVJcQh2xIYrep+qUTkcuApYAdgalMiVdUpwIgct3ZuSniGEYNasdmWhrESc8gMo6KEzLJcHeiaeN8FWMM7aEvLosowqoB1WRpGAnPIDKOihLSQ/RGYIiITAMGtIXaeX6rikTJqM4yKYl2WhpEg45DVVGN1JMNoe4QsDHu1iNwHjPKXzlDVj/z5yWVTZhgVxhaINYwE1kJmGBUldNmLGtxiru2AjURkI1V9snyyDKPypLnL8r+v/ZcLn7+w2eGs1n41rt33WtbvYWv4GUUwh8wwKkrIshcXAAcB04DMr5UC5pAZrYpaqU3tOmR3zriTVz95lW/2/2aTw5i3dB6Pz3qcKR9PMYfMKI45ZIZRUUJayPYFBqmqDeA3WjVpbiFTVfr16McDhz7Q5DAmz5nM1ldujaqtp2wEYA6ZYVSUkNGa7wDtyy3EMKpNmh2yeq2nRpo3uDrz+bSm0UgZ5pAZRkUJaSFbhJtl+SiJZS5U9fiyqTKMKlBbU5vaWZaKIjTvhzHjkCnWQmYEYA6ZYVSUEIfsLn8YRqumRmp47oPn2P/m/astZRUemPkAA3oOaFYYGYfOuiyNIMwhM4yKErLsxXWVEGIY1eY7g77D7dNv543P3qi2lEa89cVbLKtbhjTzh9G6LI2SMIfMMCpKXodMRG5W1QNFZCo06uMQQFV1y7KrM4wKcs6O53DOjudUW8YqDLl0CNM/m97sMWQZh866LI0gzCEzjIpSqIXsBP+6dyWEGIaRm4wjFmsMmbWQGUHU+3piDplhVIS8f7lVdY4//Qz4QFXfAzoCQ4GP8n3OMIy4ZBypZreQ2RgyoxSshcwwKkrIE/5JoJOIrAc8BPwQuLacogzDaGBlC5mNITMqiTlkhlFRQhwyUdVFwH7AZap6ALBZeWUZhpEh44jZGDKjotjm4oZRUYIcMhHZDjgEuNdfqy2fJMMwktgYMqMqWAuZYVSUEIfsROB04A5VnSYiGwCPl1WVYRgrsTFkRlUwh8wwKkrIOmRPAE8AiEgN8Jmt0m8YlcPGkBlVwRwyw6goRf9yi8i/RaS7iHQBXgNeF5GTyy/NMAyI2EJmY8iMUjCHzDAqSsgTfoiqfg3sC9wPDMTNtDQMowLYGDKjKphDZhgVJcQhay8i7XEO2V2quhzsL7ZhVAobQ2ZUBXPIDKOihDzh/w7MAroAT4pIf+DrcooyDKMBG0NmVAVzyAyjooQM6r8YuDhx6T0R2bF8kgzDSGJjyIyqYA6ZYVSUog4ZgIh8C7cYbKfE5fTtwmwYrRAbQ2ZUBXPIDKOihMyyvAI4CDgOEOAAoH+ZdRmG4bExZEZVMIfMMCpKyBN+e1U9DPhSVc8GtgM2Ka8swzAy2BgyoyqYQ2YYFSWky3Kxf10kIusCnwN9yifJMIwkNbM/BED8a5PD8b+vf7n9l9z439ObK8to7dQrncbDlcs/tn/ghlEBQhyye0SkJ/AnYDJuyYt/lFOUYRgN/PC1GlTgh/XN20K25xI4ahK8t1576Nyp+AeMNs2idvU8MWARL/RvZw6ZYVSAkFmWv/Ont4nIPUAnVZ1XXlmGYWT4wdw+/OChqbBL72aFI8Df7wEu/gMcd1wUbUbr5e0v3majSzZC1+pVbSmG0SYo6pCJSCfgp8AOuNaxp0XkclVdUm5xhmEA9fWNX5sbTk3zJgcYbYOVy6TYJBDDqAghXZbXA/OBS/z7HwD/ws22NAyj3GQcqeb+MNogbaMEVs7KtXXrDKMihDhkm6vqkMT7x0Xk9XIJMgwji1gOmbWQGSVgLWSGUVlCnsyTRWTbzBsR2QaYVD5JhmE0IlaXpbWQGSVgLWSGUVlCWsi2Bp4Vkff9+/WBGSIyFVBV3bJs6gzDsBYyoypYC5lhVJYQh2yPsqswDCM/1kJmVAFrITOMyhKy7MV7lRBiGEYerIXMqALWQmYYlcWezIaRdqyFzKgC1kJmGJUlr0MmIh0rKcQwjDxYC5lRBayFzDAqS6En83MAIvKvCmkxDCMX1kJmVAFrITOMylJoDFkHEfkBsL2I7Jd9U1VvL58swzBWYi1kRhXItJDVazP/CBiGEUQhh+wY4BCgJ/DtrHsKmENmGJXAWsiMKrCyhcy6LA2jIuR1yFT1ady+lZNU9eoKajIMI4m1kBlVYOUYMuuyNIyKELIO2b9E5Hjgm/79E8AVqrq8fLIMw1hJxhGzFjKjgtSIc9ythcwwKkOIQ3YZ0N6/AvwQuBz4cblEGYaRwFrIjCpgg/oNo7KEOGQjVXVo4v1jIvJKuQQZRtX4+c/hlluqrWJVPv7YvTa3hSzzeWshMwKwZS8Mo7KEOGR1IrKhqr4NICIbAHXllWUYVeCxx6C2FnbdtdpKVuWuu5rfQpb5vLWQGQFYC5lhVJYQh+xk4HEReQcQoD/wo7KqMoxqUFcHI0bAVVdVW8mqHHAATJvWvDCshcwoAWshM4zKErKX5aMisjEwyF+aoapLyyvLMKpAfb1rIUsjNTXWQmZUFGshM4zKEtJChnfAXi2zFsOoLvX16XVWRGwMmVFRrIXMMCpLkENmGG2Curr0OmQ1NfDee7Dddk0PY8EC92oOmRGAtZAZRmUxh8wwMqS5y/Lgg+Hzz5sXRvfusNFGMHJkHE1Gq8ZayAyjshR1yMR9Kw8BNlDVc0RkfaC3qr5YdnWGUUnS3GW5zz7uMIwKYS1khlFZQn59LgO2A77v388HLi2bIsOoFnV16W0hM4wKY5uLG0ZlCemy3EZVh4vIywCq+qWIdCizLsOoPGluITOMCmObixtGZQn59VkuIrXg2q1FZC3A/jIZrQ9zyAxjJba5uGFUlpBfn4uBO4C1ReT3wNPAec2NWERqReRlEbnHvx8oIi+IyEwRucla4YyKY12WhrESayEzjMpS1CFT1RuBU4A/AHOAfVU1xoZ/JwDTE+8vAP6mqhsBXwJHRIjDMMKxFjLDWIm1kBlGZSn66yMiawCfAv8B/g18IiLtmxOpiPQFvgVc5d8LsBNwqze5Dti3OXEYRsmYQ2YYK7EWMsOoLCGD+icD/XCtVgL0BD4WkU+AI1X1pSbEeyGu1a2bf78m8JWqrvDvZwPrNSFcwyid+++H++5zC6dal6VhAA0tZPe8dQ+fLvw0Spg1UsNPR/6UQb0GFTc2jDZGiEP2MHCrqj4IICK7Ad8DrsEtibFNKRGKyN7Ap6r6koiMLUmt+/xRwFEA66+/fqkfN4xV+f3v4YUXoGdPt7m4YRjUSi3b99ueNz57g5lfzIwS5heLv6Brh678fuffRwnPMFoTIQ7Ztqp6ZOaNqj4kIn9W1aNFpGMT4hwN7CMiewGdgO7ARUBPEWnnW8n6Ah/m+rCqXglcCTBixAhrSzeaz/LlsMsurqXMMAzAtZA9c/gzUcPs8LsOtq6ZYeQhZMDMHBE5VUT6++MU3DiyWpqw/IWqnq6qfVV1AHAw8JiqHgI8DuzvzcYBd5YatmE0CZtdaRiGYVSZEIfsB7gWq//5Y31/rRY4MKKWU4GTRGQmbkzZ1RHDNoz8mENmGBVBRGzWpmHkoWiXpap+BhyX53azBhao6gRggj9/BxjVnPAMo0nU1dnsSsOoAILYrE3DyEPI5uJr4WZEboYb8wWAqu5URl2GUTmshcwwKoa1kBlGbkKaBW4E3gAGAmcDs4CJZdRkGJWlvt4cMsOoAJmlNAzDWJUQh2xNVb0aWK6qT6jq4bhFXA2jdWAtZIZREazL0jDyE7LsxXL/OkdEvgV8BKxRPkmGUWHMITOMimCD+g0jPyEO2bki0gP4BXAJbt2wE8spyjAqijlkhmEYRpUJcci+VNV5wDxgRwARGV1WVYZRScwhM4yKYF2WhpGfkDFklwReM4yWxYQJsMkm8NFH5pAZRgWwLkvDyE/eFjIR2Q7YHlhLRE5K3OqOWxTWMFo2zz8Pb70FhxwCP/pRtdUYhmEYbZhCXZYdgK7eplvi+tc0bHFkVJo//AGWLIGzz662kpZPXZ17veYaaN++uloMow1gXZaGkZ+8DpmqPgE8ISLXqup7FdRkFOKMM9yrOWTNZ8UK92rdlYZREazL0jDyEzKov6OIXAkMSNrbSv1Gi2fFChCxbZMMo0IItjCsYeQjxCG7BbgCuAqoK68cw6ggdXXQLuQrYBhGLKzL0jByE/JrtEJVLy+7EqOBOXPg3/92DkO3bnDkkeY4lIMVKyxfDaOCWJelYeQn5NfobhH5KXAHsDRzUVW/KJuqlsabb8JJJ8GyZY2vb7opXHSR6xYrhX/8A848s+H9VlvBtts2X6fRGFt/zDAqig3qN4z8hAyeGQecDDwLvOSPSeUU1eJ4+GG491746itYsMAdb7wBl1zSMHC8FObPh86d4YEH3PvFi6PKNTzWQmYYhmGkhKK/Rqo6sBJCWjSff+5eJ0yA1VZz53/6E5xyCixd6pZU+PRT6N4dFi5077t3zx3W0qUwdy506QJdu7prs2bBhx82tsu8X2ed/E7FwoXOScxmtdVg9dVLSGATWLzY6UrDchKff+6WCsnm66+thcwwKoh1WZbGJws+YUV9E/7UG02ie8fudOvYrbhhmSjqkInIasBJwPqqepSIbAwMUtV7yq6upXDxxe61c+eGax07utdly+CWW+DAAxt/Zt683E7ZmDHwwguw4YbQoYO7dvjhq9r17eteDzwQbrpp1fuqLoxPPln1Xk0NTJvmulTLxcCBMHgwPP54+eII4dlnYXSBnb4y+WgYRtmxLstwbnz1Rg6949Bqy2hTXLDLBZwy+pSqxR/SX3MNrptye//+Q9zMS3PIMnTuDFts0XisWMaZWroU3nln1c988UVuh+ydd5xT9qc/NW5duvJK95pp8erZE/7611VbzjIsXeqcse9+F/bcs+H6jBnwl7/Axx+X1yH75JPczmCl+egj93rmmbDeeqve33zzyuoxjDaMlDqetg3z4Xz3bL9kz0voWNuxymraBqPWG1XV+EMcsg1V9SAR+T6Aqi4S+1Y18H//B7NnO8cnSaaF7B//gOeeW/Vzy5fnDm/hQth6axg50rViAWy8sZtpmc1tt+XukoSGLrpvfKPxZ596yjlkTRnbFkqa/gFn0nnwweV1QA3DCMK6LMPItCQesdURdG7fuYi10RoIcciWiUhncN8iEdmQxGzLNs/Pf+5ev/nNxtf793ctZsnZkkluvtm1gtVlLe22aFHD2LGMY5NvvFm7dvkdq4xD1jnri5wZb5Ydb0zK6eyVSkaLDd43jKpjXZbhZBxXa/9oO4T8Sp0JPAD0E5EbgdHA+HKKajHU17sf/N/+FvbP2t5zp53gyy8bWsL+8AfXxZjhuefcoPKMQ5ehthbGjXPnAwc6Ry/fNknt2q3a0jZ5MhxzjJvpCQ0tdcnPQJjT9OGH8F4Tds1K06zQTP6YQ2YYVceci3DqtR6w3Q3aEiGzLB8WkcnAtoAAJ6jqZ2VX1hLItEJlZlZm06NHw3mm1Wv99eH9952z1rWr6z7MR5cu8MQT+e/naiF7+mmYONGNG9tiC+cYJsnMKgxxyLbbDj74oLhdmrEWMsNIFdZlGUamJdGc2LZDyCzL7wKPqeq9/n1PEdlXVf9XbnGpJ9MSlM8hS7Lxxu51q62cQ/bss7Duus2LP5dDltF0yy3Oocv1GQjrspw7183iPOKI0rWNH5+OJS/MITOM1GBdluFkHNcasb122wpBXZaqekfmjap+JSJnAv8rm6qWQmb2ZGZGZSEOPdR1a6q6rssFC2BUM2d0tG+/qkOWabXr1Cn3Z0JbyFRdWJtuCrvtVrq2XXZxEwiqTSadaXAODaONY+uQhWNdlm2PEIcsl3tuzQ3guh0B+vQJs884Sb/6VZz427VzY7wGDWq4Nneucz7yLXgaOoYssw1UPseuGLW15Zs48PbbzrldtKi4baaMrIXMMKqOORfhWJdl2yPkV2qSiPwVuNS//xluXTIjM2C8uV2PTeVHP3LrjWV3AQwblv8zGcfkzDPdkh35yDhT2ZMCQimnQ/bKKzBlCuyxh1uPrRgDBuSfqWoYRkWxLsswVs6yNCe2zRDikB0H/Aa4Cbf0xcM4p8zItCKFdFmWg29+c9XlNoqx/vpwyCFuK6di7LVX07orwTlkCxbAddc1XNtiCxg+vGnhJck4wn/5CwwZ0vzwDMOoCNZlGY61kLU9CjpkIlIL3KOqO1ZIT8si45C1pPFJ7dvDDTeUP55113XLeowf33Bt443hzTebH7aNCzOMFom19oRTr/WWX22MgtM3VLUOqBeRHoXs2iyZlppqtZClmd/8Bt591018eOcdN1szZMxXCJl8N4fMMFoc1mUZhqLWOtbGCOmyXABMFZGHgYWZi6p6fNlUtRSq3WWZZmpq3NitDD16xBtTZou9GkaLxLosw1FVayFrY4T8ot3uDyOblthlWS1iDvK3FjLDaJGYgxGOorYGWRsjZKX+6/xeluur6owKaGo5WAtZOLEcshdegJ/5OSXmkBlGi8JayMKp13rrsmxjFHW/ReTbwBTcfpaIyDARuavMuloGNoYsnFgO2aOPutcf/hBWX7354RmGUVFsDFkY1mXZ9ghpDz0LGAV8BaCqU4ANyqaoJWFdluHEcsgyTvC114L9ezSMFoU5GOFYl2XbI6S0l6vqvKxr9eUQ0+JYutS9WgtZcWpqoD5CtVm2zA3mr7EHlWG0NKzLMhxVm2XZ1ggZ1D9NRH4A1IrIxsDxwLPlldVCWLbMtY7Zl6Y4MVvIrEXSMFos1mUZhq1D1vYIaWY4DtgMWAr8G5gHnFhGTS2HpUubvrVQWyOWQ7ZsmbVIGkYLRbAWslBsHbK2R94WMhHpBBwDbARMBbZT1SI7Urcxli415yCU5jpkb7wBF1wAzz5reW4YLRRzMMJRtTFkbY1CpX0dMALnjO0J/LkiiloSy5ZZC1kotbVuE/Qzz4S33ir987ff7gbyL18Oe+8dXZ5hGOVHEOuyDMS6LNsehcaQDVHVLQBE5GrgxcpIakFYl2U4Q4a4wfjnnAPz5sGFF5b2+cwEirfftjF7htGCsS7LMKzLsu1RqIVseebEuirzYF2W4Rx4oGvd6tWrYemKUsiMHbMHlGG0WMzBCMfWIWt7FGohGyoiX/tzATr79wKoqnYvu7q0Y12WpVNT07SxZDaY3zBaPNZlGY6tQ9b2yOuQqWptJYW0SKzLsnRqa0tfj6y+HiZMcJ81DKNFM2fBHB5+++Fqy0g9789731oU2xgh65AZ+bAuy9JpSgvZo4/C5Mmwxhrl0WQYRkXo0akHE2ZNYMKsCdWW0iLYcPUNqy3BqCDmkDUH67Isnaa0kH3xhXu95Zb4egzDqBj3fP8eZn4xs9oyWgwDeg6otgSjgphD1hyWLoXVVqu2ipZFU1rIlixxrwMGRJdjGEblWKfrOqzTdZ1qyzCMVGIjBpvD3LnWQlYqTWkhyyx50alTfD2GYRiGkQKshayp1NXBu+/CpptWW0nLorYWFi2Cc8+F+fPDPjN5sns159cwDMNopZhD1lQyzsSWW1ZXR0ujpsZtf3THHW6T8NCZk5tuCt1tpRXDMAyjdWIOWVNZsMC9bmizYEqitrYh7558Erbdtrp6DMMwDCMF2BiyppKZ+de1a3V1tDRqamDhQnduY8IMwzAMAzCHrOl89pl7tYX7SiPZRWkOmWEYhmEA5pA1ncx+jOuvX10dLY1evdxrbS2suWZ1tRiGYRhGSrAxZE0lszZW587V1dHSuOMONzt1jTVgrbWqrcYwDMMwUoE5ZE0l45BZt1tpdO0KW2xRbRWGYRiGkSqsy7KpmENmGIZhGEYkKu6QiUg/EXlcRF4XkWkicoK/voaIPCwib/nX1SutrSQWL3av1mVpGIZhGEYzqUYL2QrgF6o6BNgW+JmIDAFOAx5V1Y2BR/379GItZIZhGIZhRKLiDpmqzlHVyf58PjAdWA/4DnCdN7sO2LfS2kpi7lz3ag6ZYRiGYRjNpKpjyERkALAV8AKwjqrO8bc+Btaplq4gzjvPvdr+ioZhGIZhNJOqOWQi0hW4DThRVb9O3lNVBTTP544SkUkiMmluppWq0syb51632soWhjUMwzAMo9lUxSETkfY4Z+xGVb3dX/5ERPr4+32AT3N9VlWvVNURqjpirWqtY5VxyA4/vDrxG4ZhGIbRqqjGLEsBrgamq+pfE7fuAsb583HAnZXWFkxmQP/q6Z4IahiGYRhGy6AaC8OOBn4ITBWRKf7aGcD5wM0icgTwHnBgFbSFYTMsDcMwDMOISMUdMlV9Gsg38GrnSmppMkuXuldzyAzDMAzDiICt1N8UrIXMMAzDMIyImEPWFBYtcq/mkBmGYRiGEQHbXLwUVOGNN2DBAve+W7fq6jEMwzAMo1VgDlkp/P3v8JOfNLw3h8wwDMMwjAhYl2UpvPBC4/d9+1ZHh2EYhmEYrQpzyEpBszYPaN++OjoMwzAMw2hVmENWCvX11VZgGIZhGEYrxByyUvjww4bzv/2tejoMwzAMw2hVmENWCltv7V6ffx5OPLGqUgzDMAzDaD2YQ1YKmXXHRo2qrg7DMAzDMFoV5pCVwpIlzimTfDs/GYZhGIZhlI45ZKWwZAl07lxtFYZhGIZhtDLMISuFxYttuyTDMAzDMKJjDlkpWAuZYRiGYRhlwByyUsiMITMMwzAMw4iIOWSlYF2WhmEYhmGUAXPISsG6LA3DMAzDKAPmkJWCtZAZhmEYhlEGzCErBWshMwzDMAyjDJhDVgo2qN8wDMMwjDJgDlkpLF5sLWSGYRiGYUTHHLJSsBYywzAMwzDKgDlkpWCD+g3DMAzDKAPmkJWCDeo3DMMwDKMMmEMWiqp1WRqGYRiGURbMIQtl0SL32qVLdXUYhmEYhtHqMIcslGeeca+rr15dHYZhGIZhtDrMIQtl993d67Rp1dVhGIZhGEarwxyyUundu9oKDMMwDMNoZZhDFsq4ce71tNOqq8MwDMMwjFaHOWShXHddtRUYhmEYhtFKMYfMMAzDMAyjyphDFoJqtRUYhmEYhtGKMYcshCeeqLYCwzAMwzBaMeaQFeKuu6BjR5gyxb0/4oiqyjEMwzAMo3ViDlkh2rWDZcvgV79y73/0o+rqMQzDMAyjVWIOWSEyG4lntk2qsewyDMMwDCM+5mEUInsjcXPIDMMwDMMoA+ZhFKJdu8bvt966OjoMwzAMw2jVmENWiKRDdvXVqzpohmEYhmEYETCHrBBJB2zEiOrpMAzDMAyjVWMOWSFqaxvOBw+ung7DMAzDMFo15pAVItlC1r599XQYhmEYhtGqMYesEBmHbJ11qqvDMAzDMIxWjTlkhRBxr9nLXxiGYRiGYUTEHLJCLFniXjt2rK4OwzAMwzBaNeaQFaJfP/d67rnV1WEYhmEYRqvGFtYqRNeuoFptFYZhGIZhtHKshcwwDMMwDKPKmENmGIZhGIZRZcwhMwzDMAzDqDLmkBmGYRiGYVQZc8gMwzAMwzCqjDlkhmEYhmEYVcYcMsMwDMMwjCqTKodMRPYQkRkiMlNETqu2HsMwDMMwjEqQGodMRGqBS4E9gSHA90VkSHVVGYZhGIZhlJ/UOGTAKGCmqr6jqsuA/wLfqbImwzAMwzCMspMmh2w94IPE+9n+mmEYhmEYRqsmTQ5ZECJylIhMEpFJc+fOrbYcwzAMwzCMZpMmh+xDoF/ifV9/rRGqeqWqjlDVEWuttVbFxBmGYRiGYZQLUdVqawBARNoBbwI74xyxicAPVHVagc/MBd4rs7RewGdmU1abNGlprTZp0tJabdKkpbXapElLa7VJk5ZK21SC/qqauzVJVVNzAHvhnLK3gV9VW4/XNMlsymuTJi2t1SZNWlqrTZq0tFabNGlprTZp0lJpm2of7UgRqnofcF+1dRiGYRiGYVSSNI0hMwzDMAzDaJOYQ1acK82m7DZp0tJabdKkpbXapElLa7VJk5bWapMmLZW2qSqpGdRvGIZhGIbRVrEWMsMwDMMwjCpjDplhGIZhGEaVSdUsy9aCiAwPMFuuqlPLLqYFEph/GwEzi9hULI+tzA3DaGm0xOdWS9Qcio0hSyAiXxczARYD5xexOw941tvnYwywoEhcqwELi9gI8FgRPXsASyoQ156AFogrNJ4uwASK51+ITbE8jpV/IZq3AR4pEldv4L8F7h8O1FF4QeRhwJQi8YSkKSRviukF2A54rojNOIov8lypejwKWEbhPAxJd6w0xSqHNOXxBsAiCmuuZL0JyeNhFP9ehdhUqsxDnhV7Ak9R+Lk1FDi3iJaQcoj1rAj5fQ3RvFBV/17EpqJYC1lj3lbVrQoZiMhyoCuFK0O9qu5UJJz5qtq9iM2iAJslwF8KmQC7ViiuwcAyVd2smfHMD8i/LyLlcaz8C9G8KCCuh4F7yF+/+uB+yI4vEMaDAfGEpCkkb4rpBfguMLWIzWDypykTV6Xq8Y24H7J8NqHpjpWmWOWQpjy+HZfH3QrYVLLehORxyPcqTd+9kGfFTgHPraUU/80LKYdYz4qQ39cQzccAqXLIqr4ybZoOYIMAm78H2PwxUlxjAmyOjWTT7Lhw/3oPjBBP0byJWJ6x8i8kroJ5423uLBZGsfoF/K2C6S6o19u8ECmcStXjAwPqcYjeWGmKVQ5pyuM/BuRxJetNiM3fItlUpMwDnxUhz6SQ37NY9S+kzEP0RLGp9GFdljkQkXWA9fzbD1X1kyaE0QPXNL0yHOBBVf2q1Lhi6KlkXDHiCcm/mHkcI12hetJErLypJJX8zlSKtOm1PG47elroc6vFaQ7BHLIEIjIMuALogStggL7AV8BPVXWyt9sd2JfGleFOVX3A3z8MOBN4KCucXYGzVfX6kLgCbXoAp3s9a+PGcH0K3Amcr6pfVSouYECkeELyL1Yex8q/ED1F44LC9StQb6w0NVuvfx/ynUlTPdYY6U5bOaQpj31caao3sb5XqSnzQC1Fn1uxyiEknMC4omhOJdVuokvTgRuMuU2O69sCr/jzC3H7bR4M7OCPg/21i7zNDKBnjnBWB94sIa4QmweBU4Heifu9/bWHKhlXxHhC8i9WHsfKvxA9IXEVrF+BYcRKU7P1lmCTpnocK91pK4c05XGI3rTlcYv67gWGEfLcilUOsco8iuY0HlUXkKYDeKvAvZn+9c089yXzeeBNoEcOmx4Jm5C4QmxmFLCZUcm4IsYTkn+x8jhW/oXoCYmrYP0KDCNWmpqttwSbNNXjWOlOWzmkKY/TVm9ifa9SU+ahYRDwrI1UDrHKPIrmNB42y7Ix94vIvcD1wAf+Wj/gMCDTzLlEREaq6sSsz46kYSrz74HJIvJQIpz1cU2qvyshrhCb90TkFOA69WMQ/NiE8YnPVCqu1yPFE5J/sfI4Vv6F6AmJq1j9mhMQRqw0xdAbapOmelwfKd1pK4c05fHaKas3IeHEsqlUmYc8K0KeW7HKIdazIpbm1GFjyLIQkT2B79C43/kuVb3P3x8OXI6brj3b2/QD5gE/U9WXvN3qwO6sOujwy9C4AvWsDpzmbdb2Np8AdwEXqOoXlYwrRjwl5F+z8zhy/hXUE5h/BesX8E5AGFHSFEOvqr4UaJOaeowb/xIj3WkrhzTl8YAAvWnL4yg2EfU0+1mRiKvQcytKOcR6VsTSTAoxh6yJiEhvGs+Q+biaeozWRUurXyF6W1qaQkhbmtKmpxhttd7EpFL5EyueSpZ5i6s7leobbekHcFSkcK6MEVegzfC0xBUxnpD8i5XHsfIvRE/RuCLpjZWmZuuNnK5K1eMo6U5bOaQpj2MdlczjlvbdC9RS9LkVK66IZR5Fc7UO21w8nEIr/joDkckB4fw9RlyBNj9JUVyx4gnJv1h5HCv/QvQUjSugfoXojZWmGHpDvzNpqsdR0h0SDhUsh5BwqFAep7DexPpepanMQ7QUfW7FKoeIZR5Lc1WwLkvDMAzDMIwqY7Mss5DAxeSkwCrLUsFF8hLx7cGqAxy/KjGcZscVI56Q/Iucx83OvxL0FI3L2xWrX8X0xqoTzdYbapOyehwl3WkrhzTlcYjeCqcp1vcqNWUeWM+LPreKxRNLbwlpiqI5bVgLWQIRuRDYBDcdOTMzoy9uOvJbqnqChK2y/CDwGG4K8Mc+7N7AOGBnVd0tMK4Qm5AV4isSFzA8Ujwh+Rcrj2PlX4ieZu8uAGweEEasNFVyx4k01WMipTtt5ZCmPH41QG/a8jiWTSw9BfOHsGdFyHMrVjmEhBNiE0UzaaSUAWet/SBsUbopBKzaXiCO6AtqUnzV4orEFTOegPyLtlhmpPwL0hwQV8H6FRhGtDQ1V28JNmmqx7HSnbZySFMep63exPpepabMQ/Xm0pK8F7EcopV5DM1pPGxQf2OWiMjIHNeTi8l1UdUXsg1U9Xmgi3/7noic4ptLAdd0KiKnkrVIXpG4QmwE12SbTT0NA0QrFVeseELyL1Yex8q/ED0hcRWrXyFhxEpTDL2hNmmqx7HSnbZySFMep63exPpepanMQ8IIeW7FKodYZR5Lc+qwMWSNGQ9cLiK5FpMb79+HrLJ8EG6RvCdEJHuRvANLiCvE5vcUX7W4UnG9GimekPyLlcex8i9ET0hcxerXxIAwYqUpht5QmzTVY42U7rSVQ5ryeHjK6k1IOLFsYumJ8awIeW7FKodYz4pYmlOHjSHLgRRZTE5E9gL2ofHgxUYrWceKK1BPwVWLKx1XjHhiUsn8C9ASkn8F61dgGFHSFENvCTapqccR0522ckhTHqeq3sT6XqWpzEO1FCNWOcQq81ia04Y5ZFn4Lwmq+rGIrAV8A3hDVV8vIQwBDsD9074V2Am3pcQbwBWqWh8aV1P0iMga6rfFKCWcGHHFiCck/2LmcYz8C9UTElephITR1DpRDr2hVLMel3o/lLSVQ5ryOBaVzOOW9t3L8bxu0nOrKXHFopyaq46mYCBbWg7gaOBdYBZuMbsXgKtxAxaP8Da9cXtkXQqsCZyF66q7GejjbS7DVZS7gBuAW4AfAv8FLiohrhCb0cB0YBqwDfAw8DaumXa7SsYVMZ6Q/IuVx7HyL0RPSFwF61dgGLHS1Gy9JdikqR7HSnfayiFNeZy2ehPre5WaMg8MI+S5FascYpV5FM1pPKouIE0HMBVYzRfgAqC3v746MMWfPwAch+vDfhU4Fdc3fRxuHRmAqf61PfA50MG/bwe8WkJcITYvAlvgHnKfATv468OBZyoZV8R4gvIvUh5Hy78APSFxFaxfgWHESlOz9ZZgk6Z6HCvdaSuHNOVx2upNrO9Vaso8VEvAcytWOcQq8yia03hUXUCaDmBy4vyVrHsvJ1/9+ftZNlNy2DyQxyYkrlL1TM+VnkrFVaZ48uVfrDyOlX+las4XV8H61YQwYqWpSXqbaFPtelyOdKetHNKUx2moN6Xmceq/e00II+S51ZxyKEeZN1lzGg9b9qIxKiLt/fm3MhdFpBOszKtknl2f9fnMvY9FpCuAqu6RCKc3sKyEuErVc3qWng4VjitWPCH5FyuPY+VfiJ6QuIrVr1LDaE6aYuhtik2163E50p22ckhTHqeh3sT6XqWpzEPCKPW51ZxyiFXmsTSnj2p7hGk6cNN02+W4vh6wiz8/B+iaw2Yj4NYi4XcB1k7E1b5IXCE2+wCr5bDZEDilknHFiick/yLmcZT8C9QTElfB+hUYRqw60Wy9JdikqR7HSnfayiFNeZy2ehPre5WaMg8JI99B4+dWrHKIUuaxNKfxsFmWZUIquAdgCZoqEleMeELyL2Yex0hXqJ40EStvKkklvzOVIm16LY/bjp4W+txqcZpDMIesCUjxjaYPo3n7ev1EVV8OtOlB8Y24KxIXMCBSPCH5FyuPY+VfiJ6icUHh+hWoN1aamq3Xvw/5zqSpHmuMdKetHNKUxz6uNNWbWN+r1JR5oJaiz61Y5RASTmBcUTSnkmo30bW0A7gQuA84GNjBHwf7a5kptzOo3L5eD+JmkPRO3O/trz1UybgixhOSf7HyOFb+hegJiatg/QoMI1aamq23BJs01eNY6U5bOaQpj0P0pi2PW9R3LzCMkOdWrHKIVeZRNKfxqLqAlnYQuPku0COHTY+EzVsF4phZgk3IRqsViStiPCH5FyuPY+VfiJ5mb4geGEasNMXawD3W5uyVqsfRNq5PWTmkKY/TVm9ifa9SU+ahYRDwrI1UDrHKPIrmNB62l2UAInIdsAi3yNwSERmpqhOzzEbSsDHs76ncvl7vicgpwHXqxyD4sQnjE5+pVFyvR4onJP9i5XGs/AvRExJXsfo1JyCMWGmKoTfUJk31uD5SutNWDmnK47VTVm9CwollU6kyD3lWhDy3YpVDrGdFLM2pw8aQBSAiI3EFPgq4CbcCcDdW3Rj2Z6r6kv9MrH299sRtC5HTxsdzmrdZx9t8jFvF+AL1W1cUC6cJca2N+7fRKK4Y8ZSQf7H2ekumCRo2qi01/0L2RywYl4gMp0D9At4JCCNKnYihV1VfCrRJTT3GjX+Jke6i35cYepuop9p5PCBAb9ryOOT7kJrvHgHPikRchZ5bTSmHkvWGlnkszaQQc8iaiFRwc+yseNdW1U8rEVcMYugVke7AxsA7WuKmuNWiuZqrVb+aSojelpamENKWprTpKUZbrTcxiZE/EjarNko5xCrzSmquGOXoB22pB64P+nzcJqVf4LZlmO6v9fQ2HfCOrH+/I/ALYI/EtX64fbWeAs4gseYM8D//OhJ4HLcXVz/c3l9fAROBrbzNGjmOWbjBi2skwtwd92/gLn9cnqXnWKCXP98QeBL4EreH2hb+ei1uj7XfAdtn5cuvE3p+CxyB+wd5BnAP8KeMpmJ6E3k8vUAe35DQuzvwPvAI8B5wQMw8zlMPHstTL5ql2d/bFNgZ6JIVR7K8vgkM8uejgV8Ce4XqjVUnyqXX251XDs1EqMcl5HEP4CDgJH8cRGKwMW5Pv+7+vDNwNnA3roWoRzn1ttA8zqU37Xncor572XqBYcDzuOfZw7hn1hv+2nBvU/Q3r5LPipia03ZYC1kCEXkQeAzXD/6xv9YbGAfsrKq7icgrwFhV/VJETga+i5u5MQaYpKqni8jDwG24CnIEsDXwbVX9XEReVtWtRORF3NTdnsAfgZ+r6q0isjNwrqpuJyL1uB/0JH1xTbCqqhuIyIXAJrjxCLMTNofhBi+eICLTVHUzn557gatU9Q4RGQv8XlVHi8hVuP3VXsRt1PqEqp7kPzNZVYeLyH24fdi6A4P9+c24vvuhwLcD9ObL4/HATj6Pp6rqFv7es8APVHWWiPQCHlXVoRHz+NXsauDzcwZO9JYRNR+P60qYjnuonKCqd2bl8YW4rvF2uJlLOwP34+rXy7iHfTG9FxKnTjRbr6qeLCIXsyqHeX2o6vEpq8cDA/I4ZJmTacBQVV0hIlfixqHe6vNoqKruF0Ovqn6nBeZx9nMil9605XHIsyJWHlfqWTEFOFpVX2hkKLIt8Hf/3Ar5zavksyKK5hzxVJ9yeXot8SBspshriWuTgM7+PLmx6ZSszx4KTMP9GwrZ1+tl//oL3CDP5L+md7NsS5oBA0zMsns1+ZpIy5XA7UDHhJ4pibA/zApnSqDekDyeRsO/3qeBmoTNtMh5fBeudWtToD9ubMsH/rx/ZM1T8atH+3gm4R5cST3TfP6uhvvXvJq/3h54LVBvrDrRbL3+/AOv+TDcn5txwNzMeQrrcVCdoPjU++mJ65Oz44mlt4XmcYjetOVxi/ruBeoNmfEZ8ptXyWdFFM1pPNK7p1N1eE9ETvF904DrpxaRU2mYzfG1iGzuzz8DOvnzdjTskdVe3L5kAKjqDcAJuH8FffzlJSKym4gcgNvbbF8f3xigzn/uL8CPgd+KyF9FpBtuwHGSJeImHWSTnE1yq4hcKyIbAHeIyIki0l9EfoTrWoOG/cZQ1RWqehTuwfkY0NXfqhE3mLIf0FVEBnjNawIdAvWG5PHZwOMicjjwDHCLiIwTkWtpmIUUK4/3wbW0XYn7JzwLWK6q76lq5l98LM01qrrAxzsLGAvsKSJ/xT2o/C1VoD7z3r/W+8+H6I1VJ5qt158PwX1X9gAeVtXrgPmqep0/j6k5Rj0OyWNh1bqdSXcmb17z2gBeEZERPp5NgOWx9HqbFpXHgXpTlcct7bsXqPd+EblXRA4Ske39cZBvucs8t0J+8yr5rIilOX1U2yNM04H753UBDWPIvsA1wV5AwxioLYFXcE2o1wNvA9fgvPAfeJufA2NyhL8VrpKBa7Z/ENdkuyluIb+vcP8iRuf47D647rmPs64Px409eB3XtP+Q1/w8sHXCbry3+wyY7+3Po2GcxQ3k6F/HOVjL/fn3cTNnPgG+h+u7fwTXnXBUoN7sPP4yO4+93Ub+2h24MSGXA7sn7jc3j7PHknQB/opbWXp2Ac1fNkPzY8CwrLDb+XpU599fgBsXNxE3fuVu4Fe+XK8I1BurTkTT6223xo3p+yUwK+31uEgej8N99y/HjTc6A7f6+tvAeG/TA7jWX3sB5yC8AzyB+4Fsjt6Hs/W2gDxeRXMRvWnN40L1YutIeVyRZ4W/v6fP17v9cQWJcV2E/eZV7Fnh7+/VXM1pPGwMWRMQkVpgN1x/fDvcWIGy76MlIp2BDVX1tRz3KjKbxKdd1I3ZaIcbL/Chqs4pRW9aEZGhwHaqekUZwu4LrMhVNiIyWlWf8efb4f5NPi8iG+LGP7yP2xS3PutzefU2t06USa8AP/WaD42tOZQS63HOPJaAZVe8XXfcuLR2uB/EVWaDRdbbovK4kN605rG3b2nfvSY/24r95lXjWdFczamk2h5hSznwszcihPPbAJsfJc4zM1e6ZtkkZ670xm9ZAawF7AcMybIfBYz050NwM5aKzW65PkDrKjOjEvd28PHslrgWMivquzS0SK4FXIcbo3AT0Ndf/ys5WhKz4j8+Y1/ELtfMn29l2Wzgr1/k4z4mk46EzY7A/+H+id6Om4W5UZaN+DzYzx/bkJgNlLBbB9eiMRxYJ7BubZr1vn0Om16J8+44hznbZsvEeQ1+PByu62Y4iVbBPDoK3vc2+xS539XH1bOAzUCfh5smrq0PdErk9Y+AS4CfAO0S6cg1A2vP7PQX0dguS++I7LR7PT39+QBgf2DzHGndH9fqezyuu6YmR3wj/Hdjn+yybk69yVV38tjsWkrdCamDseuNt/lpkfur1JuQ+les3oTWHV9+nQLsQupOSB3MW28ImEGeXUYh5ZSdl6XYB4TXG9dqeimwJnAW8CpuEkafmHFV+qi6gJZyAP+IFM77oTb+4TwD+B9u+YjvJGwyA9ePBt7193+Cawa/2n/uCG9zJq7JfBLwB1zz8m9w061/5W3uyjruBhZk3nubi7OOS3BdgJn3Lyb0HYkbp3EmbkzVaf76NBp+GK/E7Tm2g7e73V9/PRHOTbgfqr64Zv5Md+Rcn573cDMoV1nGArcI4Ee4ZvKfAmvlsLkQeBY3A+t3/vw3uC6LPyXK4WHg1/7+pbjVol/HzeTB5+s1uMkFt+Ka5I/EzXbKLNWxGzAT14V6lT8e8Nd28zbDaJjSnelKazSlO6De7Ij7N/gZrjtgQI56c6DPmym+TEbmsNkX14UzB7fg4wvAoz7sb3ub0V7rNJxz+TCue+AD3D9baHA+k8fHmXNvc1ki/h1w/5of9+Hs5a//L2HzHVy9vwa3lcp4f/01GgYLX+DL4lDgn8A//fVX8EsZACf7Mv211/4H3PjCt3x9GJInr8fjfrzexHX5vOPz5gPg+97mNK/xDVz32Bu47+Y04KREObzo68LbwL+AG3E/MFt6mzG4uv4Irrv8Htx3agLQr7n1pgnPpZC6U7AORqw3J+U4PsucF6k3MxL1JqT+Faw3/npI3VnsNf4L1/VWm8MmpO6Mp0AdDKw3D5J7D8rTaNiDcn3cEkOf+rTN9Of/TZZrM+vWVP8aspzRA8BxXuOrXn8/f+1Ob7Mp7jl7L26i17W436oXgcHF9FTrqLqA1ngAX+c55uOadfEVKdcxFVjqbUJmrkzFzVpZE+dAZVrKVqdhdtBU3Fo8q3kdyRaqzCyZybixFmP9F3ks7od4DH6sFkVmwNB4VuNEvAOEG8OQ+cKFzIpKzkJ6KY9NJv2b4ByoabiH1pnAJhkbXAvPbriH2Vz/ZR4HdPM2ITN/puIfmt5ugj9fP1kOCY3tgGcS5ZAJZzo5HmC4f+zTM+mjwMbDrOoUJ53jrxN5v5k/3x/3EN02K9+m4P9N4lpP3wC+m2XzMu7hPBBXbzKtiP1xU8fBPeC2ALbD/cjs4K8PT+TBctyPwT9xP4TX4L4L19DgJE1OpPVxGtYT2iARV7J+PQsM9Oe9aNiUOenMv0Tj2a4Zm4IzsHy6N8c53TN9vp9GY6diqo83kzcb+uvr0PCdmob7jq3p05v8PmTqxKs01LleuC4VcGNgnk2UQ+azA4E7/PmulLZhdUjdyf5jlvyDtrCEulOwDhKv3szH/Wn7Le67fybue3wmcGYJ9Sak/oXMNgypOy/jngtH4hyoT3BjoMYkbELqTsE6SFi9CZlB/hxu/bfaxL1a3Gbdz/v3uRzjk3AtiF94m1wO9n64MXtzvc3DuN6HYbh6+SywZvZzKaEje/Z85vfhSdwyTN/H/Wk/GPec/zZuGaKq+wk587zaAtJ2UGQhwsAw3idPdwHwgX/9xFe6/lnHAOAjbzMt67NdcQ7FXxMVL/kgeSXL/uXka/a5f58JpwbXEvUwfnAmbpX5pG03XIvSv4F1s23w/yBxD5FJebTcgu+SxT1YR/jzTfBTwIG/A+fgHkh/oeFhvyNuDaFG6U7EsSWuhWNmLhuck7UP8J/EAyDzcOuEe5BnHrK1+B933IOvoz9fPZm2xOdfoaGbdX38gypZjrgfpXY5dHcgcONm3MP5KBqc4OTxWZ56sBmuNWBfGlowpmbZ9ME5MMeTe9mQ17Lsc9lMz2MzEvfD85PEvXdz2frzbCd8cg6bF7NsMvXrQdzacOBmmPX352vS8OP7LL7rB/d9yrR6dMK1sGXXm1G479xsGpykKYn7H2XZv5r1WotrUUg6h8kf1cxY3s658pzGyzbUZuXDyrpVqN7415C68yXwLfwfscQxFvikhLpTsA5GrDfr454pF9Dg2GY/t0LqTUj9K1hvssMpUHeybXr7vHuOht+HkLpTsA4G1puHgFNI/F7hHLpTgUcC6lZmKY8luFbBM3McX3mb5biWqmtyHPOz0+Tf51rO6JXE/XPzfPeS9WtmvvqQtqMdxkok90KEOwLnicjZqnp9gc+eh+siuwo3q6M/zunK5t/+9R5c69eUHGFN8KefiMiwjI2qLhCRvXH/GLfwNioi7VV1Oe5BmgmjEw3Te5eJyGqqugg3eyVj0wM/BVndgMq/icgt/vUTaFw/VHU+cKKIbA3c6KcZ1yRMeuAezOJ19VHVOSLSlYapzz8GLhKRX+P+GT8nIh/gWt9+7G2Oxc2+meHf/1xEFuL+pf8wIz8731Q108p4ei4bn0d3AXeJyGr+8r0i8hTuoXoVcLOIPI/7EXrS21wFTBSRF4Bv4B7+iMhauHEX4GZIvSwibwKDcN3HGZtXvM0/fTj/pfGmwgfjWvCg+MbDQ3AP5Gez0y8iZ/nT5SLSW/0AW1WdJm4x3HtwDzaA+SKyoaq+7W3miMhYXPf4Zokwa3zdODxxrZaGpQSS5Z+92GJmuYCJIrIrcJyIPI572GuW7abiFt4UYICIrK5uUceaRFxDReRrb9MxUb864H5wwNWh631ezAOmiFtIsifuDxa4f+A3ils88lNgkog8iftOnYfrjlqJqr4IvCgiv8CNNwR4X0T+gPuT8oaI/AU3bnAXXMsyuA2Q/41r1XgUuE5EHgB2wnV3g1us8gEf/x445wIRWYOG+jtJRK7GDTXYB9flhK/DmXSHbFg9keJ153lgkao+kcMm830MqTvF6uA7iaCbXG9U9X3gABH5DvCwiPwtWzdh9Sak/hWrN7DqMydX3cm2+RjfWiki/f3lkLpTrA5+GFBvDsK14D0hItl7UB7o378kIpfhxvIm69Y4XCscOCf7f5pjj0gRyTzXXwX+rLknpe3iT9uLSCdVXeLz5gYR+Rj3R6uLt7lTRLqq6gJV/XUijI1w3bck0gfOIU7SgbRSbY8wTQcBCxEW+Oy+uObZogPhS9DTl0Tffta90f51fXK3uqwH7OLPO+YJoxeJRVyz7n2LwgP2Bbcy8w0B6VgN302QuNYdtyzF1hQYfIxz8tbMcb3oQFF812WA3XY0dKdsiBu8fyCN/5Vuhut6KTQQeA3cANpV6lDCZjDuAXiJP05j1QkYeaeh+zhWK5KeXfBT/nPkZWbM4FCyJhz46+2BQ/z5SHIMPsa14h7qz/fJpcfn4yk5rq+LG3yb3YrRP+ton6ij+xVJb0/8uKOsfP4OrjtkG7IGyeMe2Hvi1q77BYmWcAKmxfv6e7ovv64+nntw4wsz3XntcF0mB/vz7XGTPk4hsb0MbhzRL2k8aL6GhlbZ9rgxkP+H6+bKdJ93xrcAFqs3oXUn8PsyFNi4SN0pWAebUG/Wy1Vvsmy64MZuPhmYjpX1JrT+Fao3JdSdsQE2RetOsToYWm8CtHTA/cF8ANeiO9Wf/zRRRweRY4yuv7eOf/0GsH4em0xPSdHljAI1H02O3wjc0kQXNvc7UK7Dlr1I4Fs3RqrqvKzrPXDdVBtXR5lhGIZhxMUvLXEAruXxVlwL3Hdw4wKv0KylKNJAS9QcSk1xkzbF73FNxZeLyBn+uALXHPt7ABFpJyJHi8gDIvKqP+4XkWNEpH1V1RstFhG5P8DmyghhhNhMjRROQb0l2MTS3Ox0RUx31HIQkVr/XPqdiGyfZfNr/9pdRP4gIv8SkR9k2VzmX/uJyH9F5Cn//GufsPlfCTYF48rSOzqP3hCbWGkKCae7iJzvbb5fwKZSegrmT0gYuNa0A3FDQf6F65adiOte/Zu3XU3cTiUni0gncTuQ3CUifxQ3HAUR6e1/Ny8VkTVF5CwRmSoiN4tInzzhjM8RTlGbJmrOFU7qsBayLKTIQoQi8h/c9NnraLx57DjcoO6DKirYaDGIyPB8t4B7VLWPuLFD+WxewXX1FAsjJJ79CthcoaprxdCrqn0DbWJpbna6SIzFLKClkmkKCSdkA+3bcBNLnseNCVyO62JbmrB5GDcZ4nngCNyQgm+r6uci8rKqbhVoUzAu3J/cYnormaaQcGLZxNJTMH9wy2YUC2Oqqm7hncKPcd3ty8QtjDtZ3QbkN+PGjnXGdU1Ox81s3Qc3pOaH4sa33YvrNv4BbumWf+OG8uyibnP2kHBCbKJoJoWYQ5ZARESLZIiIvKmqm5R6zzBEpA63pcsqExJwY9g6e5v3smzUv18PN4YlJIxiNstxD81c9X1/Ve0WQ6+qdijBJobmZqcLN2YmVrorVQ6vquqW4Frxgctw45++j5vxu5WITFHVYZkPisivcOPX9sGNzxmew+ZQ3DilfYBbmmHTKC7cuNdiequZppBwYtk0VU/B/MH9vhcL42VV3crff0BV90jYT1HVYYlXwU0W6KOq6t+/4h2gZDjvq+r6TQyn1LiarJk0oikYyJaWAzcL5TiyBh7iHtA74VrF3sb1XycHfNfgBne+UCT86f44toDNI7gF7fZups11uNWMN692XBHjCcm/WHkcK/9W6sEtqbDKYGhvl5nu/lZ2/UvaBIYRYvNSgfIqJZyCekuwiaW52emKmO5KlsMbOe79FrcQaGZpgumsOrlhPG5Zgff8+2lkTeTADdCfCcwpwaZgXIF6K5mmkHBi2cTSUzB/AsO4n9yD33vjlwih8fIa/8yyeyX56s/zLUUREk6ITRTNaTyqLiBNB27pg5/6Cv0Rbnrxu/4B8g/cTI8BuKbPubgptm/ipkDfRNZMwjxxrEnWtjxZ99fFNWH/rJk2I3Gzbi6odlyx4gnJv4h5HCX/knpwszQH5bHZ17/+jByz0/y94wLDCLEJmfHUbL0l2MTS3Ox0RUx3JcshZAPtP+JnXmfZ7EGDg1N0llugTcG4AvVWMk0h4cSyiaWnYP6EhJHvwHU9ru3PryK3A7Qh8LQ/PyePzUa4fSpDwylqE0tzGg/rssyD75/uBSzWPJuRisiaAKr6eZ7769B4g9mcG96KH4+iql/kuh9qE0Kl4ooRT0j+xczjEGJoNgzDaA2EDPOJFU4l46oW5pBFRPxCiCIyDLcGUA8aFpjti5sM8FNVnSwi6+P+wezsrwtuXZnHcPs+zgq06YEbf7AvsDZuLMqnuA2uz1fVryoVl7ePEU9I/sXK41j5V1QPhmEYhpGPajfRtaYDuNe/TqH4vnIh+4OF2OTbHPZUGvYrq0hcEeMJyb9YeRwr/4rqscMOO+yww458h7WQlQEReUvzLCIrIjNVdaMiNm+p6saBNjNUdVAemxmqOqhSceEGkMaIp7n5V0oeVyL/ZqrqRrnuGYZhGAbYwrBNQhzbiMh+/tjGT6fNcL+I3CsiB4nI9v44SNxec5l95V4St0DiNiKyrj+2Ebdg38sl2LwnbgG8dRL61hGRU2nYd6xSccWKJyT/YuVxrPwL0ZMTERkhIusWsekjIh2bGUaIzXdEZJty6y3BJpbmZqcrYrrTVg5pyuO01ZtY36vUlHlgGNP9cWxT44mltwSbKJqrSrWb6FraAeyGm558P24mx1W4H9yZwG4Ju2L7yuXaH+x+Gu8PFmKzOm6z6zdwG11/gZvufAFuodqKxRUrnpD8i5jHUfIvVHOeOnUdzrG7qYDNI7gZv39uRhghNud57feXU28JNrE0NztdEdOdtnJIUx6nrd7E+l6lpsxDwvB2xWarxyqHKGUeS3M1D+uyLBERmQ7sqaqzsq4PBO5T1cFVEWa0eESkm6rOL3BfcBuRT2tqGKE2IUTSW9QmJK6YBKSr2ekOCSeUtOkJoVBcaaw3sb5XaSrzZBjSxNnhscqhKWVebs3VwByyEhGRt4DBqroi63oH4HUtMlZIRI5S1WJ7Eu6tqvdEsBmuRWb3VSquiPGE5F+sPI6Vfyv1iJvVuQerbs31VcJegFFZNi+q/7IGhhFisyluU96kzV2qOr3EcArqLcEmluZmpytiutNWDmnK47TVm1jfq9SUeUAZDCNgdnjEcmh2mcfUnDZsDFnp/BOYKCKnisgP/HEq8AJwdcDnc21/ks3ISDY/SVFcseIJyb9YeRwr/wRARA7D7eE3FrcH3WrAjrgxaod5m91wC2eehdvmZC/gbOAtEdktMIwQm1OB/3ptL/pDgP+IyGmx9JZgE0tzs9MVMd1pK4c05XHa6k2s71VqyjwkDOBa4ARVHayqu/hjU+BE4JrI5RClzGNpTiVN6eds6wcwBDgNuMQfp+GaQKuuzY70HsAMoGeO66sDb/rz6cCAHDYD/b2QMEJs3gTa57DpQMNK4M3WW4JNLM3NTlfEdKetHNKUx2mrN7G+V6kp88Aw8q7YD8yMXA6xyjyK5jQe7TBKRlVfB16XAqu2i8juuMVGk82ld6rqAwmbinQNVDKuiPGE5F+sPI6Vf8X0CLk3ka6noVWvHTA7h82HQHtvWyyMkHjqcVs/vZdl08ffi6U31CaW5ljpipHutJVDmvI4bfUmJJxYNpUq85Bnxf3iZoJfT8Os8n7AYTTMDo9VDrHKPJbm1GEOWYlIw6rtOwHz3CXJXrX9QmATXIXJVIq+wPEisqeqnuCbrb+Pa7p+MWHzHxH5r6qeH2hzGHAmbmHWTH/6jsB5InK2ql5fqbhwD5QY8YTkX6w8jpV/RfUAvwcmi8hDNDxI1gd2BX7n32e6xP9L44fNwbgu8Y8CwgiJ50TgUXFjIpM2G+E2Qg8Np5jeUJtYmmOkSyOlO23lkKY87hOgN215HMsmlp5mPytU9XgR2ZNV/2xeqqr3BcYTS2+QTUTNqcMG9ZeIiDwHXIjbMLXOX6sFDgBOVNVtReRNVd0kx2cF13y7sYi8CWymqsuzbDoA00qwmYFbIf6rLJvVgRdUdZNKxeXfxognKP8i5XG0/CumJxHu7qzaGvdl4jODyd0a93oJYYTY1LDqoNeJmXodS28JNrE0NztdEdOdtnJIUx6nrd7E+l6lpsxDwgghYjlEKfNYmlNHufpCW+tB4f7rTP//q8DIHPdHAVP9+RtA/xw2/YEZJdi8CfTIYdMjoacicUWMJyT/YuVxrPwrqscOO+ywo6UcwFHV1tAWNDfSX20BLe3AdVtdBmyDGwewrj+/DLjZ2wzHtRi9jusKewg3yPB5YGtvswcNC8xe6Y/MArN7lGAzDngbuBw4wx9X+GvjKxlXxHhC8i9WHsfKv6J6itSrKwNszooQRojNPZXQW4JNLM3NTlfEdKetHNKUx2mrN7G+V6kp88Awjq5gOcQq8yiaq3VYl2WJ+G6qI8jRFApcrapLE7a9kzaq+nFWWBXpGqhkXLHiCcm/EJtK5l+o5lyIyNaq+lIRm2+r6t3NDCPEpo+qzim33hJsYmludroipjtt5ZCmPE5bvYn1vUpNmYeEEULEcohS5iHECqccmENWJqSCC2p6u4KrFlcqrljxBOZflDwulqaYmtOIFJgtnFZCNLe0dKVNr+Vx+UmDHgmYrZ42WqLmIKrdRNfSDtzM1KNx3Vev+uN+4Bj82jK46beZbrBf+yPTDXaYtym6J2agzTBct9h04GHcXl1v+GvDKxlXxHhC8i9WHsfKvxA9PYDzadg383Mf7/n4NXxoqF8PkKN+BYYRYrM+rvt9Lm7830zgU39tQCy9JdjE0tzsdEVMd9rKIU15nLZ6E+t7lZoyDwzjQuA+3OzDHfxxsL92UeRyiFXmUTSn8ai6gJZ2AP/B/ehui1vWoK8/vxy/gSqVXSRvCm6WYLbNtsArlYwrYjyxFmCsZP6F6HkQOBXonbjf2197KKR+BYYRYvMccBBQm7CpxT3Yno+ltwSbWJqbna6I6U5bOaQpj9NWb2J9r1JT5oFhvJn9zPLXhYZJTbHKIVaZR9GcxqPqAlraka8yJO8RNnPvLaBdDpsONKw2HGRTQE9J4TQ3rojxhORftDyOlH8hemYUiGvlrM9C9SswjBCbkNnCzdZbgk0szc1OV8R0p60c0pTHaas3sb5XqSnzwDBCZqvHKodYZR5FcxoPWxi2dL4QkQOA21S1HlYO+D4A+NLbVHJBzZBViysV14eR4om1AGMl8y9Ez3sicgpwnfoxan7s2vjEZ4rVr3kBYYTE85KIXAZcl5WmccDLEfWG2sTSHCNd9ZHSnbZySFMed01ZvQkJJ5ZNpco85FkxHrhcRLrRsKB1P9yi5+Mjl0OsZ0UszanDBvWXiIgMAC7ArdT/Ja6ZtCcNK/W/6+1CZu4NAfbJssleJC/EJteqxXdpw6rFFYsrYjyxFmCsZP6FLDZ6mo9rHW/zMW6G7gWq+kWx+gV8FRBGSDxFZwvH0Kuq7wbaxNLc7HThVuqPke60lUOa8rh7gN605XEsm4qUOQHPCn+t4OzwiOUQEk5Rm1iaSSHmkDUDEVkTQFU/z3N/HQrM3EvYVWw2U6XiihFPSP7FzOMQYmguIa6C9StthOhtaWkKIW1pSpueYrTVehOT5uSPlDA7PFY5NLfMq6G5EphDViLi9rL8VFWXiIjgmkiH4xYE/YeqrhCRYbgZdj1wTaqCG1T4FfBTVZ0sOfbExP1rzHjwswJtegCn0/DPRHEzdu4EzlfVryoVl7ePEU9I/sXK41j5V1SPrz+707QN0e9U1TdKCKOgjYi0w/1LX8UG9y99eSy9Jdg0W3OsdEVMd9rKIU15nJp6U0Iet6jvXoCWw1h1L9++uKEWZ6vq9SHxxNIbmKZomtOGOWQlIiKvAaNUdZGIXABsCPwP92ONqh4uIlNwKwa/kPXZbYG/q+pQCdsTM8TmQZxjcF2mydY35Y4HdlLV3SoVF9AtUjwh+Rcrj2PlX4ieC8m9AflhuMG82RuiJ20O9td6B4QREs9/cM7idVk244A1VPWgGHp11Q3l89nE0tzsdOGc8hjpTls5pCmPPwrQm7Y8jmVTkTIn7FkRspdvrHKI9ayIopk0oimYWdCSDuD1xPlLQE3ifWaZhKCZewVsos1mqmRcEeNpbv6VkseVyL+VMzHz3E9O136THOvk4GZ0vhUaRlNtkvdi6C3FppyaS0lXzHSnrRzSlMctod7E+l5Vo8xLCKNHDpse5SiHWGUeQ3MajxqMUvlARHby57NwsztW9lN77heRe0XkIBHZ3h8HiZvNl2m+fUlELhORbURkXX9sI272zcsl2LwnIqeIG7uE17KO/4fwQYXjihVPSP7FyuNY+ReiZ4mIjGRVRgJL/Hk9bn/UbPr4eyFhhNh8ISIHiJt5lEl3jYgcRMMspBh6Q21iaY6RrljpTls5pCmP01ZvYn2v0lTmIWH8Hjc7/HIROcMfVwCT/b2QeGLpDbWJpTl1WJdliYhIP1yzbC1uPNEOuMVFewK/VNVHvV2x2YgVmc2kzZs5NRu4O09ca+P+/ayMC1gQI00h+Rcxj7PTBPBJqfkXqGc4bmHCXNO1f6aqL4nIHsD/4f7hJpfP2Ag4Fje+rVgYIfEMoPiMp2brVdUHAm1iaW52unBdljHSnbZySFMerxWgN215HMsmlp5mPytgZVdfodnhscohyrMilmZSiDlkTUREBuP6zNvhKuBE9eudGEYhJM6G6AXDCLXxdsVmC8fQW9QmpuZI6Wp2umOmKW16mqs5jfUm1vcqTWUeqLfg7PBY5RC5zKNoThO2MGyJiIioYzpuS51cNrXAj3GDCO9X1WcT936tqueKyAa4/Q4/xP1b+huwnQ/zZFWdlSfsN1V1k6xrxWbSfBd4wrf2rAX8mYaZob9Q1dmJcPoCj6jqe4nwD1fVf4pb8uFYH/4/cbMTt/eaz9PE+l/59ErYLK5jcQMvPxORDYFrgC1w4wJ+rKpTy5zHj6nqTon3UTT7sHoAY5LhiEj2dG1NHJn3K539kDACbRrNQhKRXDOemq031Cai5manK1a601YOacrjEL0VTlOs71Vqyjygng8jx+xwEfmKxOzwYvHE0huYpmia04aNISudx0XkOHFLIaxERDqIyE4ich2u6XkMboPVS0TkrwnT/fzrtcBEYCFuI+sZwJ648Ub/9GHOF5Gv/et8EZkPbJi57m0uBE4AnsAtzfBHf368iFzk4/q9Nqyb9X+4LtY9cZutXuPDOQ/4Fc6JeExEjktoPta/3gB0AUYAj+P64y8AFgPXhugF/oXb0PtsYC9/nA0M9eED/ERVP/PnFwN/U9XVcfuiXeGv/z1SHr+adUwFRmfex9Qsbrr2ZGAssJo/dsSNUTvM2+yGa2Y/Kyuut0Rkt8AwQmxOxc1AEuBFfwjwXxE5LZbeEmxiaW52uiKmO23lkKY8Tlu9ifW9Sk2Zh4SBe0aeoKqDVXVXVd1FVTcFTqThtyFWOUQp81iaU4mmYGZBSzqATsBPgWdwU7dfB94B3gP+AWwFvJqwbwdcCdwOdARe9tdfTti8nxVHxuZi3Hi1dRL33s2yDZndMiNx/aUsuyn+dSp+v0bceIb7cE5FUs+URNgfZofTHL3Je1l6J2bZvJp8jZDHd+Gcqk2B/sAA3JiD/kD/yJpn0MwN0QPDCLEJmc3UbL0l2MTS3Ox0RUx32sohTXmctnoT63uVmjIPDCNkdniscohV5lE0p/GwFrISUdUlqnqZqo7G/WjvDAxX1f6qeqSqvoz7YmXsV6jqUTiH5TGgq79VLyKbiJuZspqIjAAQkY1wEwZQ1eOBi4D/iMjx4vrEM82vGUJmt0wQkXNEpLM//66Pa0fcoEtwztgKH+9XwLeB7iJySyI9NeIGU/bD7UU3wIezJtAhUG/IDKNbReRacV2Od4jIiSLSX0R+BLzvbWLl8T7AbTiHbqi6bszlqvqeNnTbxtIsOfIDXDO6ZMqBhkGxST4E2geGEWITMgspht5Qm1iaY6QrVrrTVg5pyuO01ZtY36s0lXlIGCGzw2OVQ6wyj6U5ddgYsmagbkXlOTluTRKRPTQxk0NVzxGRj3AzUQBOwc1grMeNTTpdRIbiVoA/MvG5l0RkF1y34RO4Frok4ym+0eqxuO7IGf79z0VkoY//h/7a2yIyRlWf8PHWAUeIyLnA97zNH4DMGIfDgatEBGAwrjk4RO/BuG7Oy0TkS2g0w+hgH8avRGQ88B/cwrsdgaNwC/Ae4sOJmcd3iNsU/HcicgQJZ6+A5h64bttSNGemaz9EaRuirw8chNvI/KOAMELiORF4VETyzdCKpTfUJpbmGOnSJqa7KRvOx9CbT0+a87hPgN605XEsm1h6mv2sUNXjJffs8Eu1YUZ7rLoV5VkRUXPqsFmWKUJEegFfap5ZICLSB9gqUemS90Jn9fTAtYZ9nnW9M4CqLs7xmfVU9UN/XourNyvEDXYf5uNbxTEtpNffLzqLKzYBeTwU2E5Vr8hzv1maJcKG6IFhhNiEzHhqtl5vM5jcS4IkbWJpbna6Iqa7kuXQ0vI4RG/a8rhFffdCwgghYt2K8qyIpTl1VLvPtK0dwK6l2OBaczbMYbNl4rw30Nufr4Ub1D4kyz6XzWZFdJwXoDWvDa6/fj9g08S19YFO/lyAHwGXAD+hYQxbiM0+GZsC8e8DdAxIwzeBQf58NPBL4FtZNl2B/YGfA8fjNratKdWmiXWmV7F05rm+Dm427XAS4/ry2G6Eawkd0hSNpej1NsOrqTlTjxLlNgK3bU1JeezvrVHoswm77sDWwOrl1ttC8zin3pTncYv67mXrxbX0n48bc/UFbpLUdH+tZ4Fw1myu1hC9uepFtTWX86i6gLZ2kDW4vJANcCCu2XkKMA0YmbCZ7F+PBt7F7RrwE+AFXJPsDOCIEmwuzjouwe23djFwcYgN8L+Evu/4OK/x8Yz3118DVvPnFwC3Aofimpj/WYLNYuAz3AzIvYDaHPkYYnMh8CxuptPv/PlvgEeAPyXK4UXgKuBtH96NwKvAFiXY9MPNrnoKOIPEwN5M3uFmgb4LPI2bIDLNhzcbN15xvxzHx5lzH8Yw3KzS6cDDPi1v+GvDvc3j+Ichrtv6Ta99KnBcLL3eZniOY7a3Hx5Z85b+Mx/gxgWuntD8on8dj3uIv+n1vwM86j/z/cA8Xt/nzae42Vwz/fl/8YOJcZNFMnp3x40lfAQ3AeiAWHpbaB6H6E1bHreo716g3gdxM8F7J8LvjVss+yH//vyE3q193rzl83hMFZ4VUTSn8ai6gNZ44Gbu5TruBhaWYDMF6OPPR/kv9nf9+5f961TcFOM1cSvlZ1rBVqfxDMpiNh/gHm6H4Ta5HQfMzZyH2NB4VuOzwEB/3ouGfT5D9gINsXnZ6z8S9+D8BLe8xJiEbYjNNFwr3Gq4AfoZR7A98Jo/fzVxvReuGR7cg/7ZEmweBo7BPbQv8Xm0ZlZ5TsGNydsO9wOxrb8+GDetfDlwD845vcYf8/3rPxNhbJOjXm6byL/XEtcnJnSsRsOs0Gbr9ef1/rOPJ47F/vWxyJqfxrVM9sS1dE7DtzDT+DvTC9eC+3Xi/jq+HEPy+DnceJTahKZa3Pim5zPxZH0fBuT4PjRbbwvN4xC9acvjFvXdC9QbspdvMo8fxzcM4BZGn1SFZ0UUzWk8qi6gNR64H/Zv4dbJSh5jgU9KsJmaFW4fnINyfKICT07cfyXL/uUSbLrhWov+Dazrr72TZVvQJiueF/PE8yCwkz+/jYalJdak4YEVYjM5K/zePl+eAz4owSbjdHXyZdLZv6/FO4a4h3VmvGVnGjuer5VgMyVLz6H4H4c85flBlv0U3OzZR3HrnmWuv5tlFzIt/GVgPX/+OA1dxLXAtFh6/ev3cBM89qyA5uz6vSPun/G2Cc1TEvc/yrJ/NUIeZ5YumAZ09+dP0/iPRTS9LTSPm6u3Gnncor57gXofwk1+Si5VtA6uBeoR/346DUNFns/6/NRYekuox1E0p/GwWZbl4XlgkfoZi0lEZEYJNvNFZENVfRtAVeeIyFjczL3NvI2KSHt1Mz6/lQijEw0L/xa1UdX5wIkisjVwo59C3GhZlACboeIWgBWgo4j08Zo74JeZwK2uf72InIWbCTpFRKbg/r2eVIJNZip1RtvH+K5TEelfgs29IvIUziG7CrhZRJ7HOcdPepv7gAdE5EncP+1bfP6tkYgjxKa9iHRS1SVezw0i8jHOAe3ibb4SkaNxY2G+FJGfAzcDuwALVHWiiOwKHCcij+MeQkpj7vdlcz2NZ6cdRsO08J8DD4nIbbgH52Mi8iBub9ZrYun1n7vNh/07ETkc+EUZNSMiPVR1no/7cRH5Hs6xX8ObvC8if8D9wXhDRP6CW8NuF2BOYB6/JG5z+euy9I6jYcP5s3ELSV+KW7fwFhG5C+cQrJwd3Fy9LTSPQ/SmLY9b1HcvUO9BuK6+J8RtRQQN+xMf6N9fBtwnIufjnnEX+bzZCef4RdHrPxdSL5Kas/cfLkVz+qi2R2hH/gO3EvzGOa63Bw7x5+uTGIyasFkP2CXUJuu64DYAvqGAtqI2CdueuJmLyWuZGTDfA7Yhx+D3QjbA2IB4i9p4u+1oaD7fENetcWBWfHv568kJFzUkJg0Us8E9iMfkiH8r4GF/3g+3C8EVuBa9n+PG1N0LDM763Lq4B9o7OcLc04dxtz+uAPbKsumBG1P4N1w3w6k0noBRit7Li+lNfPZxYG6ZNP8gU5ZZn1sf+Ic/747b9us0GiZi3IN7iPcJyWPc0ig/wf3ITvXHA7hFo5N1YmPcOMg7fJouB3Yvl15vPzyFefw9r/nSHHmcs06UkMcblSGPM3rz5fF6uepFlb57Ic+KvHpDDpyDexPOEZ6K2+XlaPxYsRL1lvqs+LQcmtN42LIXZUDE7XfZ1mxE3KJkxWzSojeNNm0BX0+6qerX1dbSWmlpedzS9LYmpMheyNUkV73w1w7AtZzdimv1+g5ujPUVqlpfDa1RqLZH2BoPYAJwHLB+1vUOuMpzHa7ytDabj3GD/tOgJY02h+P+oT2AG0fzKu5f2zE0/NNs523uz7Ip+s8OuNK/1nr73wHbZ9n8ugSb1XBjNU7GdemOx3UL/BHomsdmXLZNHq1vZr1PLuPSHrcp/F3AeTRMlgixOZaG2VUb4bqdv8LNLN68gM2X3mYLXNfGoUX0b4AbLP07XIvKP3D/9m+hYWB5xubcAjY1uGVd7gVewQ3G/i+J1t2EzT1ZNmMSNpl6k7duhdSdJtSv0QH1axWbWPUmBXVrZb3x12/HLQRdKA2l1K9Cdaegja83hxepWxfihlscjOsy3cGf3wdclLDbHdeylZl8djmwR7Gy8J/9bSk2Pq4jyNr6CDjcv16Gc8Tuwv3e3IKbrfrfjGZcD86BOMdNcLNOL8a1rjZ7KaJyHdZCVgbEjc06HPfFHIj7QeiEe0g9hKtQ01uATWfclzrU5ircFOM0pylWupsS1yn++nU07KrQF/djtIaqHiQi/ylkg+vmyIXgBi/3FZGrcD94L+IeVE+o6kkAIjJZVYcH2tyMGwfTGRjk03gTbn233qr6w0Cb+TSMA8mMp1sNWIRrUO2eidPH/xfcBI5rcP/c11TVwwJtpqnqZt7mXuAqdTsxjAV+r6qji9ngfsyewznSj+B2X7hXVZetzGw3VvA/uK6nQ3EbHt8E7IYbTrBToM01uKn4j+C6Ir/GLR1wKq6V4pJAm4L1xtetzHipbJJ1J8Sm2fULt4RFaL1JjgXNrjchNpWsWx9SvO6E2GTXnWtwXY6F6lcjG1ydKVZv3lTVTVYpbNcK9aaqbiwiF+JmJ15P47p1GG4SwwnZn88K631VXT/ERkTOwzmFk3Hb912oqpd4m0zdmqqqW4hIe1wjQB9VXSZuofLJqrqluLGHa+P+EH+N2znlLtwY6k+Kaa4a1fYIW/uB+7fVh8IL1rU6mzRpSYsNYZuUF7QB6nBr6rybODLvl3m7kI3XQ2ym+FfBPfgk8f7VEmwupvim8y8nzqfQ0GKYDCfEJmiT90I2ifR3xzkT9+GWd7kG2C2Hlnwb14fYvJp1PbOcQ0caNlMOsQmpWyF1pyL1K2K9SVvdCq475a5foXWLxPqWCdtRNMygzFm3fN5kZrt+neeYD6wowWYqDbMje/q8+VuBdD+QpSlTrzLa2+OW2OiQqIuv5kpPGo4ajLKiqstVdY66DbvbjE2atKTIJmST8mI27+C6HAYmjg1UdSBuphGEbbweYpO5r8B9/jXzXkNtNGzT+R4i8l1xs986qpsRnB1XiE3IJu/FbDK6v1bVf6nqXsCmuK6p03wYRTeuD7RZLiIb+uvDgWU+7qWJNIXYhNStkLpT0frV3HqTwroVUncqVb9C6s144P9E5HURecgf03GO7nhvs8THkc1IYIk//wo3Aa171tGNhv2eQ2zaqeoKr/MrXCtZdxG5hYY69bGIdPU2e2TEiNs+MNPKmAljOc55zqR9BQ0buKcPTYFXaIcdbeHAdYXdhPs3/KY/PvXXBobY4Ga2Ds0TfmaV7xvIMb4Dt5zI8hJsriLHOBfcTNSnQ20S12pw68A9xaprPV2Tdazjr/cGHg218e/H437cPsP9+34dNxaoR4gN8GRAWe6M24FiOq6L5TYaVpL/Tgk2O+F+zN/CtUJt46+vBfyxBJuQuhVSdypSv2LVm7TVrcC6U5H6FVJvEvH1xg032ZrECvj+3nCf5tdxwy8e8nE+D2ztbc4FRuVJywUl2NxD7tma5wL1RfKsC7C2P78/T/3qTdYamWk6bAyZYVQBCdikPMSmWog0fVapFNl0vqUiRTauz2fjx+usqaqfFfhcUZuEbWrrTQjNqTettW5B0+pXYN3qDW6dRhFZC/gG8IZmbcLt7VbOxFS3rmNURKSz17I4x731VPXDAppnqOq0IuF3Abqo6qextcfAuiwNowqo6ufJH0xxCziWbJOk2P2YNrjFHJtko647976YeiplU+i+qn6mqnWl2qhjlR/MUm1EpLu4haSz682W2TY5wqm4Tb77uJmuq4SRVW9yxhNiU+10N9UmUXdKsemGa/XNGY+4hVqfA54XkZ/gWqi+heuSPSJhn3GAXsK1um0vIkOywuydsRORtURkPxHZrBQb74j1yGWTcMbyab49W3N2OLiZm6l0xgDrsrTDjjQclLDpfDnDMJuWmce4Kf4f4cZpTSMxUJuGrWtSY5MmLa3VJjCMqRTf5/hoXJfnLNws7xeAq3HdpUdUwSaK5jQetnWSYVQIcVu65LyFe7gUtYkRhtm0vjwGzsCN55kjIqOAf4nI6ap6h7dLm02atLRWm5AwlqvqImCRiLytvhtSVb8UkUy38bG4rfo645bR2EhdV+HquJX0r66wTSzNqcMcMsOoHN/ArRe0IOu64KaZh9jECMNsWl8e16pqZs/FF0VkR+AeEelHw4y6NNm0S5GW1moTkscheyGHOECVtImlOX1Uu4nODjvayoGb+bNjnntPhtjECMNsWmUePwtsmHWvG/AosDRtNmnS0lptAsMI2Qv5JRrWZeubsOmEWyy40jZRNKfxqLoAO+ywww47mncAQ3FrPGVfb49b2T1VNmnS0lptAsOQgLoV4gBV0iaK5jQetuyFYVQIEdvAvSXYWB5bHrcGm8A8noBbv+xOVX0/cb0Dbm2zccDjqnptufWWYFMxzZXGlr0wjMrxuIgcJyKN9nUTkQ4ispOIXAdML2SDW9H6X80Jw2wsj6ttY3mcmjy+Ebdd1n9E5CNxK/a/g1tM9vu4zcfHpyVNkTWPI2VYC5lhVAiJs+l8a9nAPc02lseWx63Bpmgeq+rLeMRt1t0LWKyJbd8iPbei2cTSnAwnLZhDZhhVIN+DpBSbGGGYjeVxtW3SpKW12oSEEUKa0hRTc1owh8wwDMMwDKPK2BgywzAMwzCMKmMOmWEYhmEYRpUxh8wwjGYjInUiMkVEXhORu0WkZxniGCsi90QM70QRWS3x/r4YukXkWhHZP0I4Z4nIL0uwP6O5cRqGUT3MITMMIwaLVXWYqm4OfAH8rNqCxFHoGXcibpNiAFR1r7QP+i2COWSG0YIxh8wwjNg8h1sRGxGZICIj/HkvEZnlz8eLyO0i8oCIvCUif8wVkIjsISJviMhkYL/E9UatR75lboA/ZojI9cBrQD8RuVxEJonINBE529sfD6yLWxvucX9tloj08ucn+TBfE5ET/bUBIjJdRP7hw3pIRDrnyYNdfJxvisjeiTT/X0LzPSIyNpHOySLyiog8miMfjhSR+0Wks4gcKiIv+hbJv4tIrYicD3T2124UkS4icq8P7zUROahwkRmGUW1sc3HDMKIhIrXAzsDVAebDgK1w++7NEJFLVPWDRFidgH8AOwEzgZsCZWwMjFPV5304v1LVL7y2R0VkS1W9WEROAnZU1c+y0rA18CNgG0CAF0TkCeBLH/b3VfVIEbkZ+B5wQw4NA3Abf2+Ic/o2yidWRNby6fymqr4rImtk3T8W2BXYF9gAOAgYrarLReQy3DY4p4nIsao6zH/me8BHqvot/75HWNYZhlEtrIXMMIwYdBaRKcDHwDrAwwGfeVRV56nqEuB1oH/W/U2Bd1X1Lb/FSS7HJxfvZZwxz4G+he1lYDNgSJHP7wDcoaoLVXUBcDvwDX/vXVWd4s9fwjleubhZVetV9S3gHZ+WfGyL2yT8XQBV/SJx7zBgT2B/VV2Kc3a3Bib6/N4Z56RlMxXYVUQuEJFvqOq8Qgk2DKP6mENmGEYMFvvWmf64VqXMGLIVNDxnOmV9ZmnivI7SWuyT4WaHvTBzIiIDgV8CO6vqlsC9OXSUQqjm7AUelcKa8zEV5/T19e8FuM6P1xumqoNU9axVIld9ExjuP3+uiPw2IC7DMKqIOWSGYURDVRcBxwO/EJF2wCxciw5AqTMP3wAGiMiG/v33E/dm4RwORGQ4bnuUXHTHOWjzRGQdXGtThvlAtxyfeQrYV0RWE5EuwHf9tVI4QERqvPYNgBle8zB/vR+uSxPgeeCb3nkkq8vyZeBo4C4RWRd4FNhfRNbO2IpIpmVxubhVyfG2i1T1BuBP+LwyDCO92BgywzCioqovi8irOAfqz8DNInIUrnWqlHCWZD4nIotwTlHGgboNOExEpgEvAG/mCeMVEXkZ59x9ADyTuH0l8ICIfKSqOyY+M1lErgVe9Jeu8mkaUIL89/3nuwPH+LQ8A7yL656dDkz28c316bzdzwr9FDdmLKPnaT+B4V5//dfAQ952Oa418j2fnld99+z1wJ9EpN7b/KQE7YZhVAHbOskwDMMwDKPKWJelYRiGYRhGlTGHzDAMwzAMo8qYQ2YYhmEYhlFlzCEzDMMwDMOoMuaQGYZhGIZhVBlzyAzDMAzDMKqMOWSGYRiGYRhVxhwywzAMwzCMKvP/viMQM0E6WW8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 720x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot the two series on the same graph\n",
+    "\n",
+    "tick_spacing = 200\n",
+    "\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.plot(joined.index.astype(str), joined['f_pct'], color='red', label='percent of failure')\n",
+    "plt.plot(joined.index.astype(str), joined['p_pct'], color='green', label='percent of passing')\n",
+    "\n",
+    "# set x and y axis labels\n",
+    "plt.xlabel('Run duration buckets')\n",
+    "plt.ylabel('Percentage of passing or failing')\n",
+    "plt.xticks(rotation=90)\n",
+    "plt.xticks(np.arange(0, len(joined.index.astype(str)), tick_spacing), joined.index.astype(str)[::tick_spacing])\n",
+    "\n",
+    "# set title and legend\n",
+    "plt.title('Percentage contribution of failing and passing to their sum')\n",
+    "plt.legend()\n",
+    "\n",
+    "# show the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "7fffbd14-3a5c-444e-ad1d-fb557505bdd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_turning_point(s):\n",
+    "    # Create an empty Series\n",
+    "    sub = pd.Series()\n",
+    "    turning_point = 0\n",
+    "    for index, value in s[::-1].iteritems():\n",
+    "        if value > 60:\n",
+    "            sub.loc[index] = value\n",
+    "        else:\n",
+    "            if sub.empty:\n",
+    "                return 0\n",
+    "            elif not sub.empty:\n",
+    "                turning_point = (sub[::-1] >= 75).idxmax()\n",
+    "                return turning_point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "e8d480d4-77dd-4a9a-9abd-9130426dc4a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tp = find_turning_point(joined['f_pct'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "145b749e-dba4-4ffc-b5d5-b7bd3beca73c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmQAAAHmCAYAAADdgZLyAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAACaiklEQVR4nO2dd5hU1fnHP+8uvSuooCBgQ7CACFgwEXuJGpPYEhvRWH8WYmKNxhpLYhLUiD32JGKLvaJYYkVEERErKoqKDell9/39cc6wd4fZmTO7d+be2X0/z3OfuXPvO+d8T5k775wqqophGIZhGIaRHFVJCzAMwzAMw2jpmENmGIZhGIaRMOaQGYZhGIZhJIw5ZIZhGIZhGAljDplhGIZhGEbCmENmGIZhGIaRMOaQGUYLQkR+JCIzIu9nisiOMYY/TURGxRVeYJwiIjeKyHci8koDNheIyNci8kVAeFeLyFn+fJSIzIrcK3v6GoOIqIisl7QOqJw8AxCRiSLym0Z+9hEROTRuTUbLoVXSAozmiYjMBNYAaoAFwCPAcao6P0ldGUTkHGA9VT0oaS1xISIKrK+q7zdko6rPAQNiiu8mYJaqnhkJf6M4wi6SbYCdgN6quiD7poisDfwO6KuqXxUKTFWPznMvifRVNKXKMxEZDfxGVbdp5OfPIcZngKruFkc4RsvFWsiMUrKnqnYChgLDgDML2NfDt3xYHY0JEWmuf8D6AjNzOWOetYFvQpwxwygFzfi7Z8SJqtphR+wHMBPYMfL+L8CD/nxL4AXge+ANYFTEbiLwJ+B/wCJgPWAj4AngW+BL4AxvWwWcBnwAfAOMB1b19/oBChwKfAJ8DfzB39sVWAosA+YDb/jrvwamA/OAD4GjstJ0CjAb+Bz4jQ9/PX+vLXCpj+tL4GqgfZ78OSIS19vAUH99oM+D74FpwF6Rz9wEXAk85D/3MrCuv/es17PAp2l/YBQwCzgV+AK4NXMtq5xO9xq+A24E2vl7o4Hns3SrL5Mjff4t9fE9kF3uPk/G+vz63J+39fcy2n4HfOXz9dd58mtN4H5fB94HjvDXDwcW41pi5wPnZn1uR1w9qvX3b/LX7/R5Mtfn3UZZ+XxBVGeueg2cg6tzt/jymAYMi9gOBV739+4E7siEmyN96wJP4erx18DtQLeseH8PvOk135EpJ3//ZOrq5mFE6maOuCYCFwGvAD8A9+G/NwF5s7uvK/OAz4Df++s9gAdx9fZb4DmgqlR5hvueRMv9e3+9qw97DvAx7k9gVY7PN/QMmAicj3v+zAMeB3pEPlfo2fWbyHfnf8DffZnmSsMIYJIvgy+Bv+Wqcw3k4Z3AbV7jVGAD3Pf4K+BTYOeknv12NP5IXIAdzfPIeoD08Q/e84G1/ANqd5xDtZN/v5q3nYhzajbCdal3xv3Q/A5o599v4W1PBF4CeuN+/K8B/u3v9cP9KF0HtAcGA0uAgf7+OcBtWZp/gvthFGBbYCF1jtKuuB+pjYAO/mEYdcj+jnMYVvUaHwAuaiBv9sX9mA33ca2Ha+VpjXM2zgDaANv7B+4A/7mbfF6N8HlzO/CfSLj1foT9g305cInPn/bZD3tfTm/5MloV9yOScUZG04BDFtFzQZ5yP8+Xz+rAargfsvOztJ3n0727z+9VGsizZ4Fxvg4Mwf3gbt+QzqzP1kuzv3aYL6eM0zglcm9FuhrIr+gP42KvvRrn5Lzk77XBOQQn+vT9HOcANOSQrYf7LrT1efUsMDYr3ldwjumqOGf+6Ejd/BLYGOgI/Cu7LmTFNRFX/zL2dxP5LhTIm9nAj/z5KtR9Py7C/Qlp7Y8fAVLiPFup3HHO2H1efz/gXeDwBj5/Dis/Aybi/uBtgPu+TAQu9vdCnl1Rh2w5cDzuu7rSnzPgReBgf94J2DJPfc2Vh7v4sG8BPgL+4PPtCOCjUj3b7SjdkbgAO5rn4R8g83H/JD/G/Zi2x7XW3Jpl+xhwqD+fCJwXufdL4PUG4pgO7BB53wv3j7cVdQ5Z78j9V4AD/PlKD+Mc4f8XONGf/5OIg4X7Ac20FgmuZWrdyP2tGnoo+vSemOP6j3BOX1Xk2r+Bc/z5TcD1kXu7A+9E3udyyJZSvyWl3sPel9PRWWF+4M9H0zSH7ANg98i9XXBdixkdi4BWkftf4X+UssLsg2sJ6Ry5dhF1rV0r6cz6fL0057jfzaera3a6Gsiv6A/jk5F7g4BF/vzHOKdHIvefz86vPJr2JlLvfbwHRd7/Gbg6UjcvjtzbILsuZIU9Mct+kK8n1QF58wlwFNAly+48nCO0UpylyrPscsc5eEuBQZFrRwETG/j8OeR2yM6MvD8WeNSfhzy7og7ZJwXK+FngXCItcA3V1xx5+ETk3p64Z221f9/Zl1m3kLpmR3oOG59jlJK9VbWbqvZV1WNVdRGuJWhfEfk+c+AGZfeKfO7TyHkf3A97LvoC90bCmY774V4jYhOdVbcQ9080JyKym4i8JCLf+vB2x3XFgGuZiOqKnq+GazV7LaLlUX89Fw2laU3gU1WtjVz7GPfPvOj0eOao6uICNtG0fOx1xMGaPryGwv5GVZdH3jeUnjWBb1V1XlZYa+WwLYiIVIvIxSLygYj8gPuxg7qyLobs8mjnxwutCXym/hfS8ykNICJriMh/ROQzr+m2HHoaKvvsuhnN84bItm8N9AjIm1/gvhcfi8gzIrKVv/4XXOvu4yLyoYiclifuWPIsBz18OrLrXLH1pKF8Dnl2RSmk/XCc8/yOiLwqInsUofHLyPki4GtVrYm8h8LPBiNlmENmlJtPcf8yu0WOjqp6ccQm+4G8Tp6wdssKq52qfhagIxoHItIW13VzKbCGqnYDHsa1foHrqukd+UifyPnXuIfgRhEdXdVNaGhI97o5rn8O9MmayLA2rtWgsWhhk3ppWdvrANfq1yFzQ0R6Fhn257gfsVxhF8PnwKoi0jkrrMbmy6+An+LGl3XFtaZCXVnHwWxgLRGJhtmnIWPgQlx+bqKqXYCDitAzm5XLsBDZ9stw9Thv3qjqq6r6U1w39H9x48FQ1Xmq+jtVXQfYCzhJRHYI1B9NRzF5ll3/vvbpyK5zDdWTkO9GlJBnV3D4qvqeqv4Sl5eXAHeJSEdW/t5V0/CfO6MZYQ6ZUW5uA/YUkV38v/F2fq2n3g3YPwj0EpExItJWRDqLyBb+3tXAn0SkL4CIrCYiPw3U8SXQL+L8tMGNmZkDLBeR3YCdI/bjgV+LyEAR6QCclbnhW7SuA/4uIqt7LWuJyC4NxH098HsR2dzPJF3Pp+Fl3D/yU0SktV+7aU/gP0WkqSHnNR//JyK9RWRV3DiUO/z1N4CNRGSIiLTDdZUUE9+/gTN9ufQA/ogr/6JQ1U9x488u8vVlU1zrQtFheTrjxhN+g/vhu7CR4eTjRVxr7XEi0srXyxEFNM0H5orIWrhB+qGMB0aLyCBfN88O+MxBEfvzgLt8C0uDeSMibUTkQBHpqqrLcIPRa/29PXw9FtxkgJrMvSIoNs++BHqLSBsAr3887pnQ2X+nTqLhepL9DChEsc+uvIjIQSKymn9+fO8v1+LGvbUTkZ+ISGvcxIS2jYnDqCzMITPKiv9x/Slu4Poc3L/Ok2mgLvpuqp1wjskXwHvAdv72ZbiB9I+LyDzcAPItcoWTgzv96zciMtnHcwLugf4drqXg/oiOR4DLgadxXTMv+VtL/Oupmeu+q+dJGljvS1XvxM0k/Rdu0P5/cbPclvp07ob7tz8OOERV3wlM0znAzb47Zb/Az+B1PI6bWfoBcIHX+S7ux/pJXL4/n/W5G4BBPr7/5gj3AtwssjdxM8EmZ8JuBL/EtdZ8DtwLnK2qTzYyrFtwXVmf4WYMvpTfvHh8Wf4c5zh+j2vxepC6+pLNubgZhnNxs2jvKSKuR3CD75/C1cGnAj52K26s3Be4iRIn+OuF8uZgYKav40cDB/rr6+PqyXycYzVOVZ8OTYNPR7F59hRustAXIvK1v3Y8roXpQ1x9/RdujF0u6j0DAvQV9ewKYFdgmojMxz3LDlDVRao6Fzd27XpcOSzAzUg2mjmZWTCGYRSBiAzEzU5smzUOyjByIiIv4wbi35iwjom4wezXJ6kjhLTkmWGUA2shM4xARORnvtt0FdyYjwfMGTMaQkS2FZGevvvtUGBT3GQPowEsz4yWjDlkhhHOUbilGT7AjXU5Jlk5RsoZgBuH9z1uHb19VHV2oorSj+WZ0WKxLkvDMAzDMIyEKVkLmYj8U0S+EpG3ItdWFZEnROQ9/7qKvy4icrmIvC8ib4rI0FLpMgzDMAzDSBul7LK8CTeLJMppwARVXR+Y4N+Dm1W2vj+OBK4qoS7DMAzDMIxUUdIuSxHph9tQemP/fgZuM9bZItILt6XFABG5xp//O9suX/g9evTQfv36lUy/YRiGER+1tW5psqoqG75stExee+21r1U150K/rcqsZY2Ik/UFdVvcrEX9bSZm+Wt5HbJ+/foxadKk2EUahmEYhmHEjYg0uLVZYn9T/H5lRTfPiciRIjJJRCbNmTOnBMoMwzCMUjBu3DjGjRuXtAzDSCXldsi+9F2V+Nev/PXPqL9nWW8a2H9MVa9V1WGqOmy11Wx7L8MwjEph/PjxjB8/PmkZhpFKyu2Q3Q8c6s8PBe6LXD/Ez7bcEphra88YhmEYhtFSKNkYMhH5NzAK6CEis3Ab3l4MjBeRw3H7pWX223sY2B23D9tC4Nel0mUYhmEY5WDZsmXMmjWLxYsXJy3FKDPt2rWjd+/etG7dOvgzJXPIVPWXDdzaIYetAv9XKi2GYRiGUW5mzZpF586d6devHyKStByjTKgq33zzDbNmzaJ///7Bn7O5x4ZhGIZRAhYvXkz37t3NGWthiAjdu3cvumW03MteGIZhGC2UiRMnJi2h7Jgz1jJpTLlbC5lhGIZhGCVl7NixLFy4sKjPPPfcc2y00UYMGTKERYsW1bt3+eWXM3DgQA488MAGPz9p0iROOOEEAG666SaOO+644oWXEXPIDMMwjLJw6aWXcumllyYtwwhk+fLlsYXVGIfs9ttv5/TTT2fKlCm0b9++3r1x48bxxBNPcPvttzf4+WHDhnH55Zc3Sm+caQ/FHDLDMAyjLDz44IM8+OCDSctoMcycOZMNN9yQAw88kIEDB7LPPvuscIpee+01tt12WzbffHN22WUXZs92K02NGjWKMWPGMGzYMC677DJeffVVtt56awYPHsyIESOYN28eNTU1nHzyyQwfPpxNN92Ua665BnBd0qNGjWKfffZZEa+qcvnll/P555+z3Xbbsd12262kc8KECWy22WZssskmHHbYYSxZsoTrr7+e8ePHc9ZZZ63UCnb00Ufz4Ycfsttuu/H3v/+dV155ha222orNNtuMrbfemhkzZqzQs8cee6wU3+jRo7nrrrtWvO/UqdMK+x/96EfstddeDBo0qMF0lgobQ2YYhmEYpWbMGJgyJd4whwyBsWPzmsyYMYMbbriBkSNHcthhhzFu3DhOPPFEjj/+eO677z5WW2017rjjDv7whz/wz3/+E4ClS5cyadIkli5dyoYbbsgdd9zB8OHD+eGHH2jfvj033HADXbt25dVXX2XJkiWMHDmSnXfeGYDXX3+dadOmseaaazJy5Ej+97//ccIJJ/C3v/2Np59+mh49etTTt3jxYkaPHs2ECRPYYIMNOOSQQ7jqqqsYM2YMzz//PHvssQf77LNPvc9cffXVPProoyvC++GHH3juuedo1aoVTz75JGeccQZ33313o7J08uTJvPXWW/Tv359rr702ZzqLmTlZDOaQGYZhGEYzpU+fPowcORKAgw46iMsvv5xdd92Vt956i5122gmAmpoaevXqteIz+++/P+CcuV69ejF8+HAAunTpAsDjjz/Om2++uaKVae7cubz33nu0adOGESNG0Lt3bwCGDBnCzJkz2WabbRrUN2PGDPr3788GG2wAwKGHHsqVV17JmDFjgtM4d+5cDj30UN577z1EhGXLlgV/NpsRI0ascLgaSqc5ZAkwd/Fcul3SjX/u9U9+vZmtVWsYhmE0kgItWaUie7afiKCqbLTRRrz44os5P9OxY8e8YaoqV1xxBbvssku96xMnTqRt27Yr3ldXV5dlLNZZZ53Fdtttx7333svMmTMZNWpUXvtWrVpRW1sLQG1tLUuXLl1xL5r2htJZKmwMWR5mz3d96hf/7+KElRiGYVQ+7du3X2lwtlFaPvnkkxWO17/+9S+22WYbBgwYwJw5c1ZcX7ZsGdOmTVvpswMGDGD27Nm8+uqrAMybN4/ly5ezyy67cNVVV61oiXr33XdZsGBBXh2dO3dm3rx5OeOYOXMm77//PgC33nor2267bVFpnDt3LmuttRbgZlMWol+/frz22msA3H///Q22qDUmnU3BHLI8tK12nv6S5UsSVmIYhlH5PPLIIzzyyCNJy2hRDBgwgCuvvJKBAwfy3Xffccwxx9CmTRvuuusuTj31VAYPHsyQIUN44YUXVvpsmzZtuOOOOzj++OMZPHgwO+20E4sXL+Y3v/kNgwYNYujQoWy88cYcddRRBVvCjjzySHbdddeVBvW3a9eOG2+8kX333ZdNNtmEqqoqjj766KLSeMopp3D66aez2WabBbXIHXHEETzzzDMMHjyYF198scEWwcaksymI27WoMhk2bJhOmjSpZOF/+N2HrHv5uqzaflW+OeWbksVjGIZhND+mT5/OwIEDE4t/5syZ7LHHHrz11luJaWjJ5Cp/EXlNVYflsrcWsjwsr3We8LeLvk1YiWEYRuVz/vnnc/755yctwzBSiTlkecg4ZGDdloZhGE1lwoQJTJgwIWkZLYZ+/fpZ61gFYQ5ZHqIO2dtz3k5QiWEYhmEYzRlzyPIQdche/fzVBJUYhmEYhtGcMYcsDzW1NSvOj3rwKOu2NAzDMAyjJJhDlodltfXXJpnyxZRkhBiGYTQDunfvTvfu3ZOWYRipxByyPCxevrje+1qtTUiJYRhG5XP33Xc3eo9Bo7IZO3bsio3NQ3nuuefYaKONGDJkCIsWLSqRsvp8/vnnK+2dWS7MIcvDomWuAvTu4vblqtGafOaGYRiG0WyIcxHUxjhkt99+O6effjpTpkwp2w4Pa6655oq9K8uNOWR5EBFW77g6J299MgCXvXxZwooMwzAql9NPP53TTz89aRkthpkzZ7Lhhhty4IEHMnDgQPbZZ58VTtFrr73Gtttuy+abb84uu+zC7Nluq8BRo0YxZswYhg0bxmWXXcarr77K1ltvzeDBgxkxYgTz5s2jpqaGk08+meHDh7PppptyzTXXAG4vy1GjRrHPPvusiFdVufzyy/n888/ZbrvtVlqpH9xyKJttthmbbLIJhx12GEuWLOH6669n/PjxnHXWWRx44IHB6TrvvPMYPnw4G2+8MUceeSSZxe8vv/xyBg0axKabbsoBBxwAwDPPPMOQIUMYMmQIm222GfPmzWPmzJlsvPHGgNuG6ec//zm77ror66+/PqeccsoKDTfccAMbbLABI0aM4IgjjuC4445rcnnZ5uJ52H393fny91/yv0/+B8BdbyfjNRuGYTQHGtrMuiUw5tExsY9DHtJzCGN3HZvXZsaMGdxwww2MHDmSww47jHHjxnHiiSdy/PHHc99997Haaqtxxx138Ic//IF//vOfACxdupRJkyaxdOlSNtxwQ+644w6GDx/ODz/8QPv27bnhhhvo2rUrr776KkuWLGHkyJHsvPPOALz++utMmzaNNddck5EjR/K///2PE044gb/97W88/fTT9OjRo56+xYsXM3r0aCZMmMAGG2zAIYccwlVXXcWYMWN4/vnn2WOPPXJ2IeZK1+9//3uOO+44/vjHPwJw8MEH8+CDD7Lnnnty8cUX89FHH9G2bVu+//57AC699FKuvPJKRo4cyfz582nXrt1K8UyZMoXXX3+dtm3bMmDAAI4//niqq6s5//zzmTx5Mp07d2b77bdn8ODBxRbfSlgLWQAj1x6ZtATDMAzDKJo+ffowcqT7DTvooIN4/vnnmTFjBm+99RY77bQTQ4YM4YILLmDWrFkrPrP//vsDzunp1asXw4cPB6BLly60atWKxx9/nFtuuYUhQ4awxRZb8M033/Dee+8BMGLECHr37k1VVRVDhgxh5syZefXNmDGD/v37s8EGGwBw6KGH8uyzzzYqXQBPP/00W2yxBZtssglPPfXUik3TN910Uw488EBuu+02WrVybVEjR47kpJNO4vLLL+f7779fcT3KDjvsQNeuXWnXrh2DBg3i448/5pVXXmHbbbdl1VVXpXXr1uy7774F9YZgLWSGYRiGUWIKtWSVChFZ6b2qstFGGzXYYtnQZtsZVJUrrriCXXbZpd71iRMn0rZt2xXvq6urS7YZd650LV68mGOPPZZJkybRp08fzjnnHBYvdpPzHnroIZ599lkeeOAB/vSnPzF16lROO+00fvKTn/Dwww8zcuRIHnvssZVaycqVHrAWMsMwDMNotnzyyScrHK9//etfbLPNNgwYMIA5c+asuL5s2bIVLUlRBgwYwOzZs3n1Vbcw+rx581i+fDm77LILV111FcuWuaWh3n33XRYsWJBXR+fOnZk3b17OOGbOnMn7778PwK233sq2227bqHRlnK8ePXowf/78FYPza2tr+fTTT9luu+245JJLmDt3LvPnz+eDDz5gk0024dRTT2X48OG88847BeMFGD58OM888wzfffcdy5cvj23msDlkgRw6+FCAFQMEDcMwjOLo3bs3vXv3TlpGi2LAgAFceeWVDBw4kO+++45jjjmGNm3acNddd3HqqacyePBghgwZwgsvvLDSZ9u0acMdd9zB8ccfz+DBg9lpp51YvHgxv/nNbxg0aBBDhw5l44035qijjirYcnTkkUey6667rjSov127dtx4443su+++bLLJJlRVVXH00Uc3Kl3dunXjiCOOYOONN2aXXXZZ0dVaU1PDQQcdxCabbMJmm23GCSecQLdu3Rg7diwbb7wxm266Ka1bt2a33XYLytO11lqLM844gxEjRjBy5Ej69etH165dgz6bD6lkB2PYsGE6adKkssQl57rm0TO2OYM/7fCnssRpGIZhVC7Tp09n4MCBicU/c+ZM9thjj2a3wXga0jV//nw6derE8uXL+dnPfsZhhx3Gz372s3o2ucpfRF5T1WG5wrQWsiKJ7m9pGIZhGEbL45xzzmHIkCFsvPHG9O/fn7333rvJYdqg/kCeGf0M2960Leuuum7SUgzDMCqSMWPGAG6RUKP09OvXr9m1jkE60nXppZfGHqY5ZIEMW9O1MH636LuElRiGYVQmU6ZMSVqCYaQW67IMpH2r9gjCwmXFbf1gGIZhtFwqeZy20XgaU+7mkAUiIrRr1Y5Fy8uzwalhGIZR2bRr145vvvnGnLIWhqryzTff5Fz5Px/WZVkE7Vq1Y/HyxUnLMAzDMCqA3r17M2vWLObMmZO0FKPMtGvXruglXswhK4J2rdqxaJm1kBmGYTSGzPY4LYXWrVvTv3//pGUYFYI5ZEXQvnV7FtdYC5lhGEZjuPbaa5OWYBipxcaQFYF1WRqGYRiGUQrMISsC67I0DMNoPEceeSRHHnlk0jIMI5VYl2URtG/V3lrIDMMwGsm7776btATDSC3WQlYEtuyFYRiGYRilwByyImjf2lrIDMMwDMOIH3PIisAG9RuGYRiGUQpsDFkR2KB+wzCMxjNkyJCkJRhGajGHrAhsUL9hGEbjGTt2bNISDCO1WJdlEdigfsMwDMMwSoE5ZEVgLWSGYRiN56CDDuKggw5KWoZhpBLrsiyCzKB+VUVEkpZjGIZRUcyaNStpCYaRWqyFrAh+WPIDAE/PfDphJYZhGIZhNCfMISuCt+a8BcAOt+zAH5/+Y8JqDMMwDMNoLphDVgS9OvVacX7+s+cnqMQwDMMwjOaEjSErgiox/9UwDKOxbLXVVklLMIzUYg5ZEWQP5F9as5Q21W0SUmMYhlFZXHTRRUlLMIzUYk0+RTCq76h672f9YDOGDMMwDMNoOuaQFcEhgw9h1m9ncfd+dwMwb8m8hBUZhmFUDr/4xS/4xS9+kbQMw0gl1mVZBCLCWl3WotOcTgDMW2oOmWEYRijffPNN0hIMI7VYC1kjaN+qPYCt2m8YhmEYRiyYQ9YI2rVqB5hDZhiGYRhGPJhD1ggyDtmS5UsSVmIYhmEYRnMgkTFkIvJb4DeAAlOBXwO9gP8A3YHXgINVdWkS+gphLWSGYRjFs8MOOyQtwTBSS9kdMhFZCzgBGKSqi0RkPHAAsDvwd1X9j4hcDRwOXFVufSFkHLKvFnyVsBLDMIzK4ayzzkpagmGklqS6LFsB7UWkFdABmA1sD9zl798M7J2MtMJ0a9cNgBun3JisEMMwDMMwmgVld8hU9TPgUuATnCM2F9dF+b2qLvdms4C1cn1eRI4UkUkiMmnOnDnlkLwSndt2pk11G6Z+NZVarU1Eg2EYRqWx2267sdtuuyUtwzBSSdkdMhFZBfgp0B9YE+gI7Br6eVW9VlWHqeqw1VZbrUQqC3Pmj84E3PZJhmEYRmEWLVrEokWLkpZhGKkkiS7LHYGPVHWOqi4D7gFGAt18FyZAb+CzBLQF06VtFwAWLbOHi2EYhmEYTSMJh+wTYEsR6SBut+4dgLeBp4F9vM2hwH0JaAvGZloahmEYhhEXSYwhexk3eH8ybsmLKuBa4FTgJBF5H7f0xQ3l1lYM5pAZhmEYhhEXiaxDpqpnA2dnXf4QGJGAnEaRccgWLbcuS8MwjBD22GOPpCUYRmqxzcUbibWQNY6vF37NO1+/Q/f23Rm42sCk5RiGUUZ+//vfJy3BMFKLOWSNpH1r22C8Mex7575MnDkRQZj9u9ms0WmNpCUZhmEYRuLYXpaNpFqqAfj4+48TVlJZfL/4ewAU5dtF3yYrxjCMsjJq1ChGjRqVtAzDSCXmkDWSnp16As6xMMKpqa1ZcW6ti4ZhGIbhsC7LRpLZPmn+0vnJCqkwarWWjq07smDZAn5Y8gNLli8J+lyrqlZUV1WXWJ1hGIZhJIM5ZI2kU5tOAEyfMz1hJZVFjdbQtV1XFixbwKibRwV/bs3Oa/LRiR/RprpNybQZhmEYRlKYQ9ZIMg7Z+9+9n7CSyqKmtoat+2zNtn23Zd6SeUGfeXHWizzw7gP8sOQHenToUWKFhmEYhlF+zCFrJNVV1WzYY0OqxIbhFUOt1tK2ui3HjTgu+DPXvXYdD7z7QHD3pmEY6WS//fZLWoJhpBZzyJpAl7ZdzEkokhqtKdqJbduqLQBLaiyvDaOSOfbYY5OWYBipxRyyJtC2uq05CUVSq7VFD85vW+0csmlfTWOdVdYphSzDMMrAwunTYfp0OrRrl7SUymD99d1htAjMIWsCbVu1ZeGyhUnLqChqamuoKnK1ldU7rg7A6PtG880p35RClmEYZWD3ESNg/nwmJi2kUujXDz76KGkVRpkwh6wJtKluw3eLvktaRkXRmBayUf1GMarfKF6f/XqJVBmGURZqamCVVeDRR5NWkn7+/Gd45pmkVRhlxByyJmBdlsVTozUrdjkIRUQY2nMor372aolUGYZRNlq3hhEjklaRfnr2BLWFx1sSBR0yEVk1x+V5qrqsBHoqirat2rK0ZmnSMiqGBUsXsLx2eaNmprapbmN5bRiVjjkY4YhAbW3SKowyEvLLOBmYA7wLvOfPZ4rIZBHZvJTi0k6b6jY2yzKQW964hU4XdeLbRd+umDVZDG1btWVZ7TLUHuiGYbQERMyBbWGEOGRPALurag9V7Q7sBjwIHAuMK6W4tNO22lrIQvnwuw8B+OvOf2XMlmOK/nxmpmWPv/Rgn/H7xCnNMIwyMbpzZ0avYzOlg6iqMoeshREyhmxLVT0i80ZVHxeRS1X1KBEpvqmjGWFjyMKpqa1BEE7a6qRGff6AjQ/gywVfMuGjCTzzsQ10NYxKZHTnzrDeeknLqAysy7LFEdJCNltEThWRvv44BfhSRKqBFl1brMsynBqtadLm4P1X6c/YXceyQ/8dWFbT4ocvGkZF8vXy5Xy9xJ6ZQViXZYsjxCH7FdAb+K8/1vbXqoEWvQ+GDeoPp6a2+NmVubDB/YZRuezz5Zfs8+yzScuoDMwha3EU7LJU1a+B4xu43aJ31m5b7Qaa12qt7WlZgKa2kGUwh8wwjBaBjSFrcYQse7EB8HugX9ReVbcvnazKoE11GwCW1iylXSvbCiQfcbWQta5qTY3WmBNsGEbzxsaQtThCBvXfCVwNXA/UlFZOZZFxyJbVLDOHrACN2VQ8F5k83/s/e/PfA/5rTplhGM0T67JscYT8mi1X1atU9RVVfS1zlFxZBbDCIau1QeaFaMyWSbnYff3dAXjg3Qf4fvH3TQ7PMAwjlZhD1uIIccgeEJFjRaSXiKyaOUqurAJoXd0awMY0BRBXl+XgnoO5cvcrAWy2pWFUGMd06sQxG26YtIzKwMaQtThCuiwP9a8nR64p0OJX94uOITPyE9egfnDjyMBaJg2j0ti/fXuwhWHDsDFkLY6QWZb9yyGkEomOITPqs6xmGW/PeRvF/cObs3BOLC1kUNcyafluGJXFp8uWwYIF9ElaSCVgXZYtjgYdMhHZXlWfEpGf57qvqveUTlZlYC1kDXPOxHO48PkL610b0H1ALGFnWsiW1y6PJTzDMMrDwd99B88+y8SkhVQC5pC1OPK1kG0LPAXsmeOeAi3eIcs4BpXkkC1ZvoRfjP8FXy34qqBt6+rWXL7r5Wy+ZvF7yH+98Gu6tu3KTXvftOLawB4Diw6nIV1gXZaGYTRjbAxZi6NBh0xVz/avvy6fnMoi6VmWj73/GJe9fNlK14f0HMKFO1yY4xPw6Q+f8tB7D7HpGpuyVue1Ggx7ee1ynvjwCZ75+JlGOWQ1WkPHNh3Ze8O9i/5sIVpVuWp75ANH0qVtl4L2/br148rdr0REYtdiGIZREjLPK9W6c6NZk6/LMu8u0Kr6t/jlVBYZh+yTuZ8wbM1hZY//32/9myc/fJIhPYesuDbrh1k8+eGTDTpkNbVuKblTR57Krzb5VYNhL61ZStsL2rJ4+eJGaavReGZV5mLzXpuzbd9tWbhsIV8v/Dqv7Rfzv+CR9x/hwh0upFu7biXRYxhGEZhzEYY5ZC2OfF2WncumokLp3qE7QEGnIMOcBXNo37o95z1zHvOXzmfL3ltyyOBDGh3/8trl9Onah1eOeGXFtXMnnss5z5zjlpnIMasxM+4q08rUEJnu2EY7ZA3EHwd9u/Vl4uiJQbZXvHwFJzx6go03M4w0YF1w4VT5Vaksz1oM+boszy2nkEqkb9e+QJjTcv3k6znigSPYed2defyDx6mWau59594mO2TZjlX71u1XaOrYpuNKn6lR10JWyCETEdq1asebX77JndPuLFrbXW/fxSrtVyn6c3GTSac5ZIaRPL/r2BE23TRpGZVBtIXMaBHk67I8RVX/LCJXACvVCFU9oaTKKoAOrTsAsHDZwoK2n8z9BIDpc6YDsGXvLXnjyzeaFP/y2uUrWrIytG/lHLJdbtuFTm068Y/d/8F6q65X7zNAUHdir069uG/Gfdw3475G6Vs0b1GjPhcnmQkA5pAZRvLs2aYN9OuXtIzKIOOQ2VpkLYZ8zSTT/eukcgipRDL7Vy5altvxmPXDLJYsXwLANwu/AdygeoBV2q/CgqUL+M39v6n3mWqp5rdb/ZYNe2zIvCXzGPnPkVyy4yXstv5uK4Wfq4Vs+/7bs+M6OzJvyTwe++Axnvv4uZwOWaEWMoDXjnyNz+d9XtAum0XLFzH8uuFFf64UWAuZYaSHGcuXw9y5xLMATjPHWshaHPm6LB/wrzeXT05lISK0qW7Dec+ex/rd1+egTQ9ace+x9x9j19t3bfCz2/Xbjje/fJNH33+03vXP5n3GGp3W4LztzuOTuZ8w9aupnD7h9GCHbKPVN+KJg5/gy/lf0vOvPVfqTs0M6g9xyFZpv0qjuh3TtGCrOWSGkR6OmjcPnnnG1iELwcaQtTgK7mUpIquJyKUi8rCIPJU5yiGuErhuz+sAeHnWy/WufzbvMwD+vsvfcy79sOcGe/LxmI+ZddKsekfH1h1ZsHQBwIpV7hctz90Cl8shy5Bpvct2yIppIWsspQy7WMwhM4wUYTMGw7EuyxZHyC/n7cAdwE+Ao3F7W84ppahK4pDBh3DmU2fy2AeP1bueWSz2gI0PYGnNUv77zn/r3c8smZFNxzYdeXHWizz90dMrlml495t3ufSFSwFWLOi6esfV+eC7D1ij4xo5w8k4ZE98+MSKgfwAH3z7AUDJZkACqVrvK+OQXT/5enp26rnS/SE9h7DjOjuWW5ZhGEZ+Ms/RsWOhTe7fCyNmfvxjGDEisehDHLLuqnqDiJyoqs8Az4jIq6UWVkksXr6YT3/4FFVd4Yxkxo61qW7Dhj02BKBTm07MXzqf9q3ar1gyI5tBqw1i4syJHHb/Ydyxzx0rrp/8xMk57Uf2GZnzepvqNvTt2pdH3n+ER95/pN69ttVt6d2ld3GJLJL1Vl0vtpX5m0Lfrn1pVdWKv77415z31+y8Jp+d9FmZVRmGYRQgswn7H/6QrI6WxCWXpN4hywwImi0iPwE+B1YtnaTK47db/pYznjqDRcsXrZh5mWkha1vdlr0G7MXCMxbSproNy2qXUS3VK2b/ZfPkwU9yzEPHcM/0e1aMxbp7v7vZed2dAeh8kVsebt7p8wDo2HrlpS3AtVK9f8L7OZfkaF3Vmrat2jYhxYV55//eSUVL2fC1hjPv9Hk5uyx/99jvuHv63QmoMgzDKMA++8CCBdZlWU4SbokMccguEJGuwO+AK4AuwG9LqqrC6NquKwCbXbPZiuUkMovFZromM+uDFeoqrK6qpmvbrixYtoAvF3wJwCrtVqFTm0717LLf56JVVasgu1JQyi7RYsl03+a6bmPLDKN8nNmuHQxPxwzsiqBDh6QVGGUk3zpkl6jqqUB7VZ0LzAW2K5uyCmL39XfnwE0OXGmT8QHdBzTYEpaPbu26sXj5Yn4x/hcAORd4NZpOq6pW9cbXGYZRWnZs3Rr69ElahmGkknwtZLuLyGnA6UDxS7W3IPp168dtP78ttvCOHnY0a3Rag5raGrq07cLmvYrf3NsoTKuqVtZCZhhlZMqyZfD11wxJWohhpJB8DtmjwHdAJxH5IXJdAFXVLiVV1oLp3qE7vxn6m8KGRpOorqpesS6bYRilZ8yiRfDcc7YOmWHkoMF1yFT1ZFXtBjykql0iR2dzxozmgLWQGYZhGGmh4MKwqvrTcggxjHJTLdUoSq3aLCbDMAwjWdKzpLoRxBW7XZFzKQujeDKLxtbU1lBVXfC/iWEYhmGUDHPIKozjRhyXtIRmQ2Zpjp+P/zm/3fK3bN9/+4QVGUYzx7ZOMowGyeuQiUg1cIuqHlgmPYZRNrbtuy3D1xzOo+8/Sq9OvcwhM4wSc2HbtjAy9+4ihtHSydtPo6o1QF8RsY20jGbHVn224pUjXqFnp54229IwysDWVVVsvdZaScswjFQS0mX5IfA/EbkfWJC5qKp/K5kqwygj1VJtC8QaRhl4Yfly+Pxztk5aiGGkkBCH7AN/VAGdSyvHMMpPdZU5ZIZRDs5Ytgyef97WITOMHBR0yFT1XAAR6eTfzy+1KMMoJ9ViC8QahmEYyVJwrr+IbCwirwPTgGki8pqIbFR6aYZRHqyFzDDKhM2yNIwGCVl86VrgJFXtq6p9gd8B15VWlmGUD2shMwzDMJImxCHrqKpPZ96o6kSgY8kUGUaZsRYywzAMI2mCZlmKyFnArf79QbiZl41GRLoB1wMbAwocBswA7gD6ATOB/VT1u6bEYxghVEmVtZAZRhkYW10NO+yQtAzDSCUhLWSHAasB9wB3Az38taZwGfCoqm4IDAamA6cBE1R1fWCCf28YJceWvTCM8jBEhCE9eyYtwzBSScgsy++AE+KKUES6Aj8GRvvwlwJLReSnwChvdjMwETg1rngNoyGqq6ptg3HDKANP1tbCzJnsmLQQw0ghSeyo3B+YA9woIq+LyPUi0hFYQ1Vne5svgDUS0Ga0QNpUt+HR9x+l9fmtue41m69iGICbEbnxxtCqVWzHBTU1XPDCC0mnzDBSSRKbi7cChgLHq+rLInIZWd2Tqqoiork+LCJHAkcCrL322qXWarQALtjuAp748AkufeFSps2ZlrQcw0gHNTUwbRr8+Mfwox/FE+Ztt4F1WRpGTpJwyGYBs1T1Zf/+LpxD9qWI9FLV2SLSC/gq14dV9VrcUhwMGzYsp9NmGMWwbb9t2bbftlw16Sob3G8YGdQ/XnfcEc46K54wn38+nnAMoxlS0CETkctzXJ4LTFLV+4qNUFW/EJFPRWSAqs4AdgDe9sehwMX+teiwDaMpVEmVjSUzjAwZh8wWcjWMshDSQtYO2BC407//BfARMFhEtlPVMY2I93jgdhFpg1tC49e48WzjReRw4GNgv0aEaxiNpkqqbLalYWQwh8wwykqIQ7YpMFLV/VKJyFXAc8A2wNTGRKqqU4BhOW7ZAjVGYlSLzbY0jBWUwCG75pprYgvLMJobIQ7ZKkAnXDcluFX6V1XVGhFZUjJlhlFmrMvSMCKUwCEbMGBAbGEZRnMjxCH7MzBFRCYCgltD7EK/VMWTJdRmGGXFuiwNI0LGIauKb3WkBx54AIA999wztjANo7kQsjDsDSLyMDDCXzpDVT/35yeXTJlhlBlbINYwIpSgheyvf/0rYA6ZYeQidNmLKtxirq2A9URkPVV9tnSyDKP8pLnL8j9v/YexL41tcjgdWnfgpr1vYu2utoafUQAb1G8YZSVk2YtLgP2BaUDm10oBc8iMZkW1VKd2HbL7ZtzHm1++yY/7/rjRYcxdMpenZz7NlC+mmENmFMYcMsMoKyEtZHsDA1TVBvAbzZo0t5CpKn269uHRgx5tdBiTZ09m82s3R9XWUzYCMIfMMMpKyGjND4HWpRZiGEmTZoesVmupkqYNrs58Pq1pNFKGOWSGUVZCWsgW4mZZTgBWtJKp6gklU2UYCVBdVZ3aWZaKIjTthzHjkCnWQmYEUAKH7NZbb40tLMNoboQ4ZPf7wzCaNVVSxYufvsg+4/dJWspKPPr+o/Tr1q9JYWQcOuuyNIIogUPWp0+f2MIyjOZGyLIXN5dDiGEkzU8H/JR7pt/DO1+/k7SUerz37XssrVmKNPGH0bosjaIogUN2xx13ALD//vvHFqZhNBcadMhEZLyq7iciU6FeH4cAqqqbllydYZSR87Y7j/O2Oy9pGSsx6MpBTP96epPHkGUcOuuyNIIogUN21VVXAeaQGUYu8rWQnehf9yiHEMMwcpNxxOIaQ2YtZEYQtb6e2KB+wygLDf7lVtXZ/vRr4FNV/RhoCwwGPm/oc4ZhxEvGkWpyC5mNITOKwWZZGkZZCXnCPwu0E5G1gMeBg4GbSinKMIw6VrSQ2Rgyo5yYQ2YYZSXEIRNVXQj8HBinqvsCG5VWlmEYGTKOmI0hM8pKCTYXNwyjYUKWvRAR2Qo4EDjcX6sunSTDMKLYGDIjEUrQQnbXXXfFFpZhNDdCHLIxwOnAvao6TUTWAZ4uqSrDMFZgY8iMRCiBQ9ajR4/YwjKM5kbIOmTPAM8AiEgV8LWt0m8Y5cPGkBmJUAKH7KabbgJg9OjRsYVpGM2Fgn+5ReRfItJFRDoCbwFvi8jJpZdmGAbE2EJmY8iMYiiRQ5ZxygzDqE/IE36Qqv4A7A08AvTHzbQ0DKMM2BgyIxFslqVhlJUQh6y1iLTGOWT3q+oysL/YhlEubAyZkQjmkBlGWQl5wl8DzAQ6As+KSF/gh1KKMgyjDhtDZiSCOWSGUVZCBvVfDlweufSxiGxXOkmGYUSxMWRGIphDZhhlJWTZC0TkJ7jFYNtFLqdvF2bDaIbYGDIjEUrgkD388MOxhWUYzY2CDpmIXA10ALYDrgf2AV4psS7DMDw2hsxIhBI4ZB06dIgtLMNoboQ84bdW1UOA71T1XGArYIPSyjIMI4ONITMSoQQO2bhx4xg3blxs4RlGcyKky3KRf10oImsC3wC9SifJMIwoVbM+A0D8a6PD8b+vf73n99z+n9ObKsto7tQq7UbDtcu+iO0f+Pjx4wE49thjYwrRMJoPIQ7ZgyLSDfgLMBm35MV1pRRlGEYdB79VhQocXNu0LWS7LYYjJ8HHa7WG9u0Kf8Bo0SxsVcsz/Rbyct9W1iViGGUgZJbl+f70bhF5EGinqnNLK8swjAy/mtOLXz0+FXbs2aRwBLjmQeDyi+D442PRZjRfPvj2A9a7Yj10Ndt/0jDKQcig/nbAscA2uNax50XkKlVdXGpxhmEAtbX1X5saTlXTJgcYLYMVy6TYJBDDKAshXZa3APOAK/z7XwG3AvuWSpRhGBEyjlRTfxhtXSmjCFbMyrV16wyjLIQ4ZBur6qDI+6dF5O1SCTIMI4u4HDJrITOKoBQtZBMnTowtLMNoboQ8mSeLyJaZNyKyBTCpdJIMw6hHXF2W1kJmFIG1kBlGeQlpIdsceEFEPvHv1wZmiMhUQFV105KpMwzDWsiMRChFC9mll14KwO9///vYwjSM5kKIQ7ZryVUYhtEw1kJmJEApWsgefPBBwBwyw8hFyLIXH5dDiGEYDWAtZEYC2CxLwygv9mQ2jLRjLWRGAtgYMsMoLw06ZCLStpxCDMNoAGshMxLAWsgMo7zkezK/CCAit5ZJi2EYubAWMiMBStFC1r59e9q3bx9beIbRnMg3hqyNiPwK2FpEfp59U1XvKZ0swzBWYC1kRgJkWshqtYl/BCI88sgjsYVlGM2NfA7Z0cCBQDdgz6x7CphDZhjlwFrIjARY0UJmXZaGURYadMhU9XncvpWTVPWGMmoyDCOKtZAZCbBiDFmMXZbnn38+AGeddVZsYRpGcyHkyXyriJwgInf543gRaV1yZYZhODKOmLWQGWWkStzPQ5wtZBMmTGDChAmxhWcYzYmQhWHHAa39K8DBwFXAb0olyjCMCNZCZiSALXthGOUlxCEbrqqDI++fEpE3SiXIMBLjt7+FO+9MWsXKfPGFe21qC1nm89ZCZgRgy14YRnkJcchqRGRdVf0AQETWAWpKK8swEuCpp6C6GnbaKWklK3P//U1vIct83lrIjACshcwwykuIQ3Yy8LSIfAgI0Bf4dUlVGUYS1NTAsGFw/fVJK1mZffeFadOaFoa1kBlFUIoWsu7du8cWlmE0N0L2spwgIusDA/ylGaq6pLSyDCMBamtdC1kaqaqyFjKjrJSihezuu++OLSzDaG6EtJDhHbA3S6zFMJKltja9zoqIjSEzyoqNITOM8hLkkBlGi6CmJr0OWVUVfPwxbLVV48OYP9+9mkNmBFCKFrLTTz8dgIsuuii2MA2juWAOmWFkSHOX5QEHwDffNC2MLl1gvfVg+PB4NBnNmlK0kL344ouxhWUYzY2CDpm4b+WBwDqqep6IrA30VNVXSq7OMMpJmrss99rLHYZRJmyWpWGUl5Bfn3HAVsAv/ft5wJUlU2QYSVFTk94WMsMoM6XYXNwwjIYJ6bLcQlWHisjrAKr6nYi0KbEuwyg/aW4hM4wyY5uLG0Z5CXHIlolINbh2axFZDbC/TEbzwxwyw1hBKTYX7927d2xhGUZzI8Qhuxy4F1hdRP4E7AOc2dSIvZM3CfhMVfcQkf7Af4DuwGvAwaq6tKnxGEYw1mVpGCsoRQvZbbfdFltYhtHcKNgcoKq3A6cAFwGzgb1VNY4N/04EpkfeXwL8XVXXA74DDo8hDsMIx1rIDGMFpWghMwyjYQr++ojIqsBXwL+BfwFfikjrpkQqIr2BnwDX+/cCbA/c5U1uBvZuShyGUTTmkBnGCkrRQjZmzBjGjBkTW3iG0ZwI6bKcDPTBtVoJ0A34QkS+BI5Q1dcaEe9YXKtbZ/++O/C9qi7372cBazUiXMMonkcegYcfdgunWpelYQB1LWQPvvcgXy34KpYw733qXtbsvGYsYRlGcyPEIXsCuEtVHwMQkZ2BXwA34pbE2KKYCEVkD+ArVX1NREYVpdZ9/kjgSIC111672I8bxsr86U/w8svQrZvbXNwwDKqlmq37bM07X7/D+9++H0uY3/7wLdVif3oMIxchDtmWqnpE5o2qPi4il6rqUSLSthFxjgT2EpHdgXZAF+AyoJuItPKtZL2Bz3J9WFWvBa4FGDZsmA1uMJrOsmWw446upcwwDMC1kP3vsP/FGmbVVVU2Js0wGiBkwMxsETlVRPr64xTcOLJqGrH8haqerqq9VbUfcADwlKoeCDyNm8EJcChwX7FhG0ajsNmVhmEYRsKEOGS/wrVY/dcfa/tr1cB+MWo5FThJRN7HjSm7IcawDaNhzCEzjLIgPYRVe6+atAzDSCUFuyxV9Wvg+AZuN2lggapOBCb68w+BEU0JzzAaRU2Nza40jDLQ+qet2WWLXZKWYRipJGRz8dVwMyI3wo35AkBVty+hLsMoH9ZCZhhlw8aQGUZuQpoFbgfeAfoD5wIzgVdLqMkwykttrTlkhlEGlt+3nMf+/ljSMgwjlYQ4ZN1V9QZgmao+o6qH4RZxNYzmgbWQGUZZ0K+Vbz/7NmkZhpFKgjYX96+zReQnwOeAjco0mg/mkBlGeZCkBRhGeglxyC4Qka7A74ArcOuGjSmlKMMoK+aQGYZhGAkT4pB9p6pzgbnAdgAiMrKkqgyjnJhDZhjlw8b0G0ZOQsaQXRF4zTAqi4kTYYMN4PPPzSEzjDJQ3aua1dZdLWkZhpFKGmwhE5GtgK2B1UTkpMitLrhFYQ2jsnnpJXjvPTjwQPj1r5NWYxjNnrZ7tGXU0FFJyzCMVJKvy7IN0MnbdI5c/4G6LY6McnPRRbB4MZx7btJKKp+aGvd6443QunWyWgyjBSAIqtZnaRi5kEJfDhHpq6ofl0lPUQwbNkwnTZqUtIzyIn6akj3Ums6558I559hK/YZRJtps1oZ1VlmHd556J2kphpEIIvKaqg7LdS9kUH9bEbkW6Be1t5X6jYpn+XLn4JozZhhloXZuLfNr5ictwzBSSYhDdidwNXA9UFNaOYZRRmpqoFXIV8AwDMMwSkvIr9FyVb2q5EqMOmbPhn/9yzkMnTvDEUeY41AKli+3fDUMwzBSQciv0QMicixwL7Akc1FVbf+LDO++CyedBEuX1r++4YZw2WV1475Cue46OPvsuvebbQZbbtl0nUZ9bP0xwygrgtjm4obRACGDZw4FTgZeAF7zRwsbSV+AJ56Ahx6C77+H+fPd8c47cMUVrhWmWObNg/bt4dFH3ftFi2KVa3ishcwwykqrvq3ouWHPpGUYRiop+Gukqv3LIaSi+eYb9zpxInTo4M7/8hc45RRYssQtqfDVV9ClCyxY4N536ZI7rCVLYM4c6NgROnVy12bOhM8+q2+Xeb/GGg07FQsWOCcxmw4dYJVVikhgI1i0yOlKw3IS33zjlgrJ5ocfrIXMMMpIh906sNXGWyUto2L4cv6XLK9txJ96o1F0aduFzm07FzYsEQUdMhHpAJwErK2qR4rI+sAAVX2w5Ooqhcsvd6/t29dda9vWvS5dCnfeCfvtV/8zc+fmdsq23RZefhnWXRfatHHXDjtsZbvevd3rfvvBHXesfF/VhfHllyvfq6qCadNcl2qp6N8fBg6Ep58uXRwhvPACjMyz01cmHw3DKDm2Dlk4t795Owfde1DSMloUl+x4CaeMPCWx+EP6a27EdVNu7d9/hpt5aQ5ZhvbtYZNN6o8VyzhTS5bAhx+u/Jlvv83tkH34oXPK/vKX+q1L117rXjMtXt26wd/+tnLLWYYlS5wz9rOfwW671V2fMQP++lf44ovSOmRffpnbGSw3n3/uXs8+G9Zaa+X7G29cXj2G0YKZd+s8Hu3yKPwkaSXp57N57tl+xW5X0La6bcJqWgYj1hqRaPwhDtm6qrq/iPwSQFUXihQ7Sr0Z849/wKxZzvGJkmkhu+46ePHFlT+3bFnu8BYsgM03h+HDXSsWwPrru5mW2dx9d+4uSajrovvRj+p/9rnnnEPWmLFtoaTpH3AmnQccUFoH1DCMgtQurGUxOYYPGCuRaUk8fLPDad+6fQFrozkQ4pAtFZH24KbGiMi6RGZbtnh++1v3+uMf17/et69rMYvOlowyfrxrBavJWtpt4cK6sWMZx6ah8WatWjXsWGUcsvZZX+TMeLPseOOklM5esWS02OB9w0gcm2UZTiafrP2j5RDyK3U28CjQR0RuB0YCo0spqmKorXU/+H/8I+yTtb3n9tvDd9/VtYRddJHrYszw4otuUHnGoctQXQ2HHurO+/d3jl5D+1a2arVyS9vkyXD00W6mJ9S11EU/A2FO02efwceN2DUrTbNCM/ljDplhGBVErdYCzok1WgYhsyyfEJHJwJaAACeq6tclV1YJZFqhMjMrs+nate480+q19trwySfOWevUyXUfNkTHjvDMMw3fz9VC9vzz8OqrbtzYJps4xzBKZlZhiEO21Vbw6aeF7dKMtZAZhlGBZLosrYWs5RAyy/JnwFOq+pB/301E9lbV/5ZaXOrJtAQ15JBFWX9997rZZs4he+EFWHPNpsWfyyHLaLrzTufQ5foMhHVZzpnjZnEefnjx2kaPTseSF+aQGUZqaLNeG9bqkWNyjbESmS7LKrG9dlsKQV2Wqnpv5o2qfi8iZwP/LZmqSiEzezIzozIfBx3kujVVXdfl/PkwookzOlq3Xtkhy7TatWuX+zOhLWSqLqwNN4Sddy5e2447ugkESZNJZxqcQ8No4XTeuTObbbBZ0jIqAuuybHmEOGS53HNrbgDX7QjQq1eYfcZJ+sMf4om/VSs3xmvAgLprc+Y456OhBU9Dx5BltoFqyLErRHV16SYOfPCBc24XLixsmykjayEzjMQx5yIc67JseYT8Sk0Skb8BV/r3/4dbl8zIDBhvatdjY/n1r916Y9nLTAwZ0vBnMo7J2We7JTsaIuNMZU8KCKWUDtkbb8CUKbDrrm49tkL069fwTFXDMMrGt9d9yyMdH4E9k1aSflbMsjQntsUQ4pAdD5wF3IFb+uIJnFNmZFqRQrosS8GPf7zychuFWHttOPBAt5VTIXbfvXHdleAcsvnz4eab665tsgkMHdq48KJkHOG//hUGDWp6eIZhlAVdrixfmqJlcVKMtZC1PPI6ZCJSDTyoqtuVSU9lkXHIKml8UuvWcNttpY9nzTXdsh6jR9ddW399ePfdpodt48IMw2jm1GqttY61MPJO31DVGqBWRLrms2uxZFpqkmohSzNnnQUffeQmPnz4oZutGTLmK4RMvptDZhiVh60LG4Si1jrWwgjpspwPTBWRJ4AFmYuqekLJVFUKSXdZppmqKjd2K0PXrvGNKbPFXg3DaOaoqrWQtTBCftHu8YeRTSV2WSZFnIP8rYXMMCqS9oPa07t776RlVASK2hpkLYyQlfpv9ntZrq2qM8qgqXKwFrJw4nLIXn4Z/s/PKTGHzDAqiq7bd2Xj/hsnLaMiqNVa67JsYRR0v0VkT2AKbj9LRGSIiNxfYl2VgY0hCycuh2zCBPd68MGwyipND88wjLKi2cv0GDmxLsuWR0h76DnACOB7AFWdAqxTMkWVhHVZhhOXQ5Zxgm+6Cezfo2FUFF/+40sePfPRpGVUBNZl2fIIKe1lqjo361ptKcRUHEuWuFdrIStMVRXUxlBtli51g/mr7EFlGEbzRdVmWbY0Qgb1TxORXwHVIrI+cALwQmllVQhLl7rWMfvSFCbOFjJrkTQMo5lj65C1PEKaGY4HNgKWAP8C5gJjSqipcliypPFbC7U04nLIli61FknDqFAEWbElkJEfW4es5dFgC5mItAOOBtYDpgJbqarteRFlyRJzDkJpqkP2zjtwySXwwguW54ZRqZh/EYyqjSFraeQr7ZuBYThnbDfg0rIoqiSWLrUWslCqq90m6GefDe+9V/zn77nHDeRftgz22CN2eYZhlJ5OQzrRd+u+ScuoCKzLsuWRbwzZIFXdBEBEbgBeKY+kCsK6LMMZNMgNxj/vPJg7F8aOLe7zmQkUH3xgY/YMo0Lp+qOurN97/aRlVATWZdnyyNdCtixzYl2VDWBdluHst59r3erRo27pimLIjB2zB5RhVCy6TFm+xH5OQrB1yFoe+VrIBovID/5cgPb+vQCqql1Kri7tWJdl8VRVNW4smQ3mN4yKZ/bVs5nYZiL8Mmkl6cfWIWt5NOiQqWp1OYVUJNZlWTzV1cWvR1ZbCxMnus8ahlHRLKlZwhMfPJG0jNTzydxPrMuyhRGyDpnRENZlWTyNaSGbMAEmT4ZVVy2NJsMwykJ1VTVzF89l59t2TlpKRbDuKusmLcEoI+aQNQXrsiyexrSQffute73zzvj1GIZRNjZZfRMWLV/EP379j6SlVAT9uvVLWoJRRswhawpLlkCHDkmrqCwa00K2eLF77dcvdjmGYZSPNtVtaFPdhpFrj0xaimGkDnPImsKcOdCzZ9IqKovGtJBllrxo1y5+PYZhlI3Ro0cnLcEwUos5ZI2lpgY++gg23DBpJZVFdTUsXAgXXADz5oV9ZvJk92rdw4ZR0ZhDZhgNYw5ZY8k4E5tumqyOSqOqym1/dO+9bpPw0JmTG24IXWylFcOoZL7++msAevTokbASw0gf5pA1lvnz3eu6NgumKKqr6/Lu2Wdhyy2T1WMYRtnYZ599AJg4cWKyQgwjhdiqc40lM/OvU6dkdVQaVVWwYIE7tzFhhmEYhgGYQ9Z4fNO7beVTJNEuSnPIDMMwDAMwh6zxZPZjXHvtZHVUGpmxI9XV0L17sloMwzAMIyXYGLLGklkbq337ZHVUGvfe62anrroqrLZa0moMwzAMIxWYQ9ZYMg6ZdbsVR6dOsMkmSaswDCMBjjnmmKQlGEZqMYessZhDZhiGURT7779/0hIMI7WUfQyZiPQRkadF5G0RmSYiJ/rrq4rIEyLynn9dpdzaimLRIvdqXZaGYRhBfPrpp3z66adJyzCMVJLEoP7lwO9UdRCwJfB/IjIIOA2YoKrrAxP8+/RiLWSGYRhFcfDBB3PwwQcnLcMwUknZHTJVna2qk/35PGA6sBbwU+Bmb3YzsHe5tRXFnDnu1RwywzAMwzCaSKLLXohIP2Az4GVgDVWd7W99AayRlK4gLrzQvdr+ioZhGIZhNJHEHDIR6QTcDYxR1R+i91RVAW3gc0eKyCQRmTQn00pVbubOda+bbWYLwxqGYRiG0WQScchEpDXOGbtdVe/xl78UkV7+fi/gq1yfVdVrVXWYqg5bLal1rDIO2WGHJRO/YRiGYRjNirIveyEiAtwATFfVv0Vu3Q8cClzsX+8rt7ZgMgP6V0n3RFDDMIw08bvf/S5pCYaRWpJYh2wkcDAwVUSm+Gtn4Byx8SJyOPAxsF8C2sKwGZaGYRhFs+eeeyYtwTBSS9kdMlV9Hmho4NUO5dTSaJYsca/mkBmGYQQzY8YMAAYMGJCwEsNIH7ZSf2OwFjLDMIyiOeqoowCYOHFiskIMI4UkuuxFxbJwoXs1h8wwDMMwjBiwFrJiUIV33oH58937zp2T1WMYhmEYRrPAHLJiuOYaOOaYuvfmkBmGYRiGEQPWZVkML79c/33v3snoMAzDMAyjWWEtZMWgWZsHtG6djA7DMIwK5Mwzz0xagmGkFnPIiqG2NmkFhmEYFcuOO+6YtATDSC3WZVkMn31Wd/73vyenwzAMowKZMmUKU6ZMSVqGYaQSayErhs03h6eegpdegi22SFqNYRhGRTFmzBjA1iEzjFxYC1kxZNYdGzEiWR2GYRiGYTQrzCErhsWLnVMmDe38ZBiGYRiGUTzmkBXD4sXQvn3SKgzDMAzDaGaYQ1YMixbZdkmGYRiGYcSODeovBmshMwzDaDQXXnhh0hIMI7WYQ1YMmTFkhmEYRtFsvfXWSUswjNRiXZbFYF2WhmEYjeaFF17ghRdeSFqGYaQSayErBuuyNAzDaDRnnHEGYOuQGUYurIWsGKyFzDAMwzCMEmAOWTFYC5lhGIZhGCXAHLJisEH9hmEYhmGUAHPIimHRImshMwzDMAwjdmxQfzFYC5lhGEajGTt2bNISDCO1mENWDDao3zAMo9EMGTIkaQmGkVqsy7IYbFC/YRhGo3nyySd58sknk5ZhGKnEWshCUbUuS8MwjCZwwQUXALDjjjsmrMQw0oe1kIWycKF77dgxWR2GYRiGYTQ7zCEL5X//c6+rrJKsDsMwDMMwmh3mkIWyyy7uddq0ZHUYhmEYhtHsMIesWHr2TFqBYRiGYRjNDBvUH8qhh8LNN8NppyWtxDAMoyK55pprkpZgGKnFHLJQbr45aQWGYRgVzYABA5KWYBipxbosDcMwjLLwwAMP8MADDyQtwzBSibWQhaCatALDMIyK569//SsAe+65Z8JKDCN9WAtZCM88k7QCwzAMwzCaMeaQ5eP++6FtW5gyxb0//PBE5RiGYRiG0TwxhywfrVrB0qXwhz+497/+dbJ6DMMwDMNolphDlo/MRuKZbZOqLLsMwzAMw4gfG9Sfj+yNxM0hMwzDaDS33npr0hIMI7WYQ5aPVlnZs/nmyegwDMNoBvTp0ydpCYaRWqzJJx9Rh+yGG1Z20AzDMIxg7rjjDu64446kZRhGKjEPIx9RB2zYsOR0GIZhNAOuuuoqAPbff/+ElRhG+rAWsnxUV9edDxyYnA7DMAzDMJo15pDlI9pC1rp1cjoMwzAMw2jWmEOWj4xDtsYayeowDMMwDKNZYw5ZPkTca/byF4ZhGIZhGDFig/rzsXixe23bNlkdhmEYzYC77roraQmGkVrMIctHZs2cCy5IVodhGEYzoEePHklLMIzUYg5ZPjp1AtWkVRiGYTQLbrrpJgBGjx6dqA7DSCM2hswwDMMoCzfddNMKp8wwjPqYQ2YYhmEYhpEw5pAZhmEYhmEkjDlkhmEYhmEYCWMOmWEYhmEYRsLYLEvDMAyjLDz88MNJSzCM1GIOmWEYhlEWOnTokLQEw0gtqeqyFJFdRWSGiLwvIqclrccwDMOIj3HjxjFu3LikZRhGKkmNQyYi1cCVwG7AIOCXIjIoWVWGYRhGXIwfP57x48cnLcMwUklqHDJgBPC+qn6oqkuB/wA/TViTYRiGYRhGyUmTQ7YW8Gnk/Sx/zTAMwzAMo1mTJocsCBE5UkQmicikOXPmJC3HMAzDMAyjyaTJIfsM6BN539tfq4eqXquqw1R12GqrrVY2cYZhGIZhGKVCVDVpDQCISCvgXWAHnCP2KvArVZ2W5zNzgI9LLK0H8LXZlNQmTVqaq02atDRXmzRpaa42adLSXG3SpKXcNuWgr6rmbk1S1dQcwO44p+wD4A9J6/GaJplNaW3SpKW52qRJS3O1SZOW5mqTJi3N1SZNWsptk/SRqoVhVfVhwJZyNgzDMAyjRZGmMWSGYRiGYRgtEnPICnOt2ZTcJk1amqtNmrQ0V5s0aWmuNmnS0lxt0qSl3DaJkppB/YZhGIZhGC0VayEzDMMwDMNIGHPIDMMwDMMwEiZVsyybCyIyNMBsmapOLbmYCiQw/9YD3i9gU7Y8tjI3DKPSqMTnViVqDsXGkEUQkR8KmQCLgIsL2F0IvODtG2JbYH6BuDoACwrYCPBUAT27AovLENdugOaJKzSejsBECudfiE2hPI4r/0I0bwE8WSCunsB/8tw/DKgh/4LIQ4ApBeIJSVNI3hTSC7AV8GIBm0MpvMhzuerxCGAp+fMwJN1xpSmuckhTHq8DLCS/5nLWm5A8HkLh71WITbnKPORZsRvwHPmfW4OBCwpoCSmHuJ4VIb+vIZoXqOo1BWzKirWQ1ecDVd0sn4GILAM6kb8y1Krq9gXCmaeqXQrYLAywWQz8NZ8JsFOZ4hoILFXVjZoYz7yA/Ps2pjyOK/9CNC8MiOsJ4EEarl+9cD9kJ+QJ47GAeELSFJI3hfQC/AyYWsBmIA2nKRNXuerx7bgfsoZsQtMdV5riKoc05fE9uDzunMemnPUmJI9Dvldp+u6FPCu2D3huLaHwb15IOcT1rAj5fQ3RfDSQKocs8ZVp03QA6wTYXBNg8+eY4to2wOa4mGyaHBfuX+9+McRTMG9iLM+48i8krrx5423uKxRGofoF/L2M6c6r19u8HFM45arH+wXU4xC9caUprnJIUx7/OSCPy1lvQmz+HpNNWco88FkR8kwK+T2Lq/6FlHmInlhsyn1Yl2UORGQNYC3/9jNV/bIRYXTFNU2vCAd4TFW/LzauOPSUM6444gnJvzjzOI50hepJE3HlTTkp53emXKRNr+Vxy9FToc+titMcgjlkEURkCHA10BVXwAC9ge+BY1V1srfbBdib+pXhPlV91N8/BDgbeDwrnJ2Ac1X1lpC4Am26Aqd7PavjxnB9BdwHXKyq35crLqBfTPGE5F9ceRxX/oXoKRgX5K9fgXrjSlOT9fr3Id+ZNNVjjSPdaSuHNOWxjytN9Sau71VqyjxQS8HnVlzlEBJOYFyxaE4lSTfRpenADcbcIsf1LYE3/PlY3H6bBwDb+OMAf+0ybzMD6JYjnFWAd4uIK8TmMeBUoGfkfk9/7fFyxhVjPCH5F1cex5V/IXpC4spbvwLDiCtNTdZbhE2a6nFc6U5bOaQpj0P0pi2PK+q7FxhGyHMrrnKIq8xj0ZzGI3EBaTqA9/Lce9+/vtvAfcl8HngX6JrDpmvEJiSuEJsZeWxmlDOuGOMJyb+48jiu/AvRExJX3voVGEZcaWqy3iJs0lSP40p32sohTXmctnoT1/cqNWUeGgYBz9qYyiGuMo9FcxoPm2VZn0dE5CHgFuBTf60PcAiQaeZcLCLDVfXVrM8Op24q85+AySLyeCSctXFNqucXEVeIzccicgpws/oxCH5swujIZ8oV19sxxROSf3HlcVz5F6InJK5C9Wt2QBhxpSkOvaE2aarHtTGlO23lkKY8Xj1l9SYknLhsylXmIc+KkOdWXOUQ17MiLs2pw8aQZSEiuwE/pX6/8/2q+rC/PxS4Cjdde5a36QPMBf5PVV/zdqsAu7DyoMPvQuMK1LMKcJq3Wd3bfAncD1yiqt+WM6444iki/5qcxzHnX149gfmXt34BHwaEEUua4tCrqq8F2qSmHuPGv8SR7rSVQ5ryuF+A3rTlcSw2Mepp8rMiEle+51Ys5RDXsyIuzaQQc8gaiYj0pP4MmS+S1GM0LyqtfoXorbQ0hZC2NKVNTyFaar2Jk3LlT1zxlLPMK67ulKtvtNIP4MiYwrk2jrgCbYamJa4Y4wnJv7jyOK78C9FTMK6Y9MaVpibrjTld5arHsaQ7beWQpjyO6yhnHlfady9QS8HnVlxxxVjmsWhO6rDNxcPJt+KvMxCZHBDONXHEFWhzTIriiiuekPyLK4/jyr8QPQXjCqhfIXrjSlMcekO/M2mqx7GkOyQcylgOIeFQpjxOYb2J63uVpjIP0VLwuRVXOcRY5nFpTgTrsjQMwzAMw0gYm2WZhQQuJid5VlmWMi6SF4lvV1Ye4Ph9keE0Oa444gnJv5jzuMn5V4SegnF5u0L1q5DeuOpEk/WG2qSsHseS7rSVQ5ryOERvmdMU1/cqNWUeWM8LPrcKxROX3iLSFIvmtGEtZBFEZCywAW46cmZmRm/cdOT3VPVECVtl+THgKdwU4C982D2BQ4EdVHXnwLhCbEJWiC9LXMDQmOIJyb+48jiu/AvR0+TdBYCNA8KIK03l3HEiTfWYmNKdtnJIUx6/GaA3bXkcl01cevLmD2HPipDnVlzlEBJOiE0smkkjxQw4a+4HYYvSTSFg1fY8ccS+oCaFVy0uS1xxxhOQf7EtlhlT/gVpDogrb/0KDCO2NDVVbxE2aarHcaU7beWQpjxOW72J63uVmjIP1ZtLS/RejOUQW5nHoTmNhw3qr89iERme43p0MbmOqvpytoGqvgR09G8/FpFTfHMp4JpOReRUshbJKxBXiI3gmmyzqaVugGi54oornpD8iyuP48q/ED0hcRWqXyFhxJWmOPSG2qSpHseV7rSVQ5ryOG31Jq7vVZrKPCSMkOdWXOUQV5nHpTl12Biy+owGrhKRXIvJjfbvQ1ZZ3h+3SN4zIpK9SN5+RcQVYvMnCq9aXK643owpnpD8iyuP48q/ED0hcRWqX68GhBFXmuLQG2qTpnqsMaU7beWQpjwemrJ6ExJOXDZx6YnjWRHy3IqrHOJ6VsSlOXXYGLIcSIHF5ERkd2Av6g9erLeSdVxxBerJu2pxueOKI544KWf+BWgJyb+89SswjFjSFIfeImxSU49jTHfayiFNeZyqehPX9ypNZR6qpRBxlUNcZR6X5rRhDlkW/kuCqn4hIqsBPwLeUdW3iwhDgH1x/7TvArbHbSnxDnC1qtaGxtUYPSKyqvptMYoJJ4644ognJP/izOM48i9UT0hcxRISRmPrRCn0hpJkPS72fihpK4c05XFclDOPK+27l+N53ajnVmPiiotSak4cTcFAtrQcwFHAR8BM3GJ2LwM34AYsHu5teuL2yLoS6A6cg+uqGw/08jbjcBXlfuA24E7gYOA/wGVFxBViMxKYDkwDtgCeAD7ANdNuVc64YownJP/iyuO48i9ET0hceetXYBhxpanJeouwSVM9jivdaSuHNOVx2upNXN+r1JR5YBghz624yiGuMo9FcxqPxAWk6QCmAh18Ac4HevrrqwBT/PmjwPG4Puw3gVNxfdPH49aRAZjqX1sD3wBt/PtWwJtFxBVi8wqwCe4h9zWwjb8+FPhfOeOKMZ6g/Ispj2PLvwA9IXHlrV+BYcSVpibrLcImTfU4rnSnrRzSlMdpqzdxfa9SU+ahWgKeW3GVQ1xlHovmNB6JC0jTAUyOnL+Rde/16Ks//yTLZkoOm0cbsAmJq1g903Olp1xxlSiehvIvrjyOK/+K1dxQXHnrVyPCiCtNjdLbSJuk63Ep0p22ckhTHqeh3hSbx6n/7jUijJDnVlPKoRRl3mjNaTxs2Yv6qIi09uc/yVwUkXawIq+ieXZL1ucz974QkU4AqrprJJyewNIi4ipWz+lZetqUOa644gnJv7jyOK78C9ETEleh+lVsGE1JUxx6G2OTdD0uRbrTVg5pyuM01Ju4vldpKvOQMIp9bjWlHOIq87g0p4+kPcI0Hbhpuq1yXF8L2NGfnwd0ymGzHnBXgfA7AqtH4mpdIK4Qm72ADjls1gVOKWdcccUTkn8x5nEs+ReoJySuvPUrMIy46kST9RZhk6Z6HFe601YOacrjtNWbuL5XqSnzkDAaOqj/3IqrHGIp87g0p/GwWZYlQsq4B2ARmsoSVxzxhORfnHkcR7pC9aSJuPKmnJTzO1Mu0qbX8rjl6KnQ51bFaQ7BHLJGIIU3mj6Epu3rdYyqvh5o05XCG3GXJS6gX0zxhORfXHkcV/6F6CkYF+SvX4F640pTk/X69yHfmTTVY40j3WkrhzTlsY8rTfUmru9Vaso8UEvB51Zc5RASTmBcsWhOJUk30VXaAYwFHgYOALbxxwH+WmbK7QzKt6/XY7gZJD0j93v6a4+XM64Y4wnJv7jyOK78C9ETElfe+hUYRlxparLeImzSVI/jSnfayiFNeRyiN215XFHfvcAwQp5bcZVDXGUei+Y0HokLqLSDwM13ga45bLpGbN7LE8f7RdiEbLRalrhijCck/+LK47jyL0RPkzdEDwwjrjTFtYF7XJuzl6sex7ZxfcrKIU15nLZ6E9f3KjVlHhoGAc/amMohrjKPRXMaD9vLMgARuRlYiFtkbrGIDFfVV7PMhlO3MeyfKN++Xh+LyCnAzerHIPixCaMjnylXXG/HFE9I/sWVx3HlX4iekLgK1a/ZAWHElaY49IbapKke18aU7rSVQ5ryePWU1ZuQcOKyKVeZhzwrQp5bcZVDXM+KuDSnDhtDFoCIDMcV+AjgDtwKwJ1ZeWPY/1PV1/xn4trXazfcthA5bXw8p3mbNbzNF7hVjC9Rv3VFoXAaEdfquH8b9eKKI54i8i+uvd6iaYK6jWqLzb+Q/RHzxiUiQ8lTv4APA8KIpU7EoVdVXwu0SU09xo1/iSPdBb8vcehtpJ6k87hfgN605XHI9yE13z0CnhWRuPI9txpTDkXrDS3zuDSTQswhayRSxs2xs+JdXVW/KkdccRCHXhHpAqwPfKhFboqbFE3VnFT9aiwheistTSGkLU1p01OIllpv4iSO/JGwWbWxlENcZV5OzWWjFP2glXrg+qAvxm1S+i1uW4bp/lo3b9MG78j699sBvwN2jVzrg9tX6zngDCJrzgD/9a/Dgadxe3H1we399T3wKrCZt1k1xzETN3hx1UiYu+D+Ddzvj6uy9BwH9PDn6wLPAt/h9lDbxF+vxu2xdj6wdVa+nBnR80fgcNw/yDOAB4G/ZDQV0hvJ4+l58vi2iN5dgE+AJ4GPgX3jzOMG6sFTDdSLJmn29zYEdgA6ZsURLa8fAwP8+Ujg98DuoXrjqhOl0uvtLiyFZmKox0XkcVdgf+Akf+xPZLAxbk+/Lv68PXAu8ACuhahrKfVWaB7n0pv2PK6o7162XmAI8BLuefYE7pn1jr821NsU/M0r57MiTs1pO6yFLIKIPAY8hesH/8Jf6wkcCuygqjuLyBvAKFX9TkROBn6Gm7mxLTBJVU8XkSeAu3EV5HBgc2BPVf1GRF5X1c1E5BXc1N1uwJ+B36rqXSKyA3CBqm4lIrW4H/QovXFNsKqq64jIWGAD3HiEWRGbQ3CDF08UkWmqupFPz0PA9ap6r4iMAv6kqiNF5Hrc/mqv4DZqfUZVT/KfmayqQ0XkYdw+bF2Agf58PK7vfjCwZ4DehvJ4NLC9z+OpqrqJv/cC8CtVnSkiPYAJqjo4xjx+M7sa+PycgRO9aYyaT8B1JUzHPVROVNX7svJ4LK5rvBVu5tIOwCO4+vU67mFfSO9Y4qkTTdarqieLyOWszCFeH6p6Qsrqcf+APA5Z5mQaMFhVl4vItbhxqHf5PBqsqj+PQ6+q/rQC8zj7OZFLb9ryOORZEVcel+tZMQU4SlVfrmcosiVwjX9uhfzmlfNZEYvmHPEkT6k8vUo8CJsp8lbk2iSgvT+Pbmw6JeuzBwHTcP+GQvb1et2//g43yDP6r+mjLNuiZsAAr2bZvRl9jaTlWuAeoG1Ez5RI2J9lhTMlUG9IHk+j7l/v80BVxGZazHl8P651a0OgL25sy6f+vG/MmqfiV4/28UzCPbiieqb5/O2A+9fcwV9vDbwVqDeuOtFkvf78U6/5ENyfm0OBOZnzFNbjoDpB4an30yPXJ2fHE5feCs3jEL1py+OK+u4F6g2Z8Rnym1fOZ0UsmtN4pHdPp2T4WERO8X3TgOunFpFTqZvN8YOIbOzPvwba+fNW1O2R1VrcvmQAqOptwIm4fwW9/OXFIrKziOyL29tsbx/ftkCN/9xfgd8AfxSRv4lIZ9yA4yiLxU06yCY6m+QuEblJRNYB7hWRMSLSV0R+jetag7r9xlDV5ap6JO7B+RTQyd+qEjeYsg/QSUT6ec3dgTaBekPy+FzgaRE5DPgfcKeIHCoiN1E3CymuPN4L19J2Le6f8Exgmap+rKqZf/Fxaa5S1fk+3pnAKGA3Efkb7kHlb6kCtZn3/rXWfz5Eb1x1osl6/fkg3HdlV+AJVb0ZmKeqN/vzODXHUY9D8lhYuW5n0p3Jm7e8NoA3RGSYj2cDYFlcer1NReVxoN5U5XGlffcC9T4iIg+JyP4isrU/9vctd5nnVshvXjmfFXFpTh9Je4RpOnD/vC6hbgzZt7gm2EuoGwO1KfAGrgn1FuAD4EacF/4rb/NbYNsc4W+Gq2Tgmu0fwzXZbohbyO973L+IkTk+uxeue+6LrOtDcWMP3sY17T/uNb8EbB6xG+3tvgbmefsLqRtncRs5+tdxDtYyf/5L3MyZL4Ff4Prun8R1JxwZqDc7j7/LzmNvt56/di9uTMhVwC6R+03N4+yxJB2Bv+FWlp6VR/N3TdD8FDAkK+xWvh7V+PeX4MbFvYobv/IA8AdfrlcH6o2rTsSm19tujhvT93tgZtrrcYE8PhT33b8KN97oDNzq6x8Ao71NV+Amf+1lnIPwIfAM7geyKXqfyNZbAXm8kuYCetOax/nqxeYx5XFZnhX+/m4+Xx/wx9VExnUR9ptXtmeFv797UzWn8bAxZI1ARKqBnXH98a1wYwVKvo+WiLQH1lXVt3LcK8tsEp92UTdmoxVuvMBnqjq7GL1pRUQGA1up6tUlCLs3sDxX2YjISFX9nz/fCvdv8iURWRc3/uET3Ka4tVmfa1BvU+tEifQKcKzXfFDcmkMpsh7nzGMJWHbF23XBjUtrhftBXGk2WMx6KyqP8+lNax57+0r77jX62VboNy+JZ0VTNaeSpD3CSjnwszdiCOePATa/jpxnZq50yrKJzlzpid+yAlgN+DkwKMt+BDDcnw/CzVgqNLvllgCtK82Mitzbxsezc+RayKyon1HXIrkacDNujMIdQG9//W/kaEnMiv+EjH0Bu1wzf36SZbOOv36Zj/voTDoiNtsB/8D9E70HNwtzvSwb8Xnwc39sQWQ2UMRuDVyLxlBgjcC6tWHW+9Y5bHpEzrvgHOZsm00j51X48XC4rpuhRFoFG9CR97632avA/U4+rm55bPr7PNwwcm1toF0kr38NXAEcA7SKpCPXDKzdstNfQGOrLL3DstPu9XTz5/2AfYCNc6R1H1yr7wm47pqqHPEN89+NvbLLuin1JlfdacBmp2LqTkgdjLveeJtjC9xfqd6E1L9C9Sa07vjyaxdgF1J3Qupgg/WGgBnk2WUUUk7ZeVmMfUB4PXGtplcC3YFzgDdxkzB6xRlXuY/EBVTKAVwXUzifhNr4h/MM4L+45SN+GrHJDFw/CvjI3z8G1wx+g//c4d7mbFyT+STgIlzz8lm46dZ/8Db3Zx0PAPMz773N5VnHFbguwMz7VyL6jsCN0zgbN6bqNH99GnU/jNfi9hzbxtvd46+/HQnnDtwPVW9cM3+mO3KOT8/HuBmUKy1jgVsE8HNcM/mxwGo5bMYCL+BmYJ3vz8/CdVn8JVIOTwBn+vtX4laLfhs3kwefrzfiJhfchWuSPwI32ymzVMfOwPu4LtTr/fGov7aztxlC3ZTuTFdavSndAfVmO9y/wa9x3QH9ctSb/XzeTPFlMjyHzd64LpzZuAUfXwYm+LD39DYjvdZpOOfyCVz3wKe4f7ZQ53xGjy8y595mXCT+bXD/mp/24ezur/83YvNTXL2/EbeVymh//S3qBgtf4sviIOCfwD/99TfwSxkAJ/syPdNrvwg3vvA9Xx8GNZDXo3E/Xu/iunw+9HnzKfBLb3Oa1/gOrnvsHdx3cxpwUqQcXvF14QPgVuB23A/Mpt5mW1xdfxLXXf4g7js1EejT1HrTiOdSSN3JWwdjrDcn5Ti+zpwXqDczIvUmpP7lrTf+ekjdWeQ13orreqvOYRNSd0aTpw4G1pvHyL0H5WnU7UG5Nm6Joa982t735/+JlmsT69ZU/xqynNGjwPFe45tefx9/7T5vsyHuOfsQbqLXTbjfqleAgYX0JHUkLqA5HsAPDRzzcM26+IqU65gKLPE2ITNXpuJmrXTHOVCZlrJVqJsdNBW3Fk8HryPaQpWZJTMZN9ZilP8ij8L9EG+LH6tFgRkw1J/V+CreAcKNYch84UJmRUVnIb3WgE0m/RvgHKhpuIfW2cAGGRtcC8/OuIfZHP9lPhTo7G1CZv5MxT80vd1Ef752tBwiGlsB/4uUQyac6eR4gOH+sU/PpI88Gw+zslMcdY5/iOT9Rv58H9xDdMusfJuC/zeJaz19B/hZls3ruIdzf1y9ybQi9sVNHQf3gNsE2Ar3I7ONvz40kgfLcD8G/8T9EN6I+y7cSJ2TNDmS1qepW09onUhc0fr1AtDfn/egblPmqDP/GvVnu2Zs8s7A8uneGOd0v+/z/TTqOxVTfbyZvFnXX1+Duu/UNNx3rLtPb/T7kKkTb1JX53rgulTAjYF5IVIOmc/2B+715ztR3IbVIXUn+49Z9A/agiLqTt46SHz1Zh7uT9sfcd/9s3Hf47OBs4uoNyH1L2S2YUjdeR33XDgC50B9iRsDtW3EJqTu5K2DhNWbkBnkL+LWf6uO3KvGbdb9kn+fyzE+CdeC+K23yeVg/xw3Zm+Ot3kC1/swBFcvXwC6Zz+XIjqyZ89nfh+exS3D9Evcn/YDcM/5PXHLECXuJ+TM86QFpO2gwEKEgWF8QgPdBcCn/vVLX+n6Zh39gM+9zbSsz3bCORR/i1S86IPkjSz716Ov2ef+fSacKlxL1BP4wZm4Veajtp1xLUr/AtbMtsH/g8Q9RCY1oOVOfJcs7sE6zJ9vgJ8CDlwDnId7IP2Vuof9drg1hOqlOxLHprgWjvdz2eCcrL2Af0ceAJmHWzvcgzzzkK3G/7jjHnxt/fkq0bRFPv8Gdd2sa+MfVNFyxP0otcqhuw2BGzfjHs5HUucER4+vG6gHG+FaA/amrgVjapZNL5wDcwK5lw15K8s+l830BmyG4354jonc+yiXrT/PdsIn57B5JcsmU78ew60NB26GWV9/3p26H98X8F0/uO9TptWjHa6FLbvejMB952ZR5yRNidz/PMv+zazXalyLQtQ5jP6oZsbyts+V59RftqE6Kx9W1K189ca/htSd74Cf4P+IRY5RwJdF1J28dTDGerM27plyCXWObfZzK6TehNS/vPUmO5w8dSfbpqfPuxep+30IqTt562BgvXkcOIXI7xXOoTsVeDKgbmWW8liMaxU8O8fxvbdZhmupujHHMS87Tf59ruWM3ojcv6CB7160fr3fUH1I29EKYwWSeyHC7YALReRcVb0lz2cvxHWRXY+b1dEX53Rl8y//+iCu9WtKjrAm+tMvRWRIxkZV54vIHrh/jJt4GxWR1qq6DPcgzYTRjrrpvUtFpIOqLsTNXsnYdMVPQVY3oPLvInKnf/0S6tcPVZ0HjBGRzYHb/TTjqohJV9yDWbyuXqo6W0Q6UTf1+TfAZSJyJu6f8Ysi8imu9e033uY43OybGf79b0VkAe5f+sEZ+dn5pqqZVsbTc9n4PLofuF9EOvjLD4nIc7iH6vXAeBF5Cfcj9Ky3uR54VUReBn6Ee/gjIqvhxl2AmyH1uoi8CwzAdR9nbN7wNv/04fyH+psKH4BrwYPCGw8Pwj2QX8hOv4ic40+XiUhP9QNsVXWauMVwH8Q92ADmici6qvqBt5ktIqNw3eMbRcKs8nXjsMi1auqWEoiWf/Zii5nlAl4VkZ2A40XkadzDXrNsNxS38KYA/URkFXWLOlZF4hosIj94m7aR+tUG94MDrg7d4vNiLjBF3EKS3XB/sMD9A79d3OKRXwGTRORZ3HfqQlx31ApU9RXgFRH5HW68IcAnInIR7k/KOyLyV9y4wR1xLcvgNkD+F65VYwJws4g8CmyP6+4Gt1jloz7+XXHOBSKyKnX1d5KI3IAbarAXrssJX4cz6Q7ZsPpVCtedl4CFqvpMDpvM9zGk7hSqgx9Ggm50vVHVT4B9ReSnwBMi8vds3YTVm5D6V6jewMrPnFx1J9vmC3xrpYj09ZdD6k6hOvhZQL3ZH9eC94yIZO9BuZ9//5qIjMON5Y3WrUNxrXDgnOz/ao49IkUk81x/E7hUc09K29GfthaRdqq62OfNbSLyBe6PVkdvc5+IdFLV+ap6ZiSM9XDdt0TSB84hjtKGtJK0R5img4CFCPN8dm9c82zBgfBF6OlNpG8/695I/7o2uVtd1gJ29OdtGwijB5FFXLPu/YT8A/YFtzLzbQHp6IDvJohc64JblmJz8gw+xjl53XNcLzhQFN91GWC3FXXdKeviBu/vR/1/pRvhul7yDQReFTeAdqU6FLEZiHsAXuGP01h5AkaD09B9HB0KpGdH/JT/HHmZGTM4mKwJB/56a+BAfz6cHIOPca24B/nzvXLp8fl4So7ra+IG32a3YvTNOlpH6ujPC6S3G37cUVY+/xTXHbIFWYPkcQ/s3XBr1/2OSEs4AdPiff093ZdfJx/Pg7jxhZnuvFa4LpMD/PnWuEkfpxDZXgY3juj31B80X0Vdq2xr3BjIf+C6uTLd5+3xLYCF6k1o3Qn8vgwG1i9Qd/LWwUbUm7Vy1Zssm464sZvPBqZjRb0JrX/56k0RdWdUgE3BulOoDobWmwAtbXB/MB/FtehO9efHRuroAHKM0fX31vCvPwLWbsAm01NScDmjQM1HkeM3Arc00dimfgdKddiyFxF868ZwVZ2bdb0rrptq/WSUGYZhGEa8+KUl9sW1PN6Fa4H7KW5c4NWatRRFGqhEzaFUFTZpUfwJ11R8lYic4Y+rcc2xfwIQkVYicpSIPCoib/rjERE5WkRaJ6reqFhE5JEAm2tjCCPEZmpM4eTVW4RNXJqbnK4Y0x1rOYhItX8unS8iW2fZnOlfu4jIRSJyq4j8KstmnH/tIyL/EZHn/POvdcTmv0XY5I0rS+/IBvSG2MSVppBwuojIxd7ml3lsyqUnb/6EhIFrTdsPNxTkVly37Ku47tW/e9sO4nYqOVlE2onbgeR+EfmzuOEoiEhP/7t5pYh0F5FzRGSqiIwXkV4NhDM6RzgFbRqpOVc4qcNayLKQAgsRisi/cdNnb6b+5rGH4gZ1719WwUbFICJDG7oFPKiqvcSNHWrI5g1cV0+hMELi+Xkem6tVdbU49Kpq70CbuDQ3OV1ExmLm0VLONIWEE7KB9t24iSUv4cYELsN1sS2J2DyBmwzxEnA4bkjBnqr6jYi8rqqbBdrkjQv3J7eQ3nKmKSScuGzi0pM3f3DLZhQKY6qqbuKdwi9w3e1LxS2MO1ndBuTjcWPH2uO6JqfjZrbuhRtSc7C48W0P4bqNf4VbuuVfuKE8O6rbnD0knBCbWDSTQswhiyAiogUyRETeVdUNir1nGCJSg9vSZaUJCbgxbO29zcdZNurfr4UbwxISRiGbZbiHZq76vo+qdo5Dr6q2KcImDs1NThduzExc6S5XObypqpuCa8UHxuHGP/0SN+N3MxGZoqpDMh8UkT/gxq/thRufMzSHzUG4cUp7AXc2waZeXLhxr4X0JpmmkHDismmsnrz5g/t9LxTG66q6mb//qKruGrGfoqpDIq+CmyzQS1XVv3/DO0DRcD5R1bUbGU6xcTVaM2lEUzCQLS0HbhbK8WQNPMQ9oLfHtYp9gOu/jg74rsIN7ny5QPjT/XFcHpsncQva7dFEm5txqxlvnHRcMcYTkn9x5XFc+bdCD25JhZUGQ3u7zHT397LrX9QmMIwQm9fylFcx4eTVW4RNXJqbnK4Y013Ocngnx70/4hYCzSxNMJ2VJzeMxi0r8LF/P42siRy4AfrvA7OLsMkbV6DecqYpJJy4bOLSkzd/AsN4hNyD33vilwih/vIa/8yyeyP66s8bWooiJJwQm1g0p/FIXECaDtzSB8f6Cv05bnrxR/4Bch1upkc/XNPnHNwU23dxU6DvIGsmYQNxdCdrW56s+2vimrD/r4k2w3Gzbi5JOq644gnJvxjzOJb8i+rBzdIc0IDN3v71/8gxO83fOz4wjBCbkBlPTdZbhE1cmpucrhjTXc5yCNlA+8/4mddZNrtS5+AUnOUWaJM3rkC95UxTSDhx2cSlJ2/+hITR0IHrelzdn19PbgdoXeB5f35eAzbr4fapDA2noE1cmtN4WJdlA/j+6R7AIm1gM1IR6Q6gqt80cH8N6m8wm3PDW/HjUVT121z3Q21CKFdcccQTkn9x5nEIcWg2DMNoDoQM84krnHLGlRTmkMWI+IUQRWQIbg2grtQtMNsbNxngWFWdLCJr4/7B7OCvC25dmadw+z7ODLTpiht/sDewOm4syle4Da4vVtXvyxWXt48jnpD8iyuP48q/gnowDMMwjIZIuomuOR3AQ/51CoX3lQvZHyzEpqHNYU+lbr+yssQVYzwh+RdXHseVfwX12GGHHXbYYUdDh7WQlQAReU8bWERWRN5X1fUK2LynqusH2sxQ1QEN2MxQ1QHligs3gDSOeJqaf8XkcTny731VXS/XPcMwDMMAWxi2UYhjCxH5uT+28NNpMzwiIg+JyP4isrU/9he311xmX7nXxC2QuIWIrOmPLcQt2Pd6ETYfi1sAb42IvjVE5FTq9h0rV1xxxROSf3HlcVz5F6InJyIyTETWLGDTS0TaNjGMEJufisgWpdZbhE1cmpucrhjTnbZySFMep63exPW9Sk2ZB4Yx3R/HNTaeuPQWYROL5kRJuomu0g5gZ9z05EdwMzmux/3gvg/sHLErtK9crv3BHqH+/mAhNqvgNrt+B7fR9be46c6X4BaqLVtcccUTkn8x5nEs+RequYE6dTPOsbsjj82TuBm/lzYhjBCbC732R0qptwibuDQ3OV0xpjtt5ZCmPE5bvYnre5WaMg8Jw9sVmq0eVznEUuZxaU7ysC7LIhGR6cBuqjoz63p/4GFVHZiIMKPiEZHOqjovz33BbUQ+rbFhhNqEEJPegjYhccVJQLqanO6QcEJJm54Q8sWVxnoT1/cqTWUeDUMaOTs8rnJoTJmXWnMSmENWJCLyHjBQVZdnXW8DvK0FxgqJyJGqWmhPwj1U9cEYbIZqgdl95YorxnhC8i+uPI4r/1boETerc1dW3prr+4i9ACOybF5R/2UNDCPEZkPcprxRm/tVdXqR4eTVW4RNXJqbnK4Y0522ckhTHqet3sT1vUpNmQeUwRACZofHWA5NLvM4NacNG0NWPP8EXhWRU0XkV/44FXgZuCHg87m2P8lmeEw2x6QorrjiCcm/uPI4rvwTABE5BLeH3yjcHnQdgO1wY9QO8TY74xbOPAe3zcnuwLnAeyKyc2AYITanAv/x2l7xhwD/FpHT4tJbhE1cmpucrhjTnbZySFMep63exPW9Sk2Zh4QB3AScqKoDVXVHf2wIjAFujLkcYinzuDSnksb0c7b0AxgEnAZc4Y/TcE2giWuzI70HMAPoluP6KsC7/nw60C+HTX9/LySMEJt3gdY5bNpQtxJ4k/UWYROX5ianK8Z0p60c0pTHaas3cX2vUlPmgWE0uGI/8H7M5RBXmceiOY1HK4yiUdW3gbclz6rtIrILbrHRaHPpfar6aMSmLF0D5YwrxnhC8i+uPI4r/wrpEXJvIl1LXateK2BWDpvPgNbetlAYIfHU4rZ++jjLppe/F5feUJu4NMeVrjjSnbZySFMep63ehIQTl025yjzkWfGIuJngt1A3q7wPcAh1s8PjKoe4yjwuzanDHLIikbpV27cH5rpLkr1q+1hgA1yFyVSK3sAJIrKbqp7om61/iWu6fiVi828R+Y+qXhxocwhwNm5h1kx/+nbAhSJyrqreUq64cA+UOOIJyb+48jiu/CuoB/gTMFlEHqfuQbI2sBNwvn+f6RL/D/UfNgfgusQ/DwgjJJ4xwARxYyKjNuvhNkIPDaeQ3lCbuDTHkS6NKd1pK4c05XGvAL1py+O4bOLS0+RnhaqeICK7sfKfzStV9eHAeOLSG2QTo+bUYYP6i0REXgTG4jZMrfHXqoF9gTGquqWIvKuqG+T4rOCab9cXkXeBjVR1WZZNG2BaETYzcCvEf59lswrwsqpuUK64/Ns44gnKv5jyOLb8K6QnEu4urNwa913kMwPJ3Rr3dhFhhNhUsfKg11cz9TouvUXYxKW5yemKMd1pK4c05XHa6k1c36vUlHlIGCHEWA6xlHlcmlNHqfpCm+tB/v7rTP//m8DwHPdHAFP9+TtA3xw2fYEZRdi8C3TNYdM1oqcsccUYT0j+xZXHceVfQT122GGHHZVyAEcmraElaK6nP2kBlXbguq3GAVvgxgGs6c/HAeO9zVBci9HbuK6wx3GDDF8CNvc2u1K3wOy1/sgsMLtrETaHAh8AVwFn+ONqf210OeOKMZ6Q/Isrj+PKv4J6CtSrawNszokhjBCbB8uhtwibuDQ3OV0xpjtt5ZCmPE5bvYnre5WaMg8M46gylkNcZR6L5qQO67IsEt9NdTg5mkKBG1R1ScS2Z9RGVb/ICqssXQPljCuueELyL8SmnPkXqjkXIrK5qr5WwGZPVX2giWGE2PRS1dml1luETVyam5yuGNOdtnJIUx6nrd7E9b1KTZmHhBFCjOUQS5mHEFc4pcAcshIhZVxQ09vlXbW4XHHFFU9g/sWSx4XSFKfmNCJ5ZgunlRDNlZautOm1PC49adAjAbPV00Ylag4i6Sa6SjtwM1OPwnVfvemPR4Cj8WvL4KbfZrrBzvRHphvsEG9TcE/MQJshuG6x6cATuL263vHXhpYzrhjjCcm/uPI4rvwL0dMVuJi6fTO/8fFejF/Dh7r69Sg56ldgGCE2a+O63+fgxv+9D3zlr/WLS28RNnFpbnK6Ykx32sohTXmctnoT1/cqNWUeGMZY4GHc7MNt/HGAv3ZZzOUQV5nHojmNR+ICKu0A/o370d0St6xBb39+FX4DVcq7SN4U3CzBbJstgTfKGVeM8cS1AGM58y9Ez2PAqUDPyP2e/trjIfUrMIwQmxeB/YHqiE017sH2Ulx6i7CJS3OT0xVjutNWDmnK47TVm7i+V6kp88Aw3s1+ZvnrQt2kprjKIa4yj0VzGo/EBVTa0VBliN4jbObee0CrHDZtqFttOMgmj56iwmlqXDHGE5J/seVxTPkXomdGnrhWzPrMV78CwwixCZkt3GS9RdjEpbnJ6Yox3WkrhzTlcdrqTVzfq9SUeWAYIbPV4yqHuMo8Fs1pPGxh2OL5VkT2Be5W1VpYMeB7X+A7b1POBTVDVi0uV1yfxRRPXAswljP/QvR8LCKnADerH6Pmx66NjnymUP2aGxBGSDyvicg44OasNB0KvB6j3lCbuDTHka7amNKdtnJIUx53Slm9CQknLptylXnIs2I0cJWIdKZuQes+uEXPR8dcDnE9K+LSnDpsUH+RiEg/4BLcSv3f4ZpJu1G3Uv9H3i5k5t4gYK8sm+xF8kJscq1afL/WrVpctrhijCeuBRjLmX8hi42e5uNaw9t8gZuhe4mqfluofgHfB4QREk/B2cJx6FXVjwJt4tLc5HThVuqPI91pK4c05XGXAL1py+O4bMpS5gQ8K/y1vLPDYyyHkHAK2sSlmRRiDlkTEJHuAKr6TQP31yDPzL2IXdlmM5UrrjjiCcm/OPM4hDg0FxFX3vqVNkL0VlqaQkhbmtKmpxAttd7ESVPyR4qYHR5XOTS1zJPQXA7MISsScXtZfqWqi0VEcE2kQ3ELgl6nqstFZAhuhl1XXJOq4AYVfg8cq6qTJceemLh/jRkPfmagTVfgdOr+mShuxs59wMWq+n254vL2ccQTkn9x5XFc+VdQj68/u9C4DdHvU9V3iggjr42ItML9S1/JBvcvfVlceouwabLmuNIVY7rTVg5pyuPU1Jsi8riivnsBWg5h5b18e+OGWpyrqreExBOX3sA0xaY5bZhDViQi8hYwQlUXisglwLrAf3E/1qjqYSIyBbdi8MtZn90SuEZVB0vYnpghNo/hHIObM022vil3NLC9qu5crriAzjHFE5J/ceVxXPkXomcsuTcgPwQ3mDd7Q/SozQH+Ws+AMELi+TfOWbw5y+ZQYFVV3T8OvbryhvIN2cSlucnpwjnlcaQ7beWQpjz+PEBv2vI4LpuylDlhz4qQvXzjKoe4nhWxaCaNaApmFlTSAbwdOX8NqIq8zyyTEDRzL49NbLOZyhlXjPE0Nf+KyeNy5N+KmZgN3I9O136XHOvk4GZ0vhcaRmNtovfi0FuMTSk1F5OuONOdtnJIUx5XQr2J63uVRJkXEUbXHDZdS1EOcZV5HJrTeFRhFMunIrK9P5+Jm92xop/a84iIPCQi+4vI1v7YX9xsvkzz7WsiMk5EthCRNf2xhbjZN68XYfOxiJwibuwSXssa/h/Cp2WOK654QvIvrjyOK/9C9CwWkeGszHBgsT+vxe2Pmk0vfy8kjBCbb0VkX3EzjzLprhKR/ambhRSH3lCbuDTHka640p22ckhTHqet3sT1vUpTmYeE8Sfc7PCrROQMf1wNTPb3QuKJS2+oTVyaU4d1WRaJiPTBNctW48YTbYNbXLQb8HtVneDtCs1GLMtsJm3azKlZwAMNxLU67t/PiriA+XGkKST/Yszj7DQBfFls/gXqGYpbmDDXdO3/U9XXRGRX4B+4f7jR5TPWA47DjW8rFEZIPP0oPOOpyXpV9dFAm7g0NzlduC7LONKdtnJIUx6vFqA3bXkcl01cepr8rIAVXX35ZofHVQ6xPCvi0kwKMYeskYjIQFyfeStcBXxV/XonhpEPiWdD9LxhhNp4u0KzhePQW9AmTs0xpavJ6Y4zTWnT01TNaaw3cX2v0lTmgXrzzg6PqxxiLvNYNKcJWxi2SERE1DEdt6VOLptq4De4QYSPqOoLkXtnquoFIrIObr/Dz3D/lv4ObOXDPFlVZzYQ9ruqukHWtUIzaX4GPONbe1YDLqVuZujvVHVWJJzewJOq+nEk/MNU9Z/ilnw4zof/T9zsxK295gs1sv5XQ3olbBbXcbiBl1+LyLrAjcAmuHEBv1HVqSXO46dUdfvI+1g0+7C6AttGwxGR7OnaGjky71c4+yFhBNrUm4UkIrlmPDVZb6hNjJqbnK640p22ckhTHofoLXOa4vpepabMA+r5EHLMDheR74nMDi8UT1x6A9MUm+a0YWPIiudpETle3FIIKxCRNiKyvYjcjGt63ha3weoVIvK3iOnP/etNwKvAAtxG1jOA3XDjjf7pw5wnIj/413kiMg9YN3Pd24wFTgSewS3N8Gd/foKIXObj+pPWrZv1D1wX6264zVZv9OFcCPwB50Q8JSLHRzQf519vAzoCw4Cncf3xlwCLgJtC9AK34jb0PhfY3R/nAoN9+ADHqOrX/vxy4O+qugpuX7Sr/fVrYsrjN7OOqcDIzPs4NYubrj0ZGAV08Md2uDFqh3ibnXHN7OdkxfWeiOwcGEaIzam4GUgCvOIPAf4jIqfFpbcIm7g0NzldMaY7beWQpjxOW72J63uVmjIPCQP3jDxRVQeq6k6quqOqbgiMoe63Ia5yiKXM49KcSjQFMwsq6QDaAccC/8NN3X4b+BD4GLgO2Ax4M2LfCrgWuAdoC7zur78esfkkK46MzeW48WprRO59lGUbMrtlRuT6a1l2U/zrVPx+jbjxDA/jnIqonimRsD/LDqcpeqP3svS+mmXzZvQ1hjy+H+dUbQj0Bfrhxhz0BfrGrHkGTdwQPTCMEJuQ2UxN1luETVyam5yuGNOdtnJIUx6nrd7E9b1KTZkHhhEyOzyucoirzGPRnMbDWsiKRFUXq+o4VR2J+9HeARiqqn1V9QhVfR33xcrYL1fVI3EOy1NAJ3+rVkQ2EDczpYOIDAMQkfVwEwZQ1ROAy4B/i8gJ4vrEM82vGUJmt0wUkfNEpL0//5mPazvcoEtwzthyH+/3wJ5AFxG5M5KeKnGDKfvg9qLr58PpDrQJ1Bsyw+guEblJXJfjvSIyRkT6isivgU+8TVx5vBdwN86hG6yuG3OZqn6sdd22cWmWHPkBrhldMuVA3aDYKJ8BrQPDCLEJmYUUh95Qm7g0x5GuuNKdtnJIUx6nrd7E9b1KU5mHhBEyOzyucoirzOPSnDpsDFkTULei8uwctyaJyK4amcmhqueJyOe4mSgAp+BmMNbixiadLiKDcSvAHxH53GsisiOu2/AZXAtdlNEU3mj1OFx35Az//rcissDHf7C/9oGIbKuqz/h4a4DDReQC4Bfe5iIgM8bhMOB6EQEYiGsODtF7AK6bc5yIfAf1Zhgd4MP4g4iMBv6NW3i3LXAkbgHeA304cebxveI2BT9fRA4n4uzl0dwV121bjObMdO3HKW5D9LWB/XEbmX8eEEZIPGOACSLS0AytuPSG2sSlOY50aSPT3ZgN5+PQ25CeNOdxrwC9acvjuGzi0tPkZ4WqniC5Z4dfqXUz2uOqW7E8K2LUnDpslmWKEJEewHfawCwQEekFbBapdNF7obN6uuJaw77Jut4eQFUX5fjMWqr6mT+vxtWb5eIGuw/x8a3kmObT6+8XnMUVNwF5PBjYSlWvbuB+kzRLDBuiB4YRYhMy46nJer3NQHIvCRK1iUtzk9MVY7rLWQ6VlschetOWxxX13QsJI4QY61Ysz4q4NKeOpPtMW9oB7FSMDa41Z90cNptGznsCPf35arhB7YOy7HPZbFRAx4UBWhu0wfXX/xzYMHJtbaCdPxfg18AVwDHUjWELsdkrY5Mn/r2AtgFp+DEwwJ+PBH4P/CTLphOwD/Bb4ATcxrZVxdo0ss70KJTOBq6vgZtNO5TIuL4GbNfDtYQOaozGYvR6m6FJas7Uo0i5DcNtW1NUHvt7q+b7bMSuC7A5sEqp9VZoHufUm/I8rqjvXrZeXEv/xbgxV9/iJklN99e65Qmne1O1hujNVS+S1lzKI3EBLe0ga3B5PhtgP1yz8xRgGjA8YjPZvx4FfITbNeAY4GVck+wM4PAibC7POq7A7bd2OXB5iA3w34i+n/o4b/TxjPbX3wI6+PNLgLuAg3BNzP8swmYR8DVuBuTuQHWOfAyxGQu8gJvpdL4/Pwt4EvhLpBxeAa4HPvDh3Q68CWxShE0f3Oyq54AziAzszeQdbhboR8DzuAki03x4s3DjFX+e4/gic+7DGIKbVTodeMKn5R1/bai3eRr/MMR1W7/rtU8Fjo9Lr7cZmuOY5e2Hxqx5U/+ZT3HjAleJaH7Fv47GPcTf9fo/BCb4z/wyMI/X9nnzFW421/v+/D/4wcS4ySIZvbvgxhI+iZsAtG9ceis0j0P0pi2PK+q7F6j3MdxM8J6R8HviFst+3L+/OKJ3c5837/k83jaBZ0UsmtN4JC6gOR64mXu5jgeABUXYTAF6+fMR/ov9M//+df86FTfFuDtupfxMK9gq1J9BWcjmU9zD7RDcJreHAnMy5yE21J/V+ALQ35/3oG6fz5C9QENsXvf6j8A9OL/ELS+xbcQ2xGYarhWuA26AfsYRbA285c/fjFzvgWuGB/egf6EImyeAo3EP7St8HnXPKs8puDF5W+F+ILb01wfippUvAx7EOac3+mOef/1nJIwtctTLLSP591bk+qsRHR2omxXaZL3+vNZ/9unIsci/PhWz5udxLZPdcC2d0/AtzNT/zvTAteD+ELm/hi/HkDx+ETcepTqiqRo3vumlTDxZ34d+Ob4PTdZboXkcojdteVxR371AvSF7+Ubz+Gl8wwBuYfRJCTwrYtGcxiNxAc3xwP2w/wS3Tlb0GAV8WYTN1Kxwe+EclBMiFXhy5P4bWfavF2HTGdda9C9gTX/twyzbvDZZ8bzSQDyPAdv787upW1qiO3UPrBCbyVnh9/T58iLwaRE2GaernS+T9v59Nd4xxD2sM+Mt21Pf8XyrCJspWXoOwv84NFCen2bZT8HNnp2AW/csc/2jLLuQaeGvA2v586ep6yKuBqbFpde//gI3wWO3MmjOrt/b4f4ZbxnRPCVy//Ms+zdjyOPM0gXTgC7+/Hnq/7GITW+F5nFT9SaRxxX13QvU+zhu8lN0qaI1cC1QT/r306kbKvJS1uenxqW3iHoci+Y0HjbLsjS8BCxUP2MxiojMKMJmnoisq6ofAKjqbBEZhZu5t5G3URFprW7G508iYbSjbuHfgjaqOg8YIyKbA7f7KcT1lkUJsBksbgFYAdqKSC+vuQ1+mQnc6vq3iMg5uJmgU0RkCu7f60lF2GSmUme0fYHvOhWRvkXYPCQiz+EcsuuB8SLyEs45ftbbPAw8KiLP4v5p3+nzb9VIHCE2rUWknaou9npuE5EvcA5oR2/zvYgchRsL852I/BYYD+wIzFfVV0VkJ+B4EXka9xBS6vOIL5tbqD877RDqpoX/FnhcRO7GPTifEpHHcHuz3hiXXv+5u33Y54vIYcDvSqgZEemqqnN93E+LyC9wjv2q3uQTEbkI9wfjHRH5K24Nux2B2YF5/Jq4zeVvztJ7KHUbzp+LW0j6Sty6hXeKyP04h2DF7OCm6q3QPA7Rm7Y8rqjvXqDe/XFdfc+I24oI6vYn3s+/Hwc8LCIX455xl/m82R7n+MWi138upF5ENWfvP1yM5vSRtEdoR8MHbiX49XNcbw0c6M/XJjIYNWKzFrBjqE3WdcFtAHxbHm0FbSK23XAzF6PXMjNgfgFsQY7B7/lsgFEB8Ra08XZbUdd8vi6uW2O/rPh299ejEy6qiEwaKGSDexBvmyP+zYAn/Hkf3C4EV+Na9H6LG1P3EDAw63Nr4h5oH+YIczcfxgP+uBrYPcumK25M4d9x3QynUn8CRjF6ryqkN/LZp4E5JdL8q0xZZn1ubeA6f94Ft+3XadRNxHgQ9xDvFZLHuKVRjsH9yE71x6O4RaOjdWJ93DjIe32argJ2KZVebz80hXn8C6/5yhx5nLNOFJHH65UgjzN6G8rjtXLVi4S+eyHPigb1hhw4B/cOnCM8FbfLy1H4sWJF6i32WfFVKTSn8bBlL0qAiNvvsqXZiLhFyQrZpEVvGm1aAr6edFbVH5LW0lyptDyuNL3NCSmwF3KS5KoX/tq+uJazu3CtXj/FjbG+WlVrk9AaC0l7hM3xACYCxwNrZ11vg6s8N+MqT3Oz+QI36D8NWtJocxjuH9qjuHE0b+L+tR1N3T/NVt7mkSybgv/sgGv9a7W3Px/YOsvmzCJsOuDGapyM69IdjesW+DPQqQGbQ7NtGtD6btb76DIurXGbwt8PXEjdZIkQm+Oom121Hq7b+XvczOKN89h85202wXVtHFRA/zq4wdLn41pUrsP927+TuoHlGZsL8thU4ZZ1eQh4AzcY+z9EWncjNg9m2WwbscnUmwbrVkjdaUT9GhlQv1ayiavepKBurag3/vo9uIWg86WhmPqVr+7ktfH15rACdWssbrjFAbgu0238+cPAZRG7XXAtW5nJZ1cBuxYqC//ZPxZj4+M6nKytj4DD/Os4nCN2P+735k7cbNX/ZDTjenD2wzlugpt1ejmudbXJSxGV6rAWshIgbmzWYbgvZn/cD0I73EPqcVyFml4BNu1xX+pQm+txU4zTnKa40t2YuE7x12+mbleF3rgfo1VVdX8R+Xc+G1w3Ry4EN3i5t4hcj/vBewX3oHpGVU8CEJHJqjo00GY8bhxMe2CAT+MduPXdeqrqwYE286gbB5IZT9cBWIhrUO2SidPH/1fcBI4bcf/cu6vqIYE201R1I2/zEHC9up0YRgF/UtWRhWxwP2Yv4hzpJ3G7LzykqktXZLYbK/hvXNfTQbgNj+8AdsYNJ9g+0OZG3FT8J3FdkT/glg44FddKcUWgTd564+tWZrxUNtG6E2LT5PqFW8IitN5Ex4Jm15sQm3LWrc8oXHdCbLLrzo24Lsd89aueDa7OFKo376rqBisVtmuFeldV1xeRsbjZibdQv24dgpvEcGL257PC+kRV1w6xEZELcU7hZNz2fWNV9Qpvk6lbU1V1ExFpjWsE6KWqS8UtVD5ZVTcVN/Zwddwf4h9wO6fcjxtD/WUhzYmRtEfY3A/cv61e5F+wrtnZpElLWmwI26Q8rw1Qg1tT56PIkXm/1NuFbLweYjPFvwruwSeR928WYXM5hTedfz1yPoW6FsNoOCE2QZu857OJpL8Lzpl4GLe8y43Azjm0NLRxfYjNm1nXM8s5tKVuM+UQm5C6FVJ3ylK/Yqw3aatbwXWn1PUrtG4RWd8yYjuCuhmUOeuWz5vMbNcfGjjmAcuLsJlK3ezIbj5v/p4n3Y9macrUq4z21rglNtpE6uKbudKThqMKo6So6jJVna1uw+4WY5MmLSmyCdmkvJDNh7guh/6RYx1V7Y+baQRhG6+H2GTuK/Cwf82811AbDdt0vquI/Ezc7Le26mYEZ8cVYhOyyXshm4zuH1T1VlXdHdgQ1zV1mg+j4Mb1gTbLRGRdf30osNTHvSSSphCbkLoVUnfKWr+aWm9SWLdC6k656ldIvRkN/ENE3haRx/0xHefojvY2i30c2QwHFvvz73ET0LpkHZ2p2+85xKaVqi73Or/HtZJ1EZE7qatTX4hIJ2+za0aMuO0DM62MmTCW4ZznTNqXU7eBe/rQFHiFdtjREg5cV9gduH/D7/rjK3+tf4gNbmbr4AbCz6zyfRs5xnfglhNZVoTN9eQY54Kbifp8qE3kWhVuHbjnWHmtpxuzjjX89Z7AhFAb/3407sfta9y/77dxY4G6htgAzwaU5Q64HSim47pY7qZuJfmfFmGzPe7H/D1cK9QW/vpqwJ+LsAmpWyF1pyz1K656k7a6FVh3ylK/QupNJL6euOEmmxNZAd/fG+rT/DZu+MXjPs6XgM29zQXAiAbSckkRNg+Se7bmBUBtgTzrCKzuzx9poH71JGuNzDQdNobMMBJAAjYpD7FJCpHGzyqVApvOVypSYOP6hmz8eJ3uqvp1ns8VtInYprbehNCUetNc6xY0rn4F1q2e4NZpFJHVgB8B72jWJtzebsVMTHXrOsaKiLT3WhbluLeWqn6WR/MMVZ1WIPyOQEdV/Spu7XFgXZaGkQCq+k30B1PcAo5F20QpdD9OG9xijo2yUded+3Ccesplk+++qn6tqjXF2qhjpR/MYm1EpIu4haSz682m2TY5wim7TUP3cTNdVwojq97kjCfEJul0N9YmUneKsemMa/XNGY+4hVpfBF4SkWNwLVQ/wXXJHh6xzzhAr+Fa3bYWkUFZYfbM2InIaiLycxHZqBgb74h1zWUTccYa0nxPtubscHAzN1PpjAHWZWmHHWk4KGLT+VKGYTaVmce4Kf6f48ZpTSMyUJu6rWtSY5MmLc3VJjCMqRTe5/goXJfnTNws75eBG3DdpYcnYBOL5jQetnWSYZQJcVu65LyFe7gUtIkjDLNpfnkMnIEbzzNbREYAt4rI6ap6r7dLm02atDRXm5AwlqnqQmChiHygvhtSVb8TkUy38XG4rfra45bRWE9dV+EquJX0byizTVyaU4c5ZIZRPn6EWy9oftZ1wU0zD7GJIwyzaX55XK2qmT0XXxGR7YAHRaQPdTPq0mTTKkVamqtNSB6H7IUc4gCV0yYuzekj6SY6O+xoKQdu5s92Ddx7NsQmjjDMplnm8QvAuln3OgMTgCVps0mTluZqExhGyF7Ir1G3LlvviE073GLB5baJRXMaj8QF2GGHHXbY0bQDGIxb4yn7emvcyu6pskmTluZqExiGBNStEAeonDaxaE7jYcteGEaZELEN3CvBxvLY8rg52ATm8UTc+mX3qeonkettcGubHQo8rao3lVpvETZl01xubNkLwygfT4vI8SJSb183EWkjItuLyM3A9Hw2uBWtb21KGGZjeZy0jeVxavL4dtx2Wf8Wkc/Frdj/IW4x2V/iNh8fnZY0xaz5UFKGtZAZRpmQeDadby4buKfZxvLY8rg52BTMY1V9HY+4zbp7AIs0su1bTM+t2Gzi0hwNJy2YQ2YYCdDQg6QYmzjCMBvL46Rt0qSludqEhBFCmtIUp+a0YA6ZYRiGYRhGwtgYMsMwDMMwjIQxh8wwDMMwDCNhzCEzDKPJiEiNiEwRkbdE5AER6VaCOEaJyIMxhjdGRDpE3j8ch24RuUlE9okhnHNE5PdF2J/R1DgNw0gOc8gMw4iDRao6RFU3Br4F/i9pQeLI94wbg9ukGABV3T3tg34LYA6ZYVQw5pAZhhE3L+JWxEZEJorIMH/eQ0Rm+vPRInKPiDwqIu+JyJ9zBSQiu4rIOyIyGfh55Hq91iPfMtfPHzNE5BbgLaCPiFwlIpNEZJqInOvtTwDWxK0N97S/NlNEevjzk3yYb4nIGH+tn4hMF5HrfFiPi0j7BvJgRx/nuyKyRyTN/4hoflBERkXSOVlE3hCRCTny4QgReURE2ovIQSLyim+RvEZEqkXkYqC9v3a7iHQUkYd8eG+JyP75i8wwjKSxzcUNw4gNEakGdgBuCDAfAmyG23dvhohcoaqfRsJqB1wHbA+8D9wRKGN94FBVfcmH8wdV/dZrmyAim6rq5SJyErCdqn6dlYbNgV8DWwACvCwizwDf+bB/qapHiMh44BfAbTk09MNt/L0uzulbryGxIrKaT+ePVfUjEVk16/5xwE7A3sA6wP7ASFVdJiLjcNvgnCYix6nqEP+ZXwCfq+pP/PuuYVlnGEZSWAuZYRhx0F5EpgBfAGsATwR8ZoKqzlXVxcDbQN+s+xsCH6nqe36Lk1yOTy4+zjhjnv18C9vrwEbAoAKf3wa4V1UXqOp84B7gR/7eR6o6xZ+/hnO8cjFeVWtV9T3gQ5+WhtgSt0n4RwCq+m3k3iHAbsA+qroE5+xuDrzq83sHnJOWzVRgJxG5RER+pKpz8yXYMIzkMYfMMIw4WORbZ/riWpUyY8iWU/ecaZf1mSWR8xqKa7GPhpsd9oLMiYj0B34P7KCqmwIP5dBRDKGasxd4VPJrboipOKevt38vwM1+vN4QVR2gquesFLnqu8BQ//kLROSPAXEZhpEg5pAZhhEbqroQOAH4nYi0AmbiWnQAip15+A7QT0TW9e9/Gbk3E+dwICJDcduj5KILzkGbKyJr4FqbMswDOuf4zHPA3iLSQUQ6Aj/z14phXxGp8trXAWZ4zUP89T64Lk2Al4Afe+eRrC7L14GjgPtFZE1gArCPiKyesRWRTMviMnGrkuNtF6rqbcBf8HllGEZ6sTFkhmHEiqq+LiJv4hyoS4HxInIkrnWqmHAWZz4nIgtxTlHGgbobOEREpgEvA+82EMYbIvI6zrn7FPhf5Pa1wKMi8rmqbhf5zGQRuQl4xV+63qepXxHyP/Gf7wIc7dPyP+AjXPfsdGCyj2+OT+c9flboV7gxYxk9z/sJDA/562cCj3vbZbjWyI99et703bO3AH8RkVpvc0wR2g3DSADbOskwDMMwDCNhrMvSMAzDMAwjYcwhMwzDMAzDSBhzyAzDMAzDMBLGHDLDMAzDMIyEMYfMMAzDMAwjYcwhMwzDMAzDSBhzyAzDMAzDMBLGHDLDMAzDMIyE+X/tfDGl8tRBjgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 720x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot the two series on the same graph\n",
+    "\n",
+    "tick_spacing = 200\n",
+    "\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.plot(joined.index.astype(str), joined['f_pct'], color='red', label='percent of failure')\n",
+    "plt.plot(joined.index.astype(str), joined['p_pct'], color='green', label='percent of passing')\n",
+    "\n",
+    "# set x and y axis labels\n",
+    "plt.xlabel('Run duration buckets')\n",
+    "plt.ylabel('Percentage of passing or failing')\n",
+    "plt.xticks(rotation=90)\n",
+    "plt.xticks(np.arange(0, len(joined.index.astype(str)), tick_spacing), joined.index.astype(str)[::tick_spacing])\n",
+    "\n",
+    "# set title and legend\n",
+    "plt.title('Percentage contribution of failing and passing to their sum')\n",
+    "plt.legend()\n",
+    "\n",
+    "\n",
+    "x_position = joined.index.astype(str).tolist().index(str(tp))\n",
+    "plt.axvline(x=x_position, color='black', linestyle='--')\n",
+    "\n",
+    "# show the plot\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "42ddd38f-20e7-44d0-a177-58e4c4f352c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Interval(229440.0, 229470.0, closed='right')"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ad064bf-2615-4878-8e06-5a0aedec56c7",
+   "metadata": {},
+   "source": [
+    "Let's say we pick x as the stopping point beyond which y % tests are likely to fail "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5eeeb528-8640-4248-9696-040d89b0e2c1",
+   "metadata": {},
+   "source": [
+    "Lets evaluate how this does on the test dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "c2f39177-8db5-4a5a-9315-acecba3f2323",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passing_test = pd.read_csv(\"../data/processed/{}passing_test.csv\".format(test_id))\n",
+    "failing_test = pd.read_csv(\"../data/processed/{}failing_test.csv\".format(test_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "f349b628-e16d-42a7-9fb5-c9e0c4b7312f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>updated_at</th>\n",
+       "      <th>run_id</th>\n",
+       "      <th>status</th>\n",
+       "      <th>conclusion</th>\n",
+       "      <th>run_duration</th>\n",
+       "      <th>test_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8</td>\n",
+       "      <td>2023-02-03T15:16:11Z</td>\n",
+       "      <td>2023-02-03T15:18:51Z</td>\n",
+       "      <td>4085449911</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>160.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>16</td>\n",
+       "      <td>2023-03-09T10:43:24Z</td>\n",
+       "      <td>2023-03-09T11:12:31Z</td>\n",
+       "      <td>4373589410</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>1747.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2022-11-16T16:02:40Z</td>\n",
+       "      <td>2022-11-16T16:06:19Z</td>\n",
+       "      <td>3480995628</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>219.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>20</td>\n",
+       "      <td>2023-03-30T18:33:26Z</td>\n",
+       "      <td>2023-03-30T18:35:50Z</td>\n",
+       "      <td>4567807931</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>144.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>29</td>\n",
+       "      <td>2023-03-17T17:29:33Z</td>\n",
+       "      <td>2023-03-17T17:35:11Z</td>\n",
+       "      <td>4450078573</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>success</td>\n",
+       "      <td>338.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Unnamed: 0            created_at            updated_at      run_id  \\\n",
+       "0           8  2023-02-03T15:16:11Z  2023-02-03T15:18:51Z  4085449911   \n",
+       "1          16  2023-03-09T10:43:24Z  2023-03-09T11:12:31Z  4373589410   \n",
+       "2           1  2022-11-16T16:02:40Z  2022-11-16T16:06:19Z  3480995628   \n",
+       "3          20  2023-03-30T18:33:26Z  2023-03-30T18:35:50Z  4567807931   \n",
+       "4          29  2023-03-17T17:29:33Z  2023-03-17T17:35:11Z  4450078573   \n",
+       "\n",
+       "      status conclusion  run_duration   test_id  \n",
+       "0  completed    success         160.0  39411153  \n",
+       "1  completed    success        1747.0  39411153  \n",
+       "2  completed    success         219.0  39411153  \n",
+       "3  completed    success         144.0  39411153  \n",
+       "4  completed    success         338.0  39411153  "
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "passing_test.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "03dfab43-56fa-433c-a30f-3c27478710a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>updated_at</th>\n",
+       "      <th>run_id</th>\n",
+       "      <th>status</th>\n",
+       "      <th>conclusion</th>\n",
+       "      <th>run_duration</th>\n",
+       "      <th>test_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>14</td>\n",
+       "      <td>2023-03-28T10:39:18Z</td>\n",
+       "      <td>2023-03-28T10:40:24Z</td>\n",
+       "      <td>4542117817</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>66.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>21</td>\n",
+       "      <td>2022-11-02T13:39:54Z</td>\n",
+       "      <td>2022-11-02T14:04:54Z</td>\n",
+       "      <td>3378016721</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>1500.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>4</td>\n",
+       "      <td>2022-11-28T16:26:30Z</td>\n",
+       "      <td>2022-11-28T16:27:25Z</td>\n",
+       "      <td>3566698252</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>55.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7</td>\n",
+       "      <td>2022-11-28T16:22:30Z</td>\n",
+       "      <td>2022-11-28T16:23:25Z</td>\n",
+       "      <td>3566666479</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>55.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>28</td>\n",
+       "      <td>2023-01-26T17:44:53Z</td>\n",
+       "      <td>2023-01-26T17:47:31Z</td>\n",
+       "      <td>4017737467</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>failure</td>\n",
+       "      <td>158.0</td>\n",
+       "      <td>39411153</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Unnamed: 0            created_at            updated_at      run_id  \\\n",
+       "0          14  2023-03-28T10:39:18Z  2023-03-28T10:40:24Z  4542117817   \n",
+       "1          21  2022-11-02T13:39:54Z  2022-11-02T14:04:54Z  3378016721   \n",
+       "2           4  2022-11-28T16:26:30Z  2022-11-28T16:27:25Z  3566698252   \n",
+       "3           7  2022-11-28T16:22:30Z  2022-11-28T16:23:25Z  3566666479   \n",
+       "4          28  2023-01-26T17:44:53Z  2023-01-26T17:47:31Z  4017737467   \n",
+       "\n",
+       "      status conclusion  run_duration   test_id  \n",
+       "0  completed    failure          66.0  39411153  \n",
+       "1  completed    failure        1500.0  39411153  \n",
+       "2  completed    failure          55.0  39411153  \n",
+       "3  completed    failure          55.0  39411153  \n",
+       "4  completed    failure         158.0  39411153  "
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "failing_test.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "8f90e65f-081d-4182-866d-d4fd1647d1e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data = pd.concat([passing_test, failing_test], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "3da20d03-23dd-473e-bdf3-78f47135d2cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the time value to check against\n",
+    "time_threshold = 30  # example threshold value\n",
+    "\n",
+    "# Add new column with \"success\" or \"failure\" based on run_duration\n",
+    "test_data['predicted_status'] = np.where(test_data['run_duration'] > 229440.0, 'failure', 'success')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "e1014663-f77c-4583-a885-11ace2967133",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Match percentage: 92.24%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Calculate percentage of rows where \"new_column\" matches \"conclusion\"\n",
+    "accuracy = (test_data['predicted_status'] == test_data['conclusion']).sum() / len(test_data) * 100\n",
+    "print(f\"Match percentage: {accuracy:.2f}%\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
In this notebook:

- I evaluate the trends of passing and failing tests and evaluate the likelihood of a test to pass or fail at a given point
- Instead of adding a function directly, I kept examples which describe the approach, create plots on different tests to get feedback on the method before proceeding to create a function for it
- I evaluate the approach on a larger dataset collected from the https://github.com/github/codeql repo and find a turning point **after which the test is 75% likely to fail** and at all points after then **it is never less than 60% likely to fail**. (These percentages can be tweaked). I then evaluate it on the test dataset and get an accuracy of 92.24%

**Some things to note**
- From some plots it is clear that there is no stopping point - meaning it never occurs that a test is more likely to fail than pass
- One can argue that a calculation of such a stopping point is skewed by the number of tests in each bucket (pass/fail), so I also added a section where I calculate a percent of percents which completely ignores the number of tests in each bucket. My intuition is that in the real scenario, this is not valid since as should also factor for the proportion of passing and failing tests. I'm open to your feedback